### PR TITLE
Multi-Instance-OutputCollection und Abschlusslogik stabilisieren

### DIFF
--- a/src/core-engine-tests/EngineTest.cs
+++ b/src/core-engine-tests/EngineTest.cs
@@ -213,11 +213,16 @@ public class EngineTest
                     : ProcessInstanceState.Waiting);
         }
         
+        var multiInstanceToken = instanceEngine.Tokens.Single(t => t.CurrentFlowNode is Activity
+        {
+            LoopCharacteristics: MultiInstanceLoopCharacteristics
+        });
         var outList = (List<object>?)instanceEngine.MasterToken.Variables.GetValue("MitarbeiterOut");
         outList.Should().HaveCount(3);
         
         using(new AssertionScope())
         {
+            ((List<object>?)multiInstanceToken.OutputData?.GetValue("MitarbeiterOut")).Should().HaveCount(3);
             //check if the order is correct
             outList.Select(x => x.GetValue("Vorname")?.ToString()).Should()
                 .ContainInOrder(["Lukas", "Christian", "Max"]);
@@ -278,10 +283,15 @@ public class EngineTest
             instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Completed);
         }
 
+        var multiInstanceToken = instanceEngine.Tokens.Single(t => t.CurrentFlowNode is Activity
+        {
+            LoopCharacteristics: MultiInstanceLoopCharacteristics
+        });
         var outList = (List<object>)instanceEngine.MasterToken.Variables.GetValue("MitarbeiterOut")!;
         outList.Should().HaveCount(3);
         using(new AssertionScope())
         {
+            ((List<object>?)multiInstanceToken.OutputData?.GetValue("MitarbeiterOut")).Should().HaveCount(3);
             //check if the order is correct
             outList.Select(x => x.GetValue("Vorname")?.ToString()).Should()
                 .ContainInOrder(["Lukas", "Christian", "Max"]);

--- a/src/core-engine-tests/InstanceEngineOutputMappingTest.cs
+++ b/src/core-engine-tests/InstanceEngineOutputMappingTest.cs
@@ -1,0 +1,128 @@
+using System.Reflection;
+using BPMN.Activities;
+using BPMN.Flowzer;
+using BPMN.Process;
+using FluentAssertions;
+using Flowzer.Shared;
+using Model;
+using Variables = System.Dynamic.ExpandoObject;
+
+namespace core_engine_tests;
+
+public class InstanceEngineOutputMappingTest
+{
+    [Test]
+    public void PrepareOutputData_ShouldInitializeSubProcessVariablesForMultiInstancePropagation()
+    {
+        var outputCollection = new List<object?> { "Lukas", "Christian" };
+        var instanceEngine = CreateInstanceEngineWithMultiInstanceToken(outputCollection, outputMappings: null);
+        var multiInstanceToken = instanceEngine.Tokens.Single(token => token.ParentTokenId == instanceEngine.Tokens[1].Id);
+
+        InvokePrepareOutputData(instanceEngine, multiInstanceToken);
+
+        var subProcessToken = instanceEngine.Tokens[1];
+        subProcessToken.Variables.Should().NotBeNull();
+        ((List<object?>?)subProcessToken.Variables!.GetValue("MitarbeiterOut")).Should().BeEquivalentTo(outputCollection);
+    }
+
+    [Test]
+    public void PrepareOutputData_ShouldApplyOutputMappingsForMultiInstanceTokens()
+    {
+        var outputCollection = new List<object?> { "Lukas", "Christian" };
+        var outputMappings = new FlowzerList<FlowzerIoMapping>
+        {
+            new("=MitarbeiterOut", "GemappteMitarbeiter")
+        };
+
+        var instanceEngine = CreateInstanceEngineWithMultiInstanceToken(outputCollection, outputMappings);
+        var multiInstanceToken = instanceEngine.Tokens.Single(token => token.ParentTokenId == instanceEngine.Tokens[1].Id);
+
+        InvokePrepareOutputData(instanceEngine, multiInstanceToken);
+
+        ((List<object?>?)instanceEngine.MasterToken.Variables!.GetValue("GemappteMitarbeiter"))
+            .Should()
+            .BeEquivalentTo(outputCollection);
+    }
+
+    private static InstanceEngine CreateInstanceEngineWithMultiInstanceToken(
+        List<object?> outputCollection,
+        FlowzerList<FlowzerIoMapping>? outputMappings)
+    {
+        var processInstanceId = Guid.NewGuid();
+        var process = new Process
+        {
+            Id = "Process_1",
+            DefinitionsId = "Definitions_1",
+            Name = "Test Process",
+            IsExecutable = true,
+            FlowElements = []
+        };
+
+        var subProcess = new SubProcess
+        {
+            Id = "Activity_SubProcess",
+            Name = "SubProcess",
+            FlowElements = []
+        };
+
+        var multiInstanceServiceTask = new ServiceTask
+        {
+            Id = "Activity_MultiInstance",
+            Name = "Multi Instance Task",
+            Implementation = "InputAsOutput",
+            OutputMappings = outputMappings,
+            LoopCharacteristics = new MultiInstanceLoopCharacteristics
+            {
+                Behavior = MultiInstanceBehavior.All,
+                FlowzerLoopCharacteristics = new FlowzwerLoopCharacteristics
+                {
+                    InputCollection = Array.Empty<object>(),
+                    OutputCollection = "MitarbeiterOut",
+                    OutputElement = "=OutProperty"
+                }
+            }
+        };
+
+        var masterToken = new Token
+        {
+            ProcessInstanceId = processInstanceId,
+            CurrentBaseElement = process,
+            ActiveBoundaryEvents = [],
+            State = FlowNodeState.Active,
+            Variables = new Variables()
+        };
+
+        var subProcessToken = new Token
+        {
+            ProcessInstanceId = processInstanceId,
+            ParentTokenId = masterToken.Id,
+            CurrentBaseElement = subProcess,
+            ActiveBoundaryEvents = [],
+            State = FlowNodeState.Active
+        };
+
+        var multiInstanceToken = new Token
+        {
+            ProcessInstanceId = processInstanceId,
+            ParentTokenId = subProcessToken.Id,
+            CurrentBaseElement = multiInstanceServiceTask,
+            ActiveBoundaryEvents = [],
+            State = FlowNodeState.Completed,
+            OutputData = new Variables()
+        };
+
+        multiInstanceToken.OutputData.SetValue("MitarbeiterOut", outputCollection);
+
+        return new InstanceEngine([masterToken, subProcessToken, multiInstanceToken], Helper.TestFlowzerConfig);
+    }
+
+    private static void InvokePrepareOutputData(InstanceEngine instanceEngine, Token token)
+    {
+        var prepareOutputDataMethod = typeof(InstanceEngine).GetMethod(
+            "PrepareOutputData",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        prepareOutputDataMethod.Should().NotBeNull("die private PrepareOutputData-Methode für den Regressionstest erreichbar sein muss");
+        prepareOutputDataMethod!.Invoke(instanceEngine, [token]);
+    }
+}

--- a/src/core-engine-tests/InstanceEngineOutputMappingTest.cs
+++ b/src/core-engine-tests/InstanceEngineOutputMappingTest.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using BPMN.Activities;
 using BPMN.Flowzer;
 using BPMN.Process;
+using core_engine.Exceptions;
 using FluentAssertions;
 using Flowzer.Shared;
 using Model;
@@ -42,6 +43,36 @@ public class InstanceEngineOutputMappingTest
         ((List<object?>?)instanceEngine.MasterToken.Variables!.GetValue("GemappteMitarbeiter"))
             .Should()
             .BeEquivalentTo(outputCollection);
+    }
+
+    [Test]
+    public void GetCorrectVariablesToken_ShouldThrowHelpfulException_WhenParentScopeIsRequestedWithoutParent()
+    {
+        var processInstanceId = Guid.NewGuid();
+        var process = new Process
+        {
+            Id = "Process_1",
+            DefinitionsId = "Definitions_1",
+            Name = "Test Process",
+            IsExecutable = true,
+            FlowElements = []
+        };
+
+        var masterToken = new Token
+        {
+            ProcessInstanceId = processInstanceId,
+            CurrentBaseElement = process,
+            ActiveBoundaryEvents = [],
+            State = FlowNodeState.Active,
+            Variables = new Variables()
+        };
+
+        var instanceEngine = new InstanceEngine([masterToken], Helper.TestFlowzerConfig);
+        var action = () => instanceEngine.GetCorrectVariablesToken(masterToken, "MitarbeiterOut", includeCurrentToken: false);
+
+        action.Should()
+            .Throw<FlowzerRuntimeException>()
+            .WithMessage("*kein ParentToken*");
     }
 
     private static InstanceEngine CreateInstanceEngineWithMultiInstanceToken(

--- a/src/core-engine/Handler/MultiInstanceHandler.cs
+++ b/src/core-engine/Handler/MultiInstanceHandler.cs
@@ -86,9 +86,15 @@ public class MultiInstanceHandler : DefaultFlowNodeHandler
         
         if (loopCharacteristics.FlowzerLoopCharacteristics!.OutputCollection != null)
         {
+            // Die erzeugte Collection wird sowohl in den aktuellen Variablen als auch in den Output-Daten
+            // des Multi-Instance-Tokens abgelegt. Nur so kann der nachgelagerte Output-Mapping-Pfad beim
+            // Abschluss des Parent-Tokens die Werte wieder sauber in den Prozesskontext propagieren.
             token.Variables ??= new Variables();
+            token.OutputData ??= new Variables();
             token.Variables!.SetValue(loopCharacteristics.FlowzerLoopCharacteristics!.OutputCollection, outCollection);
-        }        
+            token.OutputData.SetValue(loopCharacteristics.FlowzerLoopCharacteristics!.OutputCollection, outCollection);
+        }
+
         token.State = FlowNodeState.Completing;
     }
 

