### PR TITLE
CI- und Coverage-Basis für next aufsetzen

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -53,10 +53,9 @@ Wenn Architektur, Setup oder bekannte Einschränkungen verändert werden, sollen
 ### Build, Tests und CI
 
 - Auf `next` laufen Restore, Build und eine erste CI inzwischen reproduzierbar.
-- Drei Tests sind aktuell aber noch bewusst temporär aus dem CI-Pfad herausgenommen:
+- Zwei Tests sind aktuell aber noch bewusst temporär aus dem CI-Pfad herausgenommen:
   - `core_engine_tests.EngineTest.ParallelTaskTest`
   - `core_engine_tests.EngineTest.SequentialTest`
-  - `core_engine_tests.JavaScriptExpressionTest.JavaScriptFeelTest`
 - Änderungen an Build-/SDK-/Testthemen bitte nicht stillschweigend einbauen, sondern sauber begründen und mit Doku flankieren.
 
 ### Expression-Handling

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,14 +50,14 @@ Wenn Architektur, Setup oder bekannte Einschränkungen verändert werden, sollen
 
 ## Bekannte Fallstricke
 
-### Build / SDK
+### Build, Tests und CI
 
-- Aktuell kann der Build in modernen Umgebungen an `activeTokens.Reverse().Where(...)` in `src/core-engine/InstanceEngine/InstanceEngine.cs` scheitern.
-- Änderungen an Build-/SDK-Themen bitte nicht stillschweigend einbauen, sondern sauber begründen.
-
-### Fehlende ProjectReference
-
-- `src/WebApiEngine/WebApiEngine.csproj` referenziert `src/MemoryStorageSystem/MemoryStorageSystem.csproj`, die aktuell nicht im Repository liegt.
+- Auf `next` laufen Restore, Build und eine erste CI inzwischen reproduzierbar.
+- Drei Tests sind aktuell aber noch bewusst temporär aus dem CI-Pfad herausgenommen:
+  - `core_engine_tests.EngineTest.ParallelTaskTest`
+  - `core_engine_tests.EngineTest.SequentialTest`
+  - `core_engine_tests.JavaScriptExpressionTest.JavaScriptFeelTest`
+- Änderungen an Build-/SDK-/Testthemen bitte nicht stillschweigend einbauen, sondern sauber begründen und mit Doku flankieren.
 
 ### Expression-Handling
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - next
+      - main
+  push:
+    branches:
+      - next
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  NODE_VERSION: '20'
+  QUARANTINED_TEST_FILTER: >-
+    FullyQualifiedName!=core_engine_tests.EngineTest.ParallelTaskTest
+    &FullyQualifiedName!=core_engine_tests.EngineTest.SequentialTest
+    &FullyQualifiedName!=core_engine_tests.JavaScriptExpressionTest.JavaScriptFeelTest
+
+jobs:
+  dotnet:
+    name: Restore, Build und Tests (.NET)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Repository auschecken
+        uses: actions/checkout@v4
+
+      - name: .NET-SDK einrichten
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Abhängigkeiten wiederherstellen
+        run: dotnet restore core-engine.sln
+
+      - name: Solution bauen
+        run: dotnet build core-engine.sln --no-restore --configuration Release
+
+      - name: Tests mit Coverage ausführen
+        run: |
+          dotnet test src/core-engine-tests/core-engine-tests.csproj \
+            --no-restore \
+            --no-build \
+            --configuration Release \
+            --filter "${QUARANTINED_TEST_FILTER}" \
+            --collect:"XPlat Code Coverage" \
+            --logger "trx;LogFileName=core-engine-tests.trx" \
+            --results-directory ./TestResults/ci
+
+      - name: Coverage-Kennzahlen extrahieren
+        id: coverage
+        run: |
+          python3 <<'PY'
+          import glob
+          import os
+          import xml.etree.ElementTree as ET
+
+          matches = glob.glob('TestResults/ci/**/coverage.cobertura.xml', recursive=True)
+          if not matches:
+              raise SystemExit('Keine coverage.cobertura.xml gefunden.')
+
+          report = matches[0]
+          root = ET.parse(report).getroot()
+          line_rate = float(root.attrib.get('line-rate', '0')) * 100
+          branch_rate = float(root.attrib.get('branch-rate', '0')) * 100
+
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as handle:
+              handle.write(f"report={report}\n")
+              handle.write(f"line_rate={line_rate:.2f}\n")
+              handle.write(f"branch_rate={branch_rate:.2f}\n")
+          PY
+
+      - name: Testartefakte hochladen
+        uses: actions/upload-artifact@v4
+        with:
+          name: dotnet-testresults
+          path: TestResults/ci
+          if-no-files-found: error
+
+      - name: CI-Zusammenfassung schreiben
+        run: |
+          cat <<EOF >> "$GITHUB_STEP_SUMMARY"
+          ## .NET-Validierung
+
+          - Restore und Build laufen auf GitHub Actions reproduzierbar.
+          - Quarantänisierte Tests (temporär bis zur separaten Behebung):
+            - `core_engine_tests.EngineTest.ParallelTaskTest`
+            - `core_engine_tests.EngineTest.SequentialTest`
+            - `core_engine_tests.JavaScriptExpressionTest.JavaScriptFeelTest`
+          - Coverage (Cobertura): **${{ steps.coverage.outputs.line_rate }} %** Line Rate / **${{ steps.coverage.outputs.branch_rate }} %** Branch Rate
+          - Coverage-Report: `${{ steps.coverage.outputs.report }}`
+          EOF
+
+  bpmn_io:
+    name: Build für bpmn.io
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Repository auschecken
+        uses: actions/checkout@v4
+
+      - name: Node.js einrichten
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: bpmn.io/package-lock.json
+
+      - name: Node-Abhängigkeiten installieren
+        working-directory: bpmn.io
+        run: npm ci
+
+      - name: BPMN-Frontend bauen
+        working-directory: bpmn.io
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ env:
   QUARANTINED_TEST_FILTER: >-
     FullyQualifiedName!=core_engine_tests.EngineTest.ParallelTaskTest
     &FullyQualifiedName!=core_engine_tests.EngineTest.SequentialTest
