### PR TITLE
Expression-Handling und Tests ohne V8 für next stabilisieren

### DIFF
--- a/src/core-engine-tests/EngineTest.cs
+++ b/src/core-engine-tests/EngineTest.cs
@@ -339,7 +339,7 @@ public class EngineTest
     {
         var model = await ModelParser.ParseModel(File.Open("embeddings/SimpleTimerEvent.bpmn", FileMode.Open));
         var process = model.GetProcesses();
-        var processEngine = new ProcessEngine(process.First());
+        var processEngine = Helper.CreateProcessEngine(process.First());
         var activeTimers = processEngine.ActiveTimers.ToArray();
         activeTimers.Should().HaveCount(1);
         activeTimers.Single().Should().BeCloseTo(DateTime.Now.AddSeconds(2), new TimeSpan(0, 0, 0, 0, 100));
@@ -355,7 +355,7 @@ public class EngineTest
     {
         var model = await ModelParser.ParseModel(File.Open("embeddings/SubProcess.bpmn", FileMode.Open));
         var process = model.GetProcesses().Single();
-        var instanceEngine = new ProcessEngine(process).StartProcess();
+        var instanceEngine = Helper.CreateProcessEngine(process).StartProcess();
         
         instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Waiting);
         instanceEngine.Tokens.Should().HaveCount(5);

--- a/src/core-engine-tests/Helper.cs
+++ b/src/core-engine-tests/Helper.cs
@@ -1,15 +1,23 @@
+using BPMN.Process;
+
 namespace core_engine_tests;
 
 public class Helper
 {
+    internal static FlowzerConfig TestFlowzerConfig { get; } = FlowzerConfig.CreateForTests();
     
     internal static async Task<InstanceEngine> StartFirstProcessOfFile(string fileName)
     {
         var model = await ModelParser.ParseModel(File.Open("embeddings/" + fileName,FileMode.Open));
         var process = model.GetProcesses();
-        var processEngine = new ProcessEngine(process.First());
+        var processEngine = CreateProcessEngine(process.First());
         var instanceEngine = processEngine.StartProcess();
         return instanceEngine;
+    }
+
+    internal static ProcessEngine CreateProcessEngine(Process process)
+    {
+        return new ProcessEngine(process, TestFlowzerConfig);
     }
 
     public static void DoTestServiceThings(InstanceEngine instanceEngine)

--- a/src/core-engine-tests/JavaScriptExpressionTest.cs
+++ b/src/core-engine-tests/JavaScriptExpressionTest.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 using System.Dynamic;
+using core_engine.Expression.Feelin;
+using FluentAssertions;
 using Microsoft.ClearScript;
 using Microsoft.ClearScript.V8;
 
@@ -18,61 +20,48 @@ public class JavaScriptExpressionTest
     [Test]
     public void JavaScriptFeelTest()
     {
-        const string scriptDirectory = @"/Users/lukasbauhaus/repos/feel/feelin/src"; // ToDo: Weg vom absoluten Pfad auf deinem Rechner
-
-        // Erstelle eine V8-Engine
-        using var engine = new V8ScriptEngine() ;
-            
-        // Lade die Index.js Datei
-        var indexPath = Path.Combine(scriptDirectory, "/Users/lukasbauhaus/repos/feelin/dist/bundle.js"); // ToDo: Weg vom absoluten Pfad auf deinem Rechner
-
-        // Definiere eine Funktion zum Laden von Modulen
-        
-
-        //engine.AddHostObject("host", new HostFunctions());
-        engine.AddHostObject("host", this);
-        engine.AddHostObject("console", new ConsoleWrapper());
-        engine.DocumentSettings.AccessFlags = DocumentAccessFlags.EnableFileLoading;
-        
-        
         try
         {
-            // Lade und führe das Hauptskript aus
-            var indexScript = File.ReadAllText(indexPath);
-            engine.Execute(indexScript);
-            
-            for (var i = 0; i < 1000; i++)
+            using var engine = new V8ScriptEngine();
+            var bundlePath = GetFeelinBundlePath();
+            File.Exists(bundlePath).Should().BeTrue($"die FEEL-Bundle-Datei unter {bundlePath} für den Test verfügbar sein muss");
+
+            engine.AddHostObject("host", this);
+            engine.AddHostObject("console", new ConsoleWrapper());
+            engine.DocumentSettings.AccessFlags = DocumentAccessFlags.EnableFileLoading;
+            engine.Execute(File.ReadAllText(bundlePath));
+
+            var testObject = new
             {
-                var sw = new Stopwatch();
-                sw.Start();
-
-                var x = new
+                name = "Mike",
+                daughter = new
                 {
-                    name = "Mike",
-                    daughter = new
-                    {
-                        name = "Lisa"
-                    }
-                };
+                    name = "Lisa"
+                }
+            };
 
-                engine.AddHostObject("obj", (dynamic)x);
+            engine.AddHostObject("obj", (dynamic)testObject);
 
-                var ret = engine.Evaluate("""libfeelin.evaluate("name", obj)""");
-                TestContext.WriteLine(ret);
-                sw.Stop();
-                Console.WriteLine(sw.ElapsedMilliseconds);
-            }
-            
+            var stopwatch = Stopwatch.StartNew();
+            var result = engine.Evaluate("""libfeelin.evaluate("name", obj)""");
+            stopwatch.Stop();
 
+            result.Should().Be("Mike");
+            TestContext.WriteLine($"FEEL-Auswertung erfolgreich in {stopwatch.ElapsedMilliseconds} ms");
         }
-        catch (Exception e)
+        catch (DllNotFoundException)
         {
-            Console.WriteLine(e);
-            
+            Assert.Ignore("V8-Bibliotheken sind in dieser Umgebung nicht verfügbar.");
         }
-        
     }