--- a/src/core-engine/InstanceEngine/InstanceEngine.cs
+++ b/src/core-engine/InstanceEngine/InstanceEngine.cs
@@ -158,9 +158,11 @@ public partial class InstanceEngine
         });
     }
 
-    public Token GetCorrectVariablesToken(Token token, string name)
+    public Token GetCorrectVariablesToken(Token token, string name, bool includeCurrentToken = true)
     {
-        var variablesToken = token;
+        var variablesToken = includeCurrentToken
+            ? token
+            : Tokens.Single(t => t.Id == token.ParentTokenId);
         
         var variablenName = name.Contains('.') ? name[..name.IndexOf('.')] : name;
         
@@ -170,11 +172,14 @@ public partial class InstanceEngine
             if (variablesToken.Variables != null &&
                 variablesToken.Variables.HasProperty(variablenName))
                 return variablesToken;
-            variablesToken = Tokens.Single(t => t.Id == variablesToken.ParentTokenId);
-            
-            // Die Höchste Ebene, die Zurückgegeben werden kann, ist die (Sub-)Process-Ebene
+
+            // Die höchste Ebene, die für das Schreiben/Lesen noch sinnvoll ist, ist die
+            // aktuelle (Sub-)Process-Ebene. Existiert die Variable dort noch nicht, wird
+            // sie in genau diesem Scope angelegt.
             if (variablesToken.CurrentBaseElement is BPMN.Process.Process or SubProcess)
                 return variablesToken;
+
+            variablesToken = Tokens.Single(t => t.Id == variablesToken.ParentTokenId);
         } while (variablesToken.Variables == null);
 
         return MasterToken;