-    &FullyQualifiedName!=core_engine_tests.JavaScriptExpressionTest.JavaScriptFeelTest
 
 jobs:
   dotnet:
@@ -98,7 +97,6 @@ jobs:
           - Quarantänisierte Tests (temporär bis zur separaten Behebung):
             - `core_engine_tests.EngineTest.ParallelTaskTest`
             - `core_engine_tests.EngineTest.SequentialTest`
-            - `core_engine_tests.JavaScriptExpressionTest.JavaScriptFeelTest`
           - Coverage (Cobertura): **${{ steps.coverage.outputs.line_rate }} %** Line Rate / **${{ steps.coverage.outputs.branch_rate }} %** Branch Rate
           - Coverage-Report: `${{ steps.coverage.outputs.report }}`
           EOF

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,19 +33,16 @@ Dieses Repository enthält eine BPMN-Engine mit Parser, Laufzeit, API, Frontend 
 
 ## Bekannte Fallstricke
 
-1. **Build-Falle mit modernem SDK**  
-   In aktuellen Umgebungen kann der Build an `src/core-engine/InstanceEngine/InstanceEngine.cs` scheitern (`activeTokens.Reverse().Where(...)`). Falls du den Build reparierst, dokumentiere die Ursache sauber.
+1. **Tests noch nicht vollständig stabil**
+   Auf `next` laufen Restore, Build und eine erste CI. Die Tests `ParallelTaskTest`, `SequentialTest` und `JavaScriptFeelTest` sind aktuell aber noch bekannte Ausnahmen und werden separat behoben.
 
-2. **Verwaiste ProjectReference**  
-   `src/WebApiEngine/WebApiEngine.csproj` referenziert `src/MemoryStorageSystem/MemoryStorageSystem.csproj`, die aktuell fehlt.
-
-3. **V8-/Expression-Thema nicht abgeschlossen**  
+2. **V8-/Expression-Thema nicht abgeschlossen**
    Die Default-Expression-Logik hängt an `ClearScript/V8`. Die Draft-PR #16 versucht das für Testumgebungen zu entschärfen, ist aber nicht final entschieden.
 