-    
+
+    private static string GetFeelinBundlePath()
+    {
+        var assemblyDirectory = Path.GetDirectoryName(typeof(FeelinExpressionHandler).Assembly.Location)
+                                ?? throw new InvalidOperationException("Das Verzeichnis der core-engine-Assembly konnte nicht ermittelt werden.");
+
+        return Path.Combine(assemblyDirectory, "Expression", "Feelin", "bundle.js");
+    }
 }
 
 public class ConsoleWrapper

--- a/src/core-engine-tests/MessageTest.cs
+++ b/src/core-engine-tests/MessageTest.cs
@@ -16,7 +16,7 @@ public class MessageTest
     public void Flow1Test()
     {
         var testMessage = new Message { Name = string.Empty, TimeToLive = 60, CorrelationKey = "12345" };
-        var instanceEngine = new ProcessEngine(Process).StartProcess();
+        var instanceEngine = Helper.CreateProcessEngine(Process).StartProcess();
         using (new AssertionScope())
         {
             instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Waiting);
@@ -48,7 +48,7 @@ public class MessageTest
             instanceEngine.ActiveCatchMessages.Should().BeEmpty();
         }
         
-        instanceEngine = new ProcessEngine(Process).StartProcess();
+        instanceEngine = Helper.CreateProcessEngine(Process).StartProcess();
         instanceEngine.HandleServiceTaskResult("step1");
         using (new AssertionScope())
         {
@@ -80,7 +80,7 @@ public class MessageTest
     public void Flow2Test()
     {
         var instanceEngine =
-            new ProcessEngine(Process).HandleMessage(new Message { Name = "NachrichtStart" });
+            Helper.CreateProcessEngine(Process).HandleMessage(new Message { Name = "NachrichtStart" });
         using (new AssertionScope())
         {
             instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Completed);

--- a/src/core-engine-tests/SignalTest.cs
+++ b/src/core-engine-tests/SignalTest.cs
@@ -16,7 +16,7 @@ public class SignalTest
     [Test]
     public void Flow1Test()
     {
-        var instanceEngines = new ProcessEngine(Process).HandleSignal("SignalStartOne");
+        var instanceEngines = Helper.CreateProcessEngine(Process).HandleSignal("SignalStartOne");
         using (new AssertionScope())
         {
             instanceEngines.Should().ContainSingle();
@@ -34,7 +34,7 @@ public class SignalTest
     [Test]
     public void Flow2Test()
     {
-        var instanceEngines = new ProcessEngine(Process).HandleSignal("SignalStartTwo");
+        var instanceEngines = Helper.CreateProcessEngine(Process).HandleSignal("SignalStartTwo");
         var engine = instanceEngines.SingleOrDefault(engine => engine.ProcessInstanceState == ProcessInstanceState.Waiting);
         using (new AssertionScope())
         {

--- a/src/core-engine-tests/SimpleExpressionHandlerTest.cs
+++ b/src/core-engine-tests/SimpleExpressionHandlerTest.cs
@@ -1,0 +1,71 @@
+using System.Dynamic;
+using core_engine.Expression;
+using FluentAssertions;
+using Flowzer.Shared;
+
+namespace core_engine_tests;
+
+public class SimpleExpressionHandlerTest
+{
+    private readonly SimpleExpressionHandler _handler = new();
+
+    [Test]
+    public void GetValue_ShouldResolveNumericLiteral()
+    {
+        var result = _handler.GetValue(new ExpandoObject(), "=12345");
+
+        result.Should().Be(12345);
+    }
+
+    [Test]
+    public void GetValue_ShouldParseJsonObjectAndArrayPayloads()
+    {
+        var result = _handler.GetValue(
+            new ExpandoObject(),
+            "={\"Address\":{\"Firstname\":\"Lukas\"},\"Tags\":[{\"Index\":1},{\"Index\":2}]}")
+            .Should().BeOfType<ExpandoObject>()
+            .Subject;
+
+        result.GetValue("Address.Firstname").Should().Be("Lukas");
+
+        var tags = result.GetValue("Tags").Should().BeOfType<List<object?>>().Subject;
+        tags.Should().HaveCount(2);
+        tags[0].GetValue("Index").Should().Be(1L);
+        tags[1].GetValue("Index").Should().Be(2L);
+    }
+
+    [Test]
+    public void MatchExpression_ShouldCompareNestedProperties()
+    {
+        var variables = new
+        {
+            Order = new
+            {
+                Address = new
+                {
+                    Firstname = "Lukas"
+                }
+            }
+        }.ToExpando()!;
+
+        var matches = _handler.MatchExpression(variables, "=Order.Address.Firstname = \"Lukas\"");
+
+        matches.Should().BeTrue();
+    }
+
+    [Test]
+    public void MatchExpression_ShouldEvaluateBooleanComparisons()
+    {
+        var variables = new
+        {
+            Person = new
+            {
+                HatZeit = true
+            }
+        }.ToExpando()!;
+
+        var matches = _handler.MatchExpression(variables, "=Person.HatZeit = true");
+
+        matches.Should().BeTrue();
+    }
+}

--- a/src/core-engine-tests/SimpleExpressionHandlerTest.cs
+++ b/src/core-engine-tests/SimpleExpressionHandlerTest.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Dynamic;
 using core_engine.Expression;
 using FluentAssertions;
@@ -67,5 +68,28 @@ public class SimpleExpressionHandlerTest
         var matches = _handler.MatchExpression(variables, "=Person.HatZeit = true");
 
         matches.Should().BeTrue();
+    }
+
+    [Test]
+    public void GetValue_ShouldParseDecimalLiteralsCultureInvariant()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUiCulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            var germanCulture = CultureInfo.GetCultureInfo("de-DE");
+            CultureInfo.CurrentCulture = germanCulture;
+            CultureInfo.CurrentUICulture = germanCulture;
+
+            var result = _handler.GetValue(new ExpandoObject(), "=1.23");
+
+            result.Should().Be(1.23d);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
     }
 }

--- a/src/core-engine/Expression/SimpleExpressionHandler.cs
+++ b/src/core-engine/Expression/SimpleExpressionHandler.cs
@@ -1,0 +1,194 @@
+using System.Dynamic;
+using System.Text.Json;
+using Flowzer.Shared;
+
+namespace core_engine.Expression;
+
+/// <summary>
+/// Vereinfachter Expression-Handler für Tests und Fallback-Szenarien ohne V8.
+/// Er deckt bewusst nur die aktuell im Testbestand verwendeten Fälle ab.
+/// </summary>
+public sealed class SimpleExpressionHandler : DefaultExpressionHandler
+{
+    public override object? GetValue(object obj, string expression)
+    {
+        if (string.IsNullOrWhiteSpace(expression))
+            return expression;
+
+        var normalizedExpression = NormalizeExpression(expression);
+        if (TryParseLiteral(normalizedExpression, out var literalValue))
+            return literalValue;
+
+        var resolvedValue = ResolveMemberAccess(obj, normalizedExpression);
+        return resolvedValue ?? normalizedExpression;
+    }
+
+    public override bool MatchExpression(object obj, string expression)
+    {
+        if (string.IsNullOrWhiteSpace(expression))
+            return false;
+
+        var normalizedExpression = NormalizeExpression(expression);
+        if (TrySplitComparison(normalizedExpression, out var leftPart, out var rightPart))
+        {
+            var leftValue = ResolveValue(obj, leftPart);
+            var rightValue = ResolveValue(obj, rightPart);
+            return string.Equals(leftValue?.ToString(), rightValue?.ToString(), StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        var expressionValue = ResolveValue(obj, normalizedExpression);
+        return expressionValue switch
+        {
+            bool booleanValue => booleanValue,
+            string stringValue when bool.TryParse(stringValue, out var parsedBoolean) => parsedBoolean,
+            _ => string.Equals(expressionValue?.ToString(), "true", StringComparison.InvariantCultureIgnoreCase)
+        };
+    }
+
+    private static object? ResolveValue(object obj, string expressionPart)
+    {
+        if (TryParseLiteral(expressionPart, out var literalValue))
+            return literalValue;
+
+        return ResolveMemberAccess(obj, expressionPart);
+    }
+
+    private static string NormalizeExpression(string expression)
+    {
+        return expression.StartsWith('=') ? expression[1..].Trim() : expression.Trim();
+    }
+
+    private static object? ResolveMemberAccess(object obj, string expression)
+    {
+        if (obj is null)
+            return null;
+
+        if (obj is ExpandoObject expandoObject)
+            return expandoObject.GetValue(expression);
+
+        if (ExpandoHelper.IsComlexValue(obj))
+        {
+            var dynamicObject = obj.ToDynamic(true) as ExpandoObject;
+            return dynamicObject?.GetValue(expression);
+        }
+
+        var property = obj.GetType().GetProperty(expression);
+        return property?.GetValue(obj);
+    }
+
+    private static bool TryParseLiteral(string expression, out object? value)
+    {
+        value = null;
+        if (string.IsNullOrWhiteSpace(expression))
+            return false;
+
+        if ((expression.StartsWith('{') && expression.EndsWith('}')) ||
+            (expression.StartsWith('[') && expression.EndsWith(']')))
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(expression);
+                value = ConvertJsonElement(document.RootElement);
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
+        if ((expression.StartsWith('"') && expression.EndsWith('"')) ||
+            (expression.StartsWith('\'') && expression.EndsWith('\'')))
+        {
+            value = expression[1..^1];
+            return true;
+        }
+
+        if (bool.TryParse(expression, out var booleanValue))
+        {
+            value = booleanValue;
+            return true;
+        }
+
+        if (int.TryParse(expression, out var intValue))
+        {
+            value = intValue;
+            return true;
+        }
+
+        if (double.TryParse(expression, out var doubleValue))
+        {
+            value = doubleValue;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TrySplitComparison(string expression, out string leftPart, out string rightPart)
+    {
+        var inSingleQuote = false;
+        var inDoubleQuote = false;
+
+        for (var index = 0; index < expression.Length; index++)
+        {
+            var currentCharacter = expression[index];
+
+            if (currentCharacter == '"' && !inSingleQuote)
+            {
+                inDoubleQuote = !inDoubleQuote;
+                continue;
+            }
+
+            if (currentCharacter == '\'' && !inDoubleQuote)
+            {
+                inSingleQuote = !inSingleQuote;
+                continue;
+            }
+
+            if (currentCharacter != '=' || inSingleQuote || inDoubleQuote)
+                continue;
+
+            leftPart = expression[..index].Trim();
+            rightPart = expression[(index + 1)..].Trim();
+            return !string.IsNullOrWhiteSpace(leftPart) && !string.IsNullOrWhiteSpace(rightPart);
+        }
+
+        leftPart = string.Empty;
+        rightPart = string.Empty;
+        return false;
+    }
+
+    private static object? ConvertJsonElement(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Object => ConvertJsonObject(element),
+            JsonValueKind.Array => ConvertJsonArray(element),
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number => element.TryGetInt64(out var longValue) ? longValue : element.GetDouble(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Null => null,
+            _ => element.ToString()
+        };
+    }
+
+    private static ExpandoObject ConvertJsonObject(JsonElement jsonObject)
+    {
+        var dynamicObject = new ExpandoObject();
+        var dictionary = (IDictionary<string, object?>)dynamicObject;
+
+        foreach (var property in jsonObject.EnumerateObject())
+        {
+            dictionary[property.Name] = ConvertJsonElement(property.Value);
+        }
+
+        return dynamicObject;
+    }
+
+    private static List<object?> ConvertJsonArray(JsonElement jsonArray)
+    {
+        return jsonArray.EnumerateArray().Select(ConvertJsonElement).ToList();
+    }
+}

--- a/src/core-engine/Expression/SimpleExpressionHandler.cs
+++ b/src/core-engine/Expression/SimpleExpressionHandler.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Dynamic;
 using System.Text.Json;
 using Flowzer.Shared;
@@ -110,13 +111,13 @@ public sealed class SimpleExpressionHandler : DefaultExpressionHandler
             return true;
         }
 
-        if (int.TryParse(expression, out var intValue))
+        if (int.TryParse(expression, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
         {
             value = intValue;
             return true;
         }
 
-        if (double.TryParse(expression, out var doubleValue))
+        if (double.TryParse(expression, NumberStyles.Float, CultureInfo.InvariantCulture, out var doubleValue))
         {
             value = doubleValue;
             return true;

--- a/src/core-engine/FlowzerConfig.cs
+++ b/src/core-engine/FlowzerConfig.cs
@@ -12,4 +12,15 @@ public class FlowzerConfig
     {
         ExpressionHandler = new FeelinExpressionHandler()
     };
+
+    /// <summary>
+    /// Liefert eine testfreundliche Konfiguration ohne native V8-Abhängigkeit.
+    /// </summary>
+    public static FlowzerConfig CreateForTests()
+    {
+        return new FlowzerConfig
+        {
+            ExpressionHandler = new SimpleExpressionHandler()
+        };
+    }
 }

--- a/src/core-engine/Handler/ExclusiveGatewayHandler.cs
+++ b/src/core-engine/Handler/ExclusiveGatewayHandler.cs
@@ -16,9 +16,9 @@ internal class ExclusiveGatewayHandler : DefaultFlowNodeHandler
         
         var outgoingTokens = base.GenerateOutgoingTokens(config, processInstance, token);
 
-        if (outgoingTokens is null)
+        if (outgoingTokens is null || outgoingTokens.Count == 0)
             throw new FlowzerRuntimeException("No Condition is true for Exclusive Gateway");
         
-        return outgoingTokens[..1];
+        return outgoingTokens.Take(1).ToList();
     }
 }

--- a/src/core-engine/Handler/MultiInstanceHandler.cs
+++ b/src/core-engine/Handler/MultiInstanceHandler.cs
@@ -74,7 +74,7 @@ public class MultiInstanceHandler : DefaultFlowNodeHandler
         {
             if (!string.IsNullOrEmpty(loopCharacteristics.FlowzerLoopCharacteristics!.OutputElement) && completedToken.OutputData != null)
             {
-                outCollection.Add(FlowzerConfig.Default.ExpressionHandler.GetValue(completedToken.OutputData,
+                outCollection.Add(processInstance.FlowzerConfig.ExpressionHandler.GetValue(completedToken.OutputData,
                     loopCharacteristics.FlowzerLoopCharacteristics!.OutputElement));
             }
             else
@@ -136,14 +136,14 @@ public class MultiInstanceHandler : DefaultFlowNodeHandler
                 {
                     CurrentBaseElement =
                         flowNodeWithoutLoop.ApplyResolveExpression<FlowNode>(
-                            FlowzerConfig.Default.ExpressionHandler.ResolveString,
+                            processInstance.FlowzerConfig.ExpressionHandler.ResolveString,
                             processInstance.GetProcessToken(token).Variables!), //ist das korrekt? muss hier nicht eine gemerged menge alle "effektiven" variablen angegeben werden?
                     ActiveBoundaryEvents = processInstance.Process
                         .FlowElements
                         .OfType<BoundaryEvent>()
                         .Where(b => b.AttachedToRef.Id == flowNodeWithoutLoop.Id)
                         .Select(b => b.ApplyResolveExpression<BoundaryEvent>(
-                            FlowzerConfig.Default.ExpressionHandler.ResolveString,
+                            processInstance.FlowzerConfig.ExpressionHandler.ResolveString,
                             processInstance.GetProcessToken(token).Variables!)).ToList(),
                     Variables = dataObj,
                     ParentTokenId = token.Id,
@@ -155,7 +155,7 @@ public class MultiInstanceHandler : DefaultFlowNodeHandler
             {
                 var completionCondition = multiInstanceLoopCharacteristics.CompletionCondition.Body;
                 var completionConditionValue =
-                    FlowzerConfig.Default.ExpressionHandler.MatchExpression(dataObj, completionCondition);
+                    processInstance.FlowzerConfig.ExpressionHandler.MatchExpression(dataObj, completionCondition);
                 if (completionConditionValue)
                     break;
             }

--- a/src/core-engine/Handler/ProcessFlowNodeHandler.cs
+++ b/src/core-engine/Handler/ProcessFlowNodeHandler.cs
@@ -17,7 +17,7 @@ public class ProcessFlowNodeHandler : DefaultFlowNodeHandler
                 {
                     CurrentBaseElement = 
                         startFlowNode.ApplyResolveExpression<FlowNode>(
-                            FlowzerConfig.Default.ExpressionHandler.ResolveString, token.OutputData),
+                            processInstance.FlowzerConfig.ExpressionHandler.ResolveString, token.OutputData),
                     ProcessInstanceId = token.ProcessInstanceId,
                     ParentTokenId = token.Id,
                     State = FlowNodeState.Ready,

--- a/src/core-engine/InstanceEngine/Base.cs
+++ b/src/core-engine/InstanceEngine/Base.cs
@@ -37,15 +37,16 @@ public partial class InstanceEngine: ICatchHandler
         
     }
     
-    public InstanceEngine(List<Token> tokens, bool allTokensIncluded = true)
+    public InstanceEngine(List<Token> tokens, FlowzerConfig? flowzerConfig = null, bool allTokensIncluded = true)
     {
         if (tokens.SingleOrDefault(t => t.ParentTokenId == null) == null)
             throw new ArgumentException("Es muss mindestens ein (Master)Token vorhanden sein", nameof(tokens));
         Tokens = tokens;
+        FlowzerConfig = flowzerConfig ?? FlowzerConfig.Default;
     }
     
     public List<Token> Tokens { get; }
-    public FlowzerConfig FlowzerConfig { get; } = FlowzerConfig.Default;
+    public FlowzerConfig FlowzerConfig { get; }
 
     public IEnumerable<Token> ActiveTokens => Tokens.Where(token => token.State == FlowNodeState.Active);
     

--- a/src/core-engine/ProcessEngine.cs
+++ b/src/core-engine/ProcessEngine.cs
@@ -3,10 +3,11 @@ using Newtonsoft.Json;
 
 namespace core_engine;
 
-public class ProcessEngine(Process process) : ICatchHandler
+public class ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null) : ICatchHandler
 {
     
     public Process Process { get; set; } = process;
+    public FlowzerConfig FlowzerConfig { get; } = flowzerConfig ?? FlowzerConfig.Default;
 
     public InstanceEngine StartProcess(Variables? data = null)
     {
@@ -19,7 +20,7 @@ public class ProcessEngine(Process process) : ICatchHandler
             ActiveBoundaryEvents = [],
             ProcessInstanceId = Guid.NewGuid(),
         };
-        var instance = new InstanceEngine([masterToken]);
+        var instance = new InstanceEngine([masterToken], FlowzerConfig);
         instance.Start(data);
         return instance;
     }
@@ -61,7 +62,7 @@ public class ProcessEngine(Process process) : ICatchHandler
             ActiveBoundaryEvents = [],
             ProcessInstanceId = Guid.NewGuid(),
         };
-        var instanceEngine = new InstanceEngine([masterToken]);
+        var instanceEngine = new InstanceEngine([masterToken], FlowzerConfig);
 
         instanceEngine.HandleMessage(message);
         
@@ -84,7 +85,7 @@ public class ProcessEngine(Process process) : ICatchHandler
                 ActiveBoundaryEvents = [],
                 ProcessInstanceId = Guid.NewGuid(),
             };
-            var instanceEngine = new InstanceEngine([masterToken]);
+            var instanceEngine = new InstanceEngine([masterToken], FlowzerConfig);
 
             instanceEngine.HandleSignal(signalName, JsonConvert.SerializeObject(signalData), startEvent);
 


### PR DESCRIPTION
## Zusammenfassung

Dieser PR zieht die inhaltlich sinnvollen Teile aus PR #16 kontrolliert auf `next` neu auf, ohne die offenen Multi-Instance-Probleme mit hineinzumischen.

## Änderungen

- neuer `SimpleExpressionHandler` für testfreundliche Expression-Auswertung ohne native V8-Abhängigkeit
- `FlowzerConfig.CreateForTests()` ergänzt, damit Tests bewusst einen V8-freien Pfad verwenden können
- `ProcessEngine` und `InstanceEngine` propagieren `FlowzerConfig` jetzt sauber weiter
- verbleibende harte `FlowzerConfig.Default`-Zugriffe in Handlern entfernt
- `ExclusiveGatewayHandler` bei leeren Trefferlisten robuster gemacht
- Tests für Message-, Signal-, Start- und Gateway-Pfade auf die testfreundliche Konfiguration umgestellt
- `JavaScriptFeelTest` auf repo-lokale Bundle-Datei umgestellt und bei fehlenden V8-Libraries sauber als `Ignore` ausgeführt
- neue Unit-Tests für `SimpleExpressionHandler` ergänzt

## Abgrenzung

Nicht Teil dieses PRs:

- die weiterhin offenen Multi-Instance-/Output-Collection-Fehler in `ParallelTaskTest` und `SequentialTest`
- allgemeine Security- oder Dependency-Upgrades
- API-/`ICore`-Designarbeit

## Lokale Validierung

```text
dotnet build core-engine.sln --no-restore
dotnet test src/core-engine-tests/core-engine-tests.csproj --no-build
```

Ergebnis lokal:

- **33/35 Tests erfolgreich**
- verbleibend offen:
  - `ParallelTaskTest`
  - `SequentialTest`
- `JavaScriptFeelTest` nutzt keinen absoluten Rechnerpfad mehr und läuft auf Umgebungen mit V8 erfolgreich bzw. wird sonst sauber übersprungen

## Bezug

- Rework / Supersedes: #16
- Fixes #10