@@ -190,7 +195,21 @@ public partial class InstanceEngine
         if (token.CurrentFlowNode is not IFlowzerOutputMapping mapping)
             return;
 
-        
+        var isMultiInstanceToken = token.CurrentFlowNode is Activity
+        {
+            LoopCharacteristics: MultiInstanceLoopCharacteristics
+        };
+
+        if (isMultiInstanceToken && token.OutputData != null)
+        {
+            foreach (var (key, value) in token.OutputData)
+            {
+                var variablesToken = GetCorrectVariablesToken(token, key, includeCurrentToken: false);
+                variablesToken.Variables.SetValue(key, value);
+            }
+
+            return;
+        }
 
         if (mapping.OutputMappings?.Count > 0)
             mapping.OutputMappings?.ForEach(ioMapping =>

--- a/src/core-engine/InstanceEngine/InstanceEngine.cs
+++ b/src/core-engine/InstanceEngine/InstanceEngine.cs
@@ -205,16 +205,19 @@ public partial class InstanceEngine
             foreach (var (key, value) in token.OutputData)
             {
                 var variablesToken = GetCorrectVariablesToken(token, key, includeCurrentToken: false);
+                variablesToken.Variables ??= new Variables();
                 variablesToken.Variables.SetValue(key, value);
             }
 
-            return;
+            if (mapping.OutputMappings?.Count is not > 0)
+                return;
         }
 
         if (mapping.OutputMappings?.Count > 0)
             mapping.OutputMappings?.ForEach(ioMapping =>
             {
                 var variablesToken = GetCorrectVariablesToken(token, ioMapping.Target);
+                variablesToken.Variables ??= new Variables();
                 var value = FlowzerConfig.ExpressionHandler.GetValue(token.OutputData as dynamic, ioMapping.Source);
                 ExpandoHelper.SetValue(variablesToken.Variables, ioMapping.Target, value);
             });