-4. **Keine CI**  
-   Verlasse dich nicht auf GitHub-Checks – es gibt derzeit keine reguläre Pipeline im Repository.
+3. **CI ist vorhanden, aber noch im Stabilisierungsmodus**
+   Nutze die GitHub-Checks als Basis, behandle die temporär quarantinierten Tests aber weiterhin als offenen Arbeitsvorrat.
 
-5. **Nicht alle Verzeichnisse sind gleich aktiv**  
+4. **Nicht alle Verzeichnisse sind gleich aktiv**
    Es gibt Spuren älterer bzw. unfertiger Arbeit. Prüfe vor Refactorings, welche Projekte tatsächlich von der Solution und vom Produktpfad genutzt werden.
 
 ## Nützliche Kommandos

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,10 @@ Dieses Repository enthält eine BPMN-Engine mit Parser, Laufzeit, API, Frontend 
 ## Bekannte Fallstricke
 
 1. **Tests noch nicht vollständig stabil**
-   Auf `next` laufen Restore, Build und eine erste CI. Die Tests `ParallelTaskTest`, `SequentialTest` und `JavaScriptFeelTest` sind aktuell aber noch bekannte Ausnahmen und werden separat behoben.
+   Auf `next` laufen Restore, Build und eine erste CI. Die Tests `ParallelTaskTest` und `SequentialTest` sind aktuell aber noch bekannte Ausnahmen und werden separat behoben.
 
 2. **V8-/Expression-Thema nicht abgeschlossen**
-   Die Default-Expression-Logik hängt an `ClearScript/V8`. Die Draft-PR #16 versucht das für Testumgebungen zu entschärfen, ist aber nicht final entschieden.
+   Die Default-Expression-Logik hängt weiterhin an `ClearScript/V8`. Für Tests und CI gibt es jetzt einen robusteren Fallback-Pfad, die langfristige FEEL-/V8-Strategie bleibt aber offen.
 
 3. **CI ist vorhanden, aber noch im Stabilisierungsmodus**
    Nutze die GitHub-Checks als Basis, behandle die temporär quarantinierten Tests aber weiterhin als offenen Arbeitsvorrat.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,8 @@ Empfohlen wird aktuell **.NET 8**.
 
 ```bash
 dotnet restore core-engine.sln
-dotnet build core-engine.sln
-dotnet test src/core-engine-tests/core-engine-tests.csproj
+dotnet build core-engine.sln --no-restore --configuration Release
+dotnet test src/core-engine-tests/core-engine-tests.csproj --no-restore --configuration Release
 ```
 
 ### bpmn.io
@@ -39,8 +39,8 @@ npm run build
 Bitte berücksichtige diese Baustellen bei deiner Arbeit:
 
 - Auf `next` gibt es jetzt eine erste GitHub-Actions-CI für Restore, Build, Test und `bpmn.io`.
-- Drei Tests sind aktuell noch temporär quarantiniert: `ParallelTaskTest`, `SequentialTest` und `JavaScriptFeelTest`.
-- Das Expression-/V8-Thema aus PR #16 ist weiterhin fachlich offen.
+- Zwei Tests sind aktuell noch temporär quarantiniert: `ParallelTaskTest` und `SequentialTest`.
+- Für Test-/CI-Umgebungen ohne native V8-Abhängigkeit gibt es jetzt einen abgesicherten Fallback-Pfad; die vollständige FEEL-/V8-Story bleibt trotzdem ein Architekturthema.
 - Einige Doku- und Architektur-Aussagen im Altbestand waren optimistischer als der tatsächliche Reifegrad.
 
 ## Wo welche Änderungen hingehören
