### PR TITLE
System.Text.Json-Sicherheitsupdate für next übernehmen

### DIFF
--- a/src/FlowzerFrontend/FlowzerFrontend.csproj
+++ b/src/FlowzerFrontend/FlowzerFrontend.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.10.1" />
         <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.6.0" />
         <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.10.0" />
-        <PackageReference Include="System.Text.Json" Version="8.0.3" />
+        <PackageReference Include="System.Text.Json" Version="8.0.5" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Ziel

Dieser PR übernimmt den bereits bekannten Patch-Stand für `System.Text.Json` kontrolliert nach `next`.

## Was wurde geändert?

- `System.Text.Json` im Frontend-Projekt von **8.0.3** auf **8.0.5** angehoben

## Warum ist das sinnvoll?

Der bisherige Stand 8.0.3 erzeugte auf `next` weiterhin die bekannten Security-Warnungen. Mit dem Patch-Upgrade verschwindet dieser Hinweis im Frontend-Strang, ohne den bereits stabilisierten Build-/Testpfad funktional zu verändern.

## Tests

- `dotnet restore core-engine.sln`
- `dotnet build core-engine.sln --no-restore --configuration Release`
- `dotnet test src/core-engine-tests/core-engine-tests.csproj --no-restore --no-build --configuration Release`

Ergebnis lokal: **42/42 Tests erfolgreich**.

## Hinweis

Nach diesem PR bleibt als bekannte Security-Warnung im .NET-Pfad noch `AutoMapper` offen; das wird bewusst separat behandelt.

Fixes #31