@@ -223,6 +226,7 @@ public partial class InstanceEngine
             foreach (var (key, value) in token.OutputData!)
             {
                 var variablesToken = GetCorrectVariablesToken(token, key);
+                variablesToken.Variables ??= new Variables();
                 variablesToken.Variables.SetValue(key, value);
             }
         }

--- a/src/core-engine/InstanceEngine/InstanceEngine.cs
+++ b/src/core-engine/InstanceEngine/InstanceEngine.cs
@@ -160,9 +160,16 @@ public partial class InstanceEngine
 
     public Token GetCorrectVariablesToken(Token token, string name, bool includeCurrentToken = true)
     {
-        var variablesToken = includeCurrentToken
-            ? token
-            : Tokens.Single(t => t.Id == token.ParentTokenId);
+        var variablesToken = token;
+        if (!includeCurrentToken)
+        {
+            if (token.ParentTokenId == null)
+                throw new FlowzerRuntimeException("Für die Variablensuche im Parent-Scope existiert kein ParentToken.");
+
+            variablesToken = Tokens.SingleOrDefault(t => t.Id == token.ParentTokenId)
+                             ?? throw new FlowzerRuntimeException(
+                                 $"Das ParentToken {token.ParentTokenId} konnte für die Variablensuche nicht gefunden werden.");
+        }
         
         var variablenName = name.Contains('.') ? name[..name.IndexOf('.')] : name;
         


### PR DESCRIPTION
## Ziel

Dieser PR stabilisiert das verbleibende Multi-Instance-Verhalten auf `next`, nachdem das V8-/Expression-Thema bereits separat gelöst wurde.

## Was wurde geändert?

- `OutputCollection` wird im Multi-Instance-Handler jetzt konsistent sowohl in den Variablen als auch in `OutputData` gehalten.
- `PrepareOutputData` propagiert rohe Multi-Instance-Ergebnisse sauber in den übergeordneten Scope, bevor reguläre Output-Mappings greifen.
- `GetCorrectVariablesToken` behandelt Prozess-/Subprozess-Scope robuster, damit Parent-/Child-Token bei Abschlusslogik korrekt aufgelöst werden.
- Die bestehenden Regressionstests für parallele und sequentielle Multi-Instance-Ausführung prüfen jetzt zusätzlich die erwartete `OutputCollection` direkt.

## Warum ist das sinnvoll?

Die beiden verbliebenen roten Engine-Tests (`ParallelTaskTest`, `SequentialTest`) liefen ins Leere, weil die gesammelten Multi-Instance-Ergebnisse nicht zuverlässig bis in den relevanten Scope propagiert wurden. Dadurch blieb `MitarbeiterOut` im Ergebnis `null`, obwohl die Child-Instanzen bereits korrekt gelaufen waren.

## Tests

- `dotnet build src/core-engine-tests/core-engine-tests.csproj --no-restore --configuration Release`
- `dotnet test src/core-engine-tests/core-engine-tests.csproj --no-restore --no-build --configuration Release`

Ergebnis lokal: **36/36 Tests grün**.

Fixes #27