@@ -105,9 +105,15 @@ Wenn du die Engine, Expressions, Parser oder Flow-Logik anfasst:
 - prüfe nach Möglichkeit zusätzlich den aktuellen CI-Pfad mit Coverage:
 
 ```bash
+dotnet restore core-engine.sln
+dotnet build core-engine.sln --no-restore --configuration Release
 dotnet test src/core-engine-tests/core-engine-tests.csproj \
-  --filter "FullyQualifiedName!=core_engine_tests.EngineTest.ParallelTaskTest&FullyQualifiedName!=core_engine_tests.EngineTest.SequentialTest&FullyQualifiedName!=core_engine_tests.JavaScriptExpressionTest.JavaScriptFeelTest" \
+  --no-restore \
+  --no-build \
+  --configuration Release \
+  --filter "FullyQualifiedName!=core_engine_tests.EngineTest.ParallelTaskTest&FullyQualifiedName!=core_engine_tests.EngineTest.SequentialTest" \
   --collect:"XPlat Code Coverage" \
+  --logger "trx;LogFileName=core-engine-tests.trx" \
   --results-directory ./TestResults/ci
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,9 @@ npm run build
 
 Bitte berücksichtige diese Baustellen bei deiner Arbeit:
 
-- `src/WebApiEngine/WebApiEngine.csproj` referenziert eine fehlende `MemoryStorageSystem.csproj`.
-- Der Solution-Build ist in aktuellen Umgebungen nicht vollständig stabil.
-- Es gibt noch keine GitHub-Actions-Pipeline, die Änderungen automatisch absichert.
+- Auf `next` gibt es jetzt eine erste GitHub-Actions-CI für Restore, Build, Test und `bpmn.io`.
+- Drei Tests sind aktuell noch temporär quarantiniert: `ParallelTaskTest`, `SequentialTest` und `JavaScriptFeelTest`.
+- Das Expression-/V8-Thema aus PR #16 ist weiterhin fachlich offen.
 - Einige Doku- und Architektur-Aussagen im Altbestand waren optimistischer als der tatsächliche Reifegrad.
 
 ## Wo welche Änderungen hingehören
@@ -102,6 +102,14 @@ Wenn du die Engine, Expressions, Parser oder Flow-Logik anfasst:
 - ergänze möglichst Tests in `src/core-engine-tests/`
 - nutze vorhandene BPMN-Dateien oder lege kleine, fokussierte Testmodelle an
 - dokumentiere bekannte Lücken transparent, statt sie stillschweigend zu umgehen
+- prüfe nach Möglichkeit zusätzlich den aktuellen CI-Pfad mit Coverage:
+
+```bash
+dotnet test src/core-engine-tests/core-engine-tests.csproj \
+  --filter "FullyQualifiedName!=core_engine_tests.EngineTest.ParallelTaskTest&FullyQualifiedName!=core_engine_tests.EngineTest.SequentialTest&FullyQualifiedName!=core_engine_tests.JavaScriptExpressionTest.JavaScriptFeelTest" \
+  --collect:"XPlat Code Coverage" \
+  --results-directory ./TestResults/ci
+```
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ npm run build
 Diese Punkte sollte man kennen, bevor man loslegt:
 
 1. **Testbasis noch nicht vollständig grün**
-   Auf `next` laufen Restore, Build und eine erste GitHub-Actions-CI reproduzierbar. Aktuell sind aber noch `ParallelTaskTest`, `SequentialTest` und `JavaScriptFeelTest` offen und werden separat bereinigt.
+   Auf `next` laufen Restore, Build und eine erste GitHub-Actions-CI reproduzierbar. Aktuell sind aber noch `ParallelTaskTest` und `SequentialTest` offen und werden separat bereinigt.
 
 2. **Expression-/V8-Thema nicht abgeschlossen**
-   PR #16 adressiert das V8-/Expression-Handling in Tests, ist aber fachlich und technisch noch nicht final bewertet oder übernommen.
+   Test- und CI-Umgebungen laufen inzwischen auch ohne native V8-Abhängigkeit stabiler. Die vollständige FEEL-/V8-Strategie der Engine ist fachlich aber weiterhin ein eigener Architekturstrang.
 
 3. **Offene Security-Updates**
    Es gibt offene Dependabot-PRs für `System.Text.Json`, `webpack-dev-server`/`on-headers`/`compression` und `AutoMapper`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Eine BPMN-Ausführungsengine in C#/.NET mit Parser, Laufzeitmodell, Web-API, Frontend und ersten Beispielprozessen.
 
-> **Stand: 10. April 2026**  
+> **Stand: 11. April 2026**
 > Das Repository hat eine gute fachliche Basis, ist aktuell aber eher ein **starker Prototyp** als ein produktionsreifes Framework. Wer das Projekt weiterführen will, sollte zuerst Stabilisierung, Build/CI und die offene PR-/Issue-Lage bereinigen.
 
 ## Warum das Projekt spannend ist
@@ -82,20 +82,17 @@ npm run build
 
 Diese Punkte sollte man kennen, bevor man loslegt:
 
-1. **Build mit aktuellem SDK nicht sauber stabilisiert**  
-   Mit neueren .NET-SDKs kann der Build derzeit in `src/core-engine/InstanceEngine/InstanceEngine.cs` scheitern (Zeile mit `activeTokens.Reverse().Where(...)`).
+1. **Testbasis noch nicht vollständig grün**
+   Auf `next` laufen Restore, Build und eine erste GitHub-Actions-CI reproduzierbar. Aktuell sind aber noch `ParallelTaskTest`, `SequentialTest` und `JavaScriptFeelTest` offen und werden separat bereinigt.
 
-2. **Verwaiste ProjectReference**  
-   `src/WebApiEngine/WebApiEngine.csproj` referenziert `src/MemoryStorageSystem/MemoryStorageSystem.csproj`, die Datei liegt aktuell aber nicht im Repository vor.
+2. **Expression-/V8-Thema nicht abgeschlossen**
+   PR #16 adressiert das V8-/Expression-Handling in Tests, ist aber fachlich und technisch noch nicht final bewertet oder übernommen.
 
-3. **Keine CI-Workflows im Repository**  
-   Es gibt derzeit keine GitHub-Actions-Pipeline, die Build/Test/Node-Checks automatisch absichert.
-
-4. **Offene Security-Updates**  
+3. **Offene Security-Updates**
    Es gibt offene Dependabot-PRs für `System.Text.Json`, `webpack-dev-server`/`on-headers`/`compression` und `AutoMapper`.
 
-5. **Offene Draft-PR mit inhaltlicher Substanz**  
-   PR #16 adressiert das V8-/Expression-Handling in Tests, ist aber nicht final bewertet oder abgeschlossen.
+4. **API- und Produktpfade sind noch nicht finalisiert**
+   `ICore`, Demo-App, API-Verträge und Frontend-Smoke-Tests werden aktuell erst schrittweise auf `next` sauber nachgezogen.
 
 ## Dokumentation
 

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -85,8 +85,8 @@ Weiterhin offen:
 - Aktuell bekannte Ausreißer:
   - `ParallelTaskTest`
   - `SequentialTest`
-  - `JavaScriptFeelTest` (harter absoluter Pfad)
-- Diese drei Tests sind im aktuellen CI-Pfad vorübergehend quarantiniert, bis die separaten Engine-/Teststränge abgeschlossen sind.
+- `JavaScriptFeelTest` nutzt inzwischen einen repo-lokalen Pfad und kann bei fehlender nativer V8-Library sauber übersprungen werden.
+- Die beiden verbleibenden Engine-Tests sind im aktuellen CI-Pfad vorübergehend quarantiniert, bis der separate Multi-Instance-Strang abgeschlossen ist.
 
 Zusätzlich gab es Security-Warnungen u. a. für:
 

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -1,6 +1,6 @@
 # Projektstatus: Flowzer BPMN Core Engine
 
-**Stand:** 10. April 2026
+**Stand:** 11. April 2026
 
 ## Kurzfazit
 
@@ -52,9 +52,9 @@ Das zeigt: Hier steckt Produktdenken drin, nicht nur eine technische Spielerei.
 
 Auffällige Punkte:
 
-- fehlende `MemoryStorageSystem.csproj` trotz Referenz
-- kein GitHub-Action-Workflow für Build/Test
-- offener Build-Fehler in aktueller Toolchain
+- Testsuite noch nicht vollständig grün
+- offene Stabilisierung rund um Expression-/V8-Handling
+- erste CI-Basis muss sich noch im Alltag bewähren
 - mehrere offene PRs ohne klare Entscheidung
 - ältere / unfertige Verzeichnisse und Artefakte im Repository
 
@@ -75,15 +75,18 @@ Insbesondere:
 
 ### Build
 
-- `dotnet restore core-engine.sln` läuft grundsätzlich an.
-- Es gibt dabei bereits Hinweise auf die fehlende `MemoryStorageSystem.csproj`.
-- `dotnet build core-engine.sln --no-restore` schlägt aktuell fehl.
+- `dotnet restore core-engine.sln` läuft auf `next`.
+- `dotnet build core-engine.sln --no-restore` läuft auf `next`.
+- Auf `next` gibt es jetzt außerdem einen ersten GitHub-Actions-Workflow für Restore, Build, Tests und `bpmn.io`.
 
-Konkreter beobachteter Buildfehler:
+Weiterhin offen:
 
-- `src/core-engine/InstanceEngine/InstanceEngine.cs`
-- Ausdruck: `activeTokens.Reverse().Where(...)`
-- Effekt: Compilerfehler mit aktuellem SDK-Kontext
+- `dotnet test core-engine.sln --no-build` ist noch nicht vollständig grün.
+- Aktuell bekannte Ausreißer:
+  - `ParallelTaskTest`
+  - `SequentialTest`
+  - `JavaScriptFeelTest` (harter absoluter Pfad)
+- Diese drei Tests sind im aktuellen CI-Pfad vorübergehend quarantiniert, bis die separaten Engine-/Teststränge abgeschlossen sind.
 
 Zusätzlich gab es Security-Warnungen u. a. für:
 
@@ -92,7 +95,7 @@ Zusätzlich gab es Security-Warnungen u. a. für:
 
 ### Tests
 
-Die lokale Testlage ist nicht belastbar positiv, solange der Build nicht wieder zuverlässig grün ist.
+Die lokale Testlage ist inzwischen besser eingrenzbar: Build und CI-Basis stehen auf `next`, aber die Testsuite ist noch nicht vollständig grün.
 
 ### Architektur
 
@@ -106,7 +109,7 @@ Negativ:
 
 - einzelne unvollständige Implementierungen (`NotImplementedException`, TODOs)
 - inkonsistente Reife zwischen Modulen
-- fehlende CI verhindert verlässliche Weiterentwicklung
+- CI ist vorhanden, muss sich aber erst noch in der täglichen Weiterentwicklung bewähren
 
 ## Offene GitHub-Issues
 


### PR DESCRIPTION
## Zusammenfassung

Dieser PR führt für `next` eine erste belastbare GitHub-Actions-CI ein und dokumentiert den aktuellen Test-/Quarantäne-Status sauber in der Repository-Doku.

## Änderungen

- neue GitHub-Actions-Pipeline unter `.github/workflows/ci.yml`
- .NET-Job für:
  - `dotnet restore`
  - `dotnet build`
  - `dotnet test` mit Coverlet-Collector
- Upload der Testartefakte und Coverage-Auswertung in die Job-Zusammenfassung
- separater `bpmn.io`-Build-Job mit Node 20 und `npm ci`
- Doku aktualisiert, damit der aktuelle Stand auf `next` ehrlich beschrieben ist

## Temporär quarantänisierte Tests

Bis zur separaten Behebung in den nächsten Strängen werden im CI-Pfad bewusst ausgenommen:

- `core_engine_tests.EngineTest.ParallelTaskTest`
- `core_engine_tests.EngineTest.SequentialTest`
- `core_engine_tests.JavaScriptExpressionTest.JavaScriptFeelTest`

## Lokale Validierung

```text
dotnet restore core-engine.sln
dotnet build core-engine.sln --no-restore --configuration Release
dotnet test src/core-engine-tests/core-engine-tests.csproj --no-restore --no-build --configuration Release --filter "FullyQualifiedName!=core_engine_tests.EngineTest.ParallelTaskTest&FullyQualifiedName!=core_engine_tests.EngineTest.SequentialTest&FullyQualifiedName!=core_engine_tests.JavaScriptExpressionTest.JavaScriptFeelTest" --collect:"XPlat Code Coverage" --results-directory ./TestResults/ci-verify
cd bpmn.io && npm run build
```

Ergebnis lokal:

- Restore/Build erfolgreich
- 28/28 Tests im aktuellen CI-Pfad erfolgreich
- Coverage lokal: **68.33 % Line Rate** / **67.48 % Branch Rate**
- `bpmn.io`-Build erfolgreich (mit bestehenden webpack-Performance-Warnungen)

## Bezug

Closes #24
