### PR TITLE
ICore als minimalen öffentlichen Kernvertrag einführen

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Diese Punkte sollte man kennen, bevor man loslegt:
 
 - [docs/PROJECT-STATUS.md](docs/PROJECT-STATUS.md) – ehrliche Bestandsaufnahme
 - [docs/ROADMAP.md](docs/ROADMAP.md) – Vorschlag für die nächsten Schritte
+- [docs/ICORE.md](docs/ICORE.md) – dokumentierter Kernvertrag und minimaler Integrationspfad
 - [CONTRIBUTING.md](CONTRIBUTING.md) – Leitfaden für Beiträge über GitHub
 - [AGENTS.md](AGENTS.md) – Hinweise für KI, Codex und Copilot
 - [DEVELOPMENT-GUIDELINES.md](DEVELOPMENT-GUIDELINES.md) – Entwicklungsprinzipien
@@ -115,6 +116,18 @@ Die sinnvolle Reihenfolge ist aktuell:
 6. **Demo und Contributor Experience verbessern**
 
 Details dazu stehen in [docs/ROADMAP.md](docs/ROADMAP.md).
+
+## Minimaler `ICore`-Nutzungsweg
+
+Für Integrationen ohne WebAPI oder Storage liegt jetzt ein bewusst kleiner Kernvertrag vor:
+
+1. BPMN-Datei laden
+2. initiale Start-Subscriptions lesen
+3. Event über `BpmnNodeId` verarbeiten
+4. aktive Interaktionen aus dem Ergebnis ableiten
+
+Ein vollständiger Ablauf ist dokumentiert in [docs/ICORE.md](docs/ICORE.md).  
+Eine konkrete Beispiel-Datei liegt unter [`examples/SimpleEngineExample.cs`](examples/SimpleEngineExample.cs).
 
 ## Beispiel
 

--- a/docs/ICORE.md
+++ b/docs/ICORE.md
@@ -1,0 +1,131 @@
+# `ICore`-Vertrag
+
+## Ziel
+
+`ICore` beschreibt den kleinsten bewusst öffentlichen Integrationspfad für die Engine, ohne WebAPI-, Storage- oder UI-Abhängigkeiten.
+
+Der Vertrag richtet sich an Einbettungen wie:
+
+- einfache Host-Anwendungen
+- Console-Demos
+- Tests auf Integrationsniveau
+- Adapter, die den Kern ohne REST direkt ansprechen wollen
+
+## Verantwortlichkeiten
+
+`ICore` übernimmt aktuell genau diese Aufgaben:
+
+1. **eine BPMN-Definition laden**
+2. **initiale Einstiegspunkte ermitteln**
+3. **ein Event starten oder eine aktive Interaktion fortführen**
+4. **den aktuellen Instanz-Snapshot zurückgeben**
+
+## Bewusst nicht Teil des Vertrags
+
+Diese Themen gehören aktuell **nicht** in `ICore`:
+
+- Persistenz von Definitionen oder Instanzen
+- REST-/HTTP-spezifische DTOs
+- Frontend-spezifische Modelle
+- Benutzer- und Rollenverwaltung
+- langfristige Subscription-Speicherung
+- verteilte oder mehrknotige Laufzeit
+
+## Öffentliche Typen
+
+Der Vertrag besteht aus diesen Typen:
+
+- `ICore`
+- `CoreEngine`
+- `CoreEventData`
+- `CoreEventResult`
+- `CoreInstance`
+- `CoreInteraction`
+- `CoreSubscription`
+
+## Unterstützter Integrationspfad in der ersten Version
+
+Die aktuelle erste Version unterstützt bewusst den häufigsten Happy Path:
+
+- **genau eine geladene BPMN-Definition**
+- **genau ein Prozess** pro geladener Definition
+- Start über:
+  - Plain Start Event
+  - Message Start Event
+  - Signal Start Event
+- Fortführung aktiver:
+  - User Tasks
+  - Service Tasks
+- Ergebnisrückgabe als in-memory Snapshot
+
+## Aktuelle Grenzen
+
+Die erste Version ist absichtlich klein. Aktuell gelten daher noch diese Grenzen:
+
+- kein eingebauter Persistenz-Layer
+- kein vollständiger Query-Vertrag für Instanzhistorie
+- kein allgemeines externes Subscription-Management
+- Plain-Starts werden aktuell nur sauber unterstützt, wenn die Definition genau **ein** explizites Plain-Start-Event enthält
+
+## Beispiel
+
+```csharp
+using core_engine;
+
+var core = new CoreEngine(FlowzerConfig.CreateForTests());
+
+await using var xmlStream = File.OpenRead("examples/simple-approval-process.bpmn");
+await core.LoadBpmnFile(xmlStream, verify: true);
+
+var subscriptions = await core.GetInitialSubscriptions();
+var startSubscription = subscriptions.Single();
+
+var instanceId = Guid.NewGuid();
+
+var startResult = await core.HandleEvent(new CoreEventData
+{
+    InstanceId = instanceId,
+    BpmnNodeId = startSubscription.BpmnNodeId
+});
+
+var userTask = startResult.Instance.Interactions.Single();
+
+var nextResult = await core.HandleEvent(new CoreEventData
+{
+    InstanceId = instanceId,
+    BpmnNodeId = userTask.NodeId,
+    AdditionalData = new Dictionary<string, object?>
+    {
+        ["approval"] = "approved"
+    }
+});
+```
+
+## Ereignismodell
+
+`HandleEvent(...)` arbeitet immer nach demselben Muster:
+
+- **neue `InstanceId`** + Start-`BpmnNodeId` → neue Instanz starten
+- **bestehende `InstanceId`** + aktive Interaktions-`BpmnNodeId` → wartende Interaktion fortführen
+
+## Event `InteractionFinished`
+
+Nach jeder erfolgreich verarbeiteten Interaktion feuert `ICore` ein `InteractionFinished`-Event mit einem aktuellen `CoreInstance`-Snapshot.
+
+Das ist nützlich für:
+
+- Logging
+- Demo-Anwendungen
+- Adapterschichten
+- einfache Reaktionen auf Statuswechsel
+
+## Testabdeckung
+
+Der bevorzugte Integrationspfad ist aktuell durch Tests abgesichert für:
+
+- Laden einer BPMN-Datei
+- Plain Start Events
+- Message Start Events
+- Signal Start Events
+- User-Task-Fortsetzung
+- Service-Task-Fortsetzung bis Prozessende

--- a/docs/ICORE.md
+++ b/docs/ICORE.md
@@ -75,7 +75,7 @@ using core_engine;
 var core = new CoreEngine(FlowzerConfig.CreateForTests());
 
 await using var xmlStream = File.OpenRead("examples/simple-approval-process.bpmn");
-await core.LoadBpmnFile(xmlStream, verify: true);
+await core.LoadBpmnFile(xmlStream);
 
 var subscriptions = await core.GetInitialSubscriptions();
 var startSubscription = subscriptions.Single();
@@ -94,6 +94,7 @@ var nextResult = await core.HandleEvent(new CoreEventData
 {
     InstanceId = instanceId,
     BpmnNodeId = userTask.NodeId,
+    InteractionId = userTask.InteractionId,
     AdditionalData = new Dictionary<string, object?>
     {
         ["approval"] = "approved"
@@ -107,6 +108,7 @@ var nextResult = await core.HandleEvent(new CoreEventData
 
 - **neue `InstanceId`** + Start-`BpmnNodeId` → neue Instanz starten
 - **bestehende `InstanceId`** + aktive Interaktions-`BpmnNodeId` → wartende Interaktion fortführen
+- wenn mehrere aktive Interaktionen auf denselben BPMN-Knoten zeigen, kann optional die eindeutige `InteractionId` mitgegeben werden
 
 ## Event `InteractionFinished`
 

--- a/examples/SimpleEngineExample.cs
+++ b/examples/SimpleEngineExample.cs
@@ -1,159 +1,104 @@
-using core_engine;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
+using core_engine;
 
-namespace Examples
+namespace Examples;
+
+/// <summary>
+/// Minimales Nutzungsbeispiel für den öffentlichen <see cref="ICore"/>-Vertrag.
+/// </summary>
+public class SimpleEngineExample
 {
-    /// <summary>
-    /// Beispiel für die Verwendung der BPMN Core Engine
-    /// </summary>
-    public class SimpleEngineExample
+    public async Task RunSimpleApprovalProcess()
     {
-        public async Task RunSimpleApprovalProcess()
+        var engine = new CoreEngine(FlowzerConfig.CreateForTests());
+        SetupEventHandlers(engine);
+
+        await using var xmlStream = File.OpenRead("examples/simple-approval-process.bpmn");
+        await engine.LoadBpmnFile(xmlStream, verify: true);
+
+        var subscriptions = await engine.GetInitialSubscriptions();
+        var startSubscription = subscriptions.Single();
+
+        Console.WriteLine($"Start-Subscription: {startSubscription.Type} ({startSubscription.BpmnNodeId})");
+
+        var instanceId = Guid.NewGuid();
+        var startResult = await engine.HandleEvent(new CoreEventData
         {
-            // 1. Engine initialisieren
-            var engine = new CoreEngine(); // Diese Klasse muss noch implementiert werden
-            
-            // 2. BPMN-Prozess laden
-            var bpmnFilePath = "examples/simple-approval-process.bpmn";
-            using var xmlStream = File.OpenRead(bpmnFilePath);
-            
-            await engine.LoadBpmnFile(xmlStream, verify: true);
-            Console.WriteLine("BPMN-Prozess erfolgreich geladen");
-            
-            // 3. Anfangs-Subscriptions abrufen
-            var subscriptions = await engine.GetInitialSubscriptions();
-            Console.WriteLine($"Gefunden: {subscriptions.Length} Start-Subscriptions");
-            
-            foreach (var subscription in subscriptions)
-            {
-                Console.WriteLine($"  - Service: {subscription.ServiceId}, Node: {subscription.BpmnNodeId}");
-            }
-            
-            // 4. Neue Prozessinstanz starten
-            var instanceId = Guid.NewGuid();
-            var startEventData = new EventData
-            {
-                BpmnNodeId = "StartEvent_1",
-                InstanceId = instanceId
-            };
-            
-            var instanceData = new Instance(); // Diese Klasse muss erweitert werden
-            
-            // 5. Start-Event verarbeiten
-            var result = await engine.HandleEvent(instanceData, startEventData);
-            Console.WriteLine($"Prozess gestartet. Nächste Interaktionen: {result.Interactions?.Count ?? 0}");
-            
-            // 6. User Task verarbeiten (simuliert)
-            if (result.Interactions?.Count > 0)
-            {
-                var userTask = result.Interactions[0];
-                if (userTask is UserTask task)
-                {
-                    Console.WriteLine($"User Task erhalten: {task.Name}");
-                    
-                    // Simulation: Benutzer genehmigt das Dokument
-                    var userTaskCompletionData = new EventData
-                    {
-                        BpmnNodeId = task.NodeId,
-                        InstanceId = instanceId
-                    };
-                    
-                    // Zusätzliche Daten für Entscheidung hinzufügen
-                    userTaskCompletionData.AdditionalData = new Dictionary<string, object>
-                    {
-                        ["approval"] = "approved"
-                    };
-                    
-                    var completionResult = await engine.HandleEvent(instanceData, userTaskCompletionData);
-                    Console.WriteLine($"User Task abgeschlossen. Nächste Interaktionen: {completionResult.Interactions?.Count ?? 0}");
-                }
-            }
-        }
-        
-        /// <summary>
-        /// Beispiel für Event-Handler Registration
-        /// </summary>
-        public void SetupEventHandlers()
+            InstanceId = instanceId,
+            BpmnNodeId = startSubscription.BpmnNodeId
+        });
+
+        Console.WriteLine($"Instanz gestartet: {startResult.Instance.Id}");
+        await ContinueInteractions(engine, instanceId, startResult.Instance.Interactions);
+    }
+
+    /// <summary>
+    /// Registriert einen einfachen Konsolen-Handler für Statuswechsel.
+    /// </summary>
+    private static void SetupEventHandlers(ICore engine)
+    {
+        engine.InteractionFinished += (_, instance) =>
         {
-            var engine = new CoreEngine();
-            
-            // Event-Handler für abgeschlossene Interaktionen
-            engine.InteractionFinished += (sender, instance) =>
+            Console.WriteLine(
+                $"InteractionFinished: Instanz={instance.Id}, State={instance.State}, offene Interaktionen={instance.Interactions.Count}");
+        };
+    }
+
+    private static async Task ContinueInteractions(
+        ICore engine,
+        Guid instanceId,
+        IReadOnlyList<CoreInteraction> interactions)
+    {
+        var pendingInteractions = interactions;
+
+        while (pendingInteractions.Count > 0)
+        {
+            var interaction = pendingInteractions[0];
+            Console.WriteLine($"Bearbeite {interaction.Type}: {interaction.NodeId} ({interaction.Name})");
+
+            var additionalData = interaction.Type == CoreInteractionType.UserTask
+                ? new Dictionary<string, object?> { ["approval"] = "approved" }
+                : new Dictionary<string, object?>();
+
+            var result = await engine.HandleEvent(new CoreEventData
             {
-                Console.WriteLine($"Interaction beendet für Instanz: {instance.Id}");
-                // Hier könnte externe Verarbeitung stattfinden
-                // z.B. Benachrichtigungen senden, Daten speichern, etc.
-            };
-        }
-        
-        /// <summary>
-        /// Beispiel für Service-Integration
-        /// </summary>
-        public async Task HandleServiceTask(ServiceTask serviceTask, Dictionary<string, object> processData)
-        {
-            switch (serviceTask.NodeId)
-            {
-                case "ServiceTask_1": // Approval Notification
-                    await SendApprovalNotification(processData);
-                    break;
-                    
-                case "ServiceTask_2": // Rejection Notification
-                    await SendRejectionNotification(processData);
-                    break;
-                    
-                default:
-                    Console.WriteLine($"Unbekannte Service Task: {serviceTask.NodeId}");
-                    break;
-            }
-        }
-        
-        private async Task SendApprovalNotification(Dictionary<string, object> processData)
-        {
-            // Simulation einer Email-Benachrichtigung
-            Console.WriteLine("✅ Genehmigungsbenachrichtigung gesendet");
-            await Task.Delay(100); // Simuliert asynchrone Operation
-        }
-        
-        private async Task SendRejectionNotification(Dictionary<string, object> processData)
-        {
-            // Simulation einer Email-Benachrichtigung
-            Console.WriteLine("❌ Ablehnungsbenachrichtigung gesendet");
-            await Task.Delay(100); // Simuliert asynchrone Operation
+                InstanceId = instanceId,
+                BpmnNodeId = interaction.NodeId,
+                AdditionalData = additionalData
+            });
+
+            pendingInteractions = result.Instance.Interactions;
         }
     }
-    
-    /// <summary>
-    /// Hauptprogramm zum Ausführen der Beispiele
-    /// </summary>
-    public class Program
+}
+
+/// <summary>
+/// Einfache Startklasse für das Beispiel.
+/// </summary>
+public static class Program
+{
+    public static async Task Main(string[] args)
     {
-        public static async Task Main(string[] args)
+        Console.WriteLine("Flowzer BPMN Core Engine – ICore-Beispiel");
+        Console.WriteLine("========================================");
+
+        try
         {
-            Console.WriteLine("🚀 Flowzer BPMN Core Engine - Beispiel");
-            Console.WriteLine("=====================================");
-            
-            try
-            {
-                var example = new SimpleEngineExample();
-                
-                // Event-Handler einrichten
-                example.SetupEventHandlers();
-                
-                // Einfachen Approval-Prozess ausführen
-                await example.RunSimpleApprovalProcess();
-                
-                Console.WriteLine("\n✅ Beispiel erfolgreich abgeschlossen!");
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"❌ Fehler beim Ausführen des Beispiels: {ex.Message}");
-                Console.WriteLine($"Details: {ex}");
-            }
-            
-            Console.WriteLine("\nDrücken Sie eine beliebige Taste zum Beenden...");
-            Console.ReadKey();
+            var example = new SimpleEngineExample();
+            await example.RunSimpleApprovalProcess();
+
+            Console.WriteLine();
+            Console.WriteLine("Beispiel erfolgreich abgeschlossen.");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"Fehler beim Ausführen des Beispiels: {ex.Message}");
+            Console.WriteLine(ex);
         }
     }
 }

--- a/examples/SimpleEngineExample.cs
+++ b/examples/SimpleEngineExample.cs
@@ -18,7 +18,7 @@ public class SimpleEngineExample
         SetupEventHandlers(engine);
 
         await using var xmlStream = File.OpenRead("examples/simple-approval-process.bpmn");
-        await engine.LoadBpmnFile(xmlStream, verify: true);
+        await engine.LoadBpmnFile(xmlStream);
 
         var subscriptions = await engine.GetInitialSubscriptions();
         var startSubscription = subscriptions.Single();
@@ -68,6 +68,7 @@ public class SimpleEngineExample
             {
                 InstanceId = instanceId,
                 BpmnNodeId = interaction.NodeId,
+                InteractionId = interaction.InteractionId,
                 AdditionalData = additionalData
             });
 

--- a/examples/simple-approval-process.bpmn
+++ b/examples/simple-approval-process.bpmn
@@ -1,81 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" 
-                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" 
-                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" 
-                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI" 
-                  id="Definitions_1" 
-                  targetNamespace="http://bpmn.io/schema/bpmn" 
-                  exporter="bpmn-js (https://demo.bpmn.io)" 
-                  exporterVersion="12.0.0">
-  
-  <bpmn:process id="SimpleProcess" isExecutable="true">
-    
-    <!-- Start Event -->
-    <bpmn:startEvent id="StartEvent_1" name="Process Started">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_SimpleApproval"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="SimpleApprovalProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
       <bpmn:outgoing>Flow_1</bpmn:outgoing>
     </bpmn:startEvent>
-    
-    <!-- User Task -->
+
     <bpmn:userTask id="UserTask_1" name="Review Document">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="approval-form" />
+      </bpmn:extensionElements>
       <bpmn:incoming>Flow_1</bpmn:incoming>
       <bpmn:outgoing>Flow_2</bpmn:outgoing>
-      <bpmn:ioSpecification>
-        <bpmn:dataInput id="DataInput_1" name="document" />
-        <bpmn:dataOutput id="DataOutput_1" name="approval" />
-        <bpmn:inputSet>
-          <bpmn:dataInputRefs>DataInput_1</bpmn:dataInputRefs>
-        </bpmn:inputSet>
-        <bpmn:outputSet>
-          <bpmn:dataOutputRefs>DataOutput_1</bpmn:dataOutputRefs>
-        </bpmn:outputSet>
-      </bpmn:ioSpecification>
     </bpmn:userTask>
-    
-    <!-- Exclusive Gateway -->
-    <bpmn:exclusiveGateway id="Gateway_1" name="Document Approved?">
+
+    <bpmn:serviceTask id="ServiceTask_1" name="Send Notification">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="send-notification" />
+      </bpmn:extensionElements>
       <bpmn:incoming>Flow_2</bpmn:incoming>
-      <bpmn:outgoing>Flow_3_Approved</bpmn:outgoing>
-      <bpmn:outgoing>Flow_3_Rejected</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    
-    <!-- Service Task - Approved Path -->
-    <bpmn:serviceTask id="ServiceTask_1" name="Send Approval Notification">
-      <bpmn:incoming>Flow_3_Approved</bpmn:incoming>
-      <bpmn:outgoing>Flow_4</bpmn:outgoing>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
     </bpmn:serviceTask>
-    
-    <!-- Service Task - Rejected Path -->
-    <bpmn:serviceTask id="ServiceTask_2" name="Send Rejection Notification">
-      <bpmn:incoming>Flow_3_Rejected</bpmn:incoming>
-      <bpmn:outgoing>Flow_5</bpmn:outgoing>
-    </bpmn:serviceTask>
-    
-    <!-- End Event - Approved -->
-    <bpmn:endEvent id="EndEvent_1" name="Document Approved">
-      <bpmn:incoming>Flow_4</bpmn:incoming>
+
+    <bpmn:endEvent id="EndEvent_1" name="Done">
+      <bpmn:incoming>Flow_3</bpmn:incoming>
     </bpmn:endEvent>
-    
-    <!-- End Event - Rejected -->
-    <bpmn:endEvent id="EndEvent_2" name="Document Rejected">
-      <bpmn:incoming>Flow_5</bpmn:incoming>
-    </bpmn:endEvent>
-    
-    <!-- Sequence Flows -->
+
     <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="UserTask_1" />
-    <bpmn:sequenceFlow id="Flow_2" sourceRef="UserTask_1" targetRef="Gateway_1" />
-    <bpmn:sequenceFlow id="Flow_3_Approved" name="Approved" sourceRef="Gateway_1" targetRef="ServiceTask_1">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        ${approval == 'approved'}
-      </bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_3_Rejected" name="Rejected" sourceRef="Gateway_1" targetRef="ServiceTask_2">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        ${approval == 'rejected'}
-      </bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_4" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
-    <bpmn:sequenceFlow id="Flow_5" sourceRef="ServiceTask_2" targetRef="EndEvent_2" />
-    
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="UserTask_1" targetRef="ServiceTask_1" />
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
   </bpmn:process>
-  
 </bpmn:definitions>

--- a/src/core-engine-tests/CoreEngineTest.cs
+++ b/src/core-engine-tests/CoreEngineTest.cs
@@ -1,0 +1,243 @@
+using System.Text;
+using FluentAssertions;
+using Model;
+
+namespace core_engine_tests;
+
+public class CoreEngineTest
+{
+    [Test]
+    public async System.Threading.Tasks.Task LoadBpmnFile_ShouldExposeInitialStartSubscription()
+    {
+        var coreEngine = new CoreEngine(FlowzerConfig.CreateForTests());
+
+        await using var bpmnStream = CreateSimpleProcessStream();
+        await coreEngine.LoadBpmnFile(bpmnStream, verify: true);
+
+        var subscriptions = await coreEngine.GetInitialSubscriptions();
+
+        subscriptions.Should().ContainSingle();
+        subscriptions[0].Type.Should().Be(CoreSubscriptionType.Start);
+        subscriptions[0].BpmnNodeId.Should().Be("StartEvent_1");
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task LoadBpmnFile_ShouldExposeMessageAndSignalSubscriptions()
+    {
+        var coreEngine = new CoreEngine(FlowzerConfig.CreateForTests());
+
+        await using var bpmnStream = CreateMessageAndSignalProcessStream();
+        await coreEngine.LoadBpmnFile(bpmnStream, verify: true);
+
+        var subscriptions = await coreEngine.GetInitialSubscriptions();
+
+        subscriptions.Should().HaveCount(2);
+        subscriptions.Should().ContainSingle(subscription =>
+            subscription.Type == CoreSubscriptionType.Message &&
+            subscription.BpmnNodeId == "StartEvent_Message" &&
+            subscription.Name == "OrderCreated");
+        subscriptions.Should().ContainSingle(subscription =>
+            subscription.Type == CoreSubscriptionType.Signal &&
+            subscription.BpmnNodeId == "StartEvent_Signal" &&
+            subscription.Name == "InventoryRefresh");
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task HandleEvent_ShouldStartProcessAndExposeUserTask()
+    {
+        var coreEngine = new CoreEngine(FlowzerConfig.CreateForTests());
+
+        await using var bpmnStream = CreateSimpleProcessStream();
+        await coreEngine.LoadBpmnFile(bpmnStream, verify: true);
+
+        var result = await coreEngine.HandleEvent(new CoreEventData
+        {
+            InstanceId = Guid.NewGuid(),
+            BpmnNodeId = "StartEvent_1"
+        });
+
+        result.Instance.State.Should().Be(ProcessInstanceState.Waiting);
+        result.Instance.Interactions.Should().ContainSingle();
+        result.Instance.Interactions[0].Type.Should().Be(CoreInteractionType.UserTask);
+        result.Instance.Interactions[0].NodeId.Should().Be("UserTask_1");
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task HandleEvent_ShouldStartProcessFromMessageSubscription()
+    {
+        var coreEngine = new CoreEngine(FlowzerConfig.CreateForTests());
+
+        await using var bpmnStream = CreateMessageAndSignalProcessStream();
+        await coreEngine.LoadBpmnFile(bpmnStream, verify: true);
+
+        var result = await coreEngine.HandleEvent(new CoreEventData
+        {
+            InstanceId = Guid.NewGuid(),
+            BpmnNodeId = "StartEvent_Message",
+            AdditionalData = new Dictionary<string, object?> { ["orderId"] = "4711" }
+        });
+
+        result.Instance.State.Should().Be(ProcessInstanceState.Waiting);
+        result.Instance.Interactions.Should().ContainSingle();
+        result.Instance.Interactions[0].Type.Should().Be(CoreInteractionType.UserTask);
+        result.Instance.Interactions[0].NodeId.Should().Be("MessageUserTask_1");
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task HandleEvent_ShouldStartProcessFromSignalSubscription()
+    {
+        var coreEngine = new CoreEngine(FlowzerConfig.CreateForTests());
+
+        await using var bpmnStream = CreateMessageAndSignalProcessStream();
+        await coreEngine.LoadBpmnFile(bpmnStream, verify: true);
+
+        var result = await coreEngine.HandleEvent(new CoreEventData
+        {
+            InstanceId = Guid.NewGuid(),
+            BpmnNodeId = "StartEvent_Signal",
+            AdditionalData = new Dictionary<string, object?> { ["warehouse"] = "north" }
+        });
+
+        result.Instance.State.Should().Be(ProcessInstanceState.Waiting);
+        result.Instance.Interactions.Should().ContainSingle();
+        result.Instance.Interactions[0].Type.Should().Be(CoreInteractionType.UserTask);
+        result.Instance.Interactions[0].NodeId.Should().Be("SignalUserTask_1");
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task HandleEvent_ShouldAdvanceUserTaskToServiceTask_AndThenFinishProcess()
+    {
+        var coreEngine = new CoreEngine(FlowzerConfig.CreateForTests());
+        var finishedSnapshots = new List<CoreInstance>();
+        coreEngine.InteractionFinished += (_, snapshot) => finishedSnapshots.Add(snapshot);
+
+        await using var bpmnStream = CreateSimpleProcessStream();
+        await coreEngine.LoadBpmnFile(bpmnStream, verify: true);
+
+        var instanceId = Guid.NewGuid();
+
+        var startResult = await coreEngine.HandleEvent(new CoreEventData
+        {
+            InstanceId = instanceId,
+            BpmnNodeId = "StartEvent_1"
+        });
+
+        var userTaskResult = await coreEngine.HandleEvent(new CoreEventData
+        {
+            InstanceId = instanceId,
+            BpmnNodeId = "UserTask_1",
+            AdditionalData = new Dictionary<string, object?> { ["approval"] = "approved" }
+        });
+
+        var serviceTaskResult = await coreEngine.HandleEvent(new CoreEventData
+        {
+            InstanceId = instanceId,
+            BpmnNodeId = "ServiceTask_1"
+        });
+
+        startResult.Instance.Interactions.Should().ContainSingle();
+        userTaskResult.Instance.Interactions.Should().ContainSingle();
+        userTaskResult.Instance.Interactions[0].Type.Should().Be(CoreInteractionType.ServiceTask);
+        userTaskResult.Instance.Interactions[0].NodeId.Should().Be("ServiceTask_1");
+
+        serviceTaskResult.Instance.State.Should().Be(ProcessInstanceState.Completed);
+        serviceTaskResult.Instance.Interactions.Should().BeEmpty();
+        finishedSnapshots.Should().HaveCount(3);
+        finishedSnapshots[^1].State.Should().Be(ProcessInstanceState.Completed);
+    }
+
+    private static MemoryStream CreateSimpleProcessStream()
+    {
+        const string bpmnXml = """
+                               <?xml version="1.0" encoding="UTF-8"?>
+                               <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                                 xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                                                 xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                                                 xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                                                 xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                                                 id="Definitions_1"
+                                                 targetNamespace="http://bpmn.io/schema/bpmn">
+                                 <bpmn:process id="SimpleProcess" isExecutable="true">
+                                   <bpmn:startEvent id="StartEvent_1" name="Start">
+                                     <bpmn:outgoing>Flow_1</bpmn:outgoing>
+                                   </bpmn:startEvent>
+                                   <bpmn:userTask id="UserTask_1" name="Review">
+                                     <bpmn:extensionElements>
+                                       <zeebe:formDefinition formKey="core-engine-test-form" />
+                                     </bpmn:extensionElements>
+                                     <bpmn:incoming>Flow_1</bpmn:incoming>
+                                     <bpmn:outgoing>Flow_2</bpmn:outgoing>
+                                   </bpmn:userTask>
+                                   <bpmn:serviceTask id="ServiceTask_1" name="Notify">
+                                     <bpmn:extensionElements>
+                                       <zeebe:taskDefinition type="notify-handler" />
+                                     </bpmn:extensionElements>
+                                     <bpmn:incoming>Flow_2</bpmn:incoming>
+                                     <bpmn:outgoing>Flow_3</bpmn:outgoing>
+                                   </bpmn:serviceTask>
+                                   <bpmn:endEvent id="EndEvent_1" name="Done">
+                                     <bpmn:incoming>Flow_3</bpmn:incoming>
+                                   </bpmn:endEvent>
+                                   <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="UserTask_1" />
+                                   <bpmn:sequenceFlow id="Flow_2" sourceRef="UserTask_1" targetRef="ServiceTask_1" />
+                                   <bpmn:sequenceFlow id="Flow_3" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
+                                 </bpmn:process>
+                               </bpmn:definitions>
+                               """;
+
+        return new MemoryStream(Encoding.UTF8.GetBytes(bpmnXml));
+    }
+
+    private static MemoryStream CreateMessageAndSignalProcessStream()
+    {
+        const string bpmnXml = """
+                               <?xml version="1.0" encoding="UTF-8"?>
+                               <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                                 xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                                                 xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                                                 xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                                                 xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                                                 id="Definitions_MessageAndSignal"
+                                                 targetNamespace="http://bpmn.io/schema/bpmn">
+                                 <bpmn:message id="Message_1" name="OrderCreated" />
+                                 <bpmn:signal id="Signal_1" name="InventoryRefresh" />
+                                 <bpmn:process id="EventStartProcess" isExecutable="true">
+                                   <bpmn:startEvent id="StartEvent_Message" name="Message Start">
+                                     <bpmn:outgoing>Flow_Message_1</bpmn:outgoing>
+                                     <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_1" />
+                                   </bpmn:startEvent>
+                                   <bpmn:userTask id="MessageUserTask_1" name="Handle Message">
+                                     <bpmn:extensionElements>
+                                       <zeebe:formDefinition formKey="message-start-form" />
+                                     </bpmn:extensionElements>
+                                     <bpmn:incoming>Flow_Message_1</bpmn:incoming>
+                                     <bpmn:outgoing>Flow_Message_2</bpmn:outgoing>
+                                   </bpmn:userTask>
+                                   <bpmn:endEvent id="EndEvent_Message">
+                                     <bpmn:incoming>Flow_Message_2</bpmn:incoming>
+                                   </bpmn:endEvent>
+                                   <bpmn:startEvent id="StartEvent_Signal" name="Signal Start">
+                                     <bpmn:outgoing>Flow_Signal_1</bpmn:outgoing>
+                                     <bpmn:signalEventDefinition id="SignalEventDefinition_1" signalRef="Signal_1" />
+                                   </bpmn:startEvent>
+                                   <bpmn:userTask id="SignalUserTask_1" name="Handle Signal">
+                                     <bpmn:extensionElements>
+                                       <zeebe:formDefinition formKey="signal-start-form" />
+                                     </bpmn:extensionElements>
+                                     <bpmn:incoming>Flow_Signal_1</bpmn:incoming>
+                                     <bpmn:outgoing>Flow_Signal_2</bpmn:outgoing>
+                                   </bpmn:userTask>
+                                   <bpmn:endEvent id="EndEvent_Signal">
+                                     <bpmn:incoming>Flow_Signal_2</bpmn:incoming>
+                                   </bpmn:endEvent>
+                                   <bpmn:sequenceFlow id="Flow_Message_1" sourceRef="StartEvent_Message" targetRef="MessageUserTask_1" />
+                                   <bpmn:sequenceFlow id="Flow_Message_2" sourceRef="MessageUserTask_1" targetRef="EndEvent_Message" />
+                                   <bpmn:sequenceFlow id="Flow_Signal_1" sourceRef="StartEvent_Signal" targetRef="SignalUserTask_1" />
+                                   <bpmn:sequenceFlow id="Flow_Signal_2" sourceRef="SignalUserTask_1" targetRef="EndEvent_Signal" />
+                                 </bpmn:process>
+                               </bpmn:definitions>
+                               """;
+
+        return new MemoryStream(Encoding.UTF8.GetBytes(bpmnXml));
+    }
+}

--- a/src/core-engine-tests/CoreEngineTest.cs
+++ b/src/core-engine-tests/CoreEngineTest.cs
@@ -12,7 +12,7 @@ public class CoreEngineTest
         var coreEngine = new CoreEngine(FlowzerConfig.CreateForTests());
 
         await using var bpmnStream = CreateSimpleProcessStream();
-        await coreEngine.LoadBpmnFile(bpmnStream, verify: true);
+        await coreEngine.LoadBpmnFile(bpmnStream);
 
         var subscriptions = await coreEngine.GetInitialSubscriptions();
 
@@ -27,7 +27,7 @@ public class CoreEngineTest
         var coreEngine = new CoreEngine(FlowzerConfig.CreateForTests());
 
         await using var bpmnStream = CreateMessageAndSignalProcessStream();
-        await coreEngine.LoadBpmnFile(bpmnStream, verify: true);
+        await coreEngine.LoadBpmnFile(bpmnStream);
 
         var subscriptions = await coreEngine.GetInitialSubscriptions();
 
@@ -43,12 +43,25 @@ public class CoreEngineTest
     }
 
     [Test]
+    public async System.Threading.Tasks.Task LoadBpmnFile_ShouldHideUnsupportedPlainStartSubscriptions_WhenMultiplePlainStartsExist()
+    {
+        var coreEngine = new CoreEngine(FlowzerConfig.CreateForTests());
+
+        await using var bpmnStream = CreateMultiPlainStartProcessStream();
+        await coreEngine.LoadBpmnFile(bpmnStream);
+
+        var subscriptions = await coreEngine.GetInitialSubscriptions();
+
+        subscriptions.Should().BeEmpty();
+    }
+
+    [Test]
     public async System.Threading.Tasks.Task HandleEvent_ShouldStartProcessAndExposeUserTask()
     {
         var coreEngine = new CoreEngine(FlowzerConfig.CreateForTests());
 
         await using var bpmnStream = CreateSimpleProcessStream();
-        await coreEngine.LoadBpmnFile(bpmnStream, verify: true);
+        await coreEngine.LoadBpmnFile(bpmnStream);
 
         var result = await coreEngine.HandleEvent(new CoreEventData
         {
@@ -58,6 +71,7 @@ public class CoreEngineTest
 
         result.Instance.State.Should().Be(ProcessInstanceState.Waiting);
         result.Instance.Interactions.Should().ContainSingle();
+        result.Instance.Interactions[0].InteractionId.Should().NotBeEmpty();
         result.Instance.Interactions[0].Type.Should().Be(CoreInteractionType.UserTask);
         result.Instance.Interactions[0].NodeId.Should().Be("UserTask_1");
     }
@@ -68,7 +82,7 @@ public class CoreEngineTest
         var coreEngine = new CoreEngine(FlowzerConfig.CreateForTests());
 
         await using var bpmnStream = CreateMessageAndSignalProcessStream();
-        await coreEngine.LoadBpmnFile(bpmnStream, verify: true);
+        await coreEngine.LoadBpmnFile(bpmnStream);
 
         var result = await coreEngine.HandleEvent(new CoreEventData
         {
@@ -79,6 +93,7 @@ public class CoreEngineTest
 
         result.Instance.State.Should().Be(ProcessInstanceState.Waiting);
         result.Instance.Interactions.Should().ContainSingle();
+        result.Instance.Interactions[0].InteractionId.Should().NotBeEmpty();
         result.Instance.Interactions[0].Type.Should().Be(CoreInteractionType.UserTask);
         result.Instance.Interactions[0].NodeId.Should().Be("MessageUserTask_1");
     }
@@ -89,7 +104,7 @@ public class CoreEngineTest
         var coreEngine = new CoreEngine(FlowzerConfig.CreateForTests());
 
         await using var bpmnStream = CreateMessageAndSignalProcessStream();
-        await coreEngine.LoadBpmnFile(bpmnStream, verify: true);
+        await coreEngine.LoadBpmnFile(bpmnStream);
 
         var result = await coreEngine.HandleEvent(new CoreEventData
         {
@@ -100,6 +115,7 @@ public class CoreEngineTest
 
         result.Instance.State.Should().Be(ProcessInstanceState.Waiting);
         result.Instance.Interactions.Should().ContainSingle();
+        result.Instance.Interactions[0].InteractionId.Should().NotBeEmpty();
         result.Instance.Interactions[0].Type.Should().Be(CoreInteractionType.UserTask);
         result.Instance.Interactions[0].NodeId.Should().Be("SignalUserTask_1");
     }
@@ -112,7 +128,7 @@ public class CoreEngineTest
         coreEngine.InteractionFinished += (_, snapshot) => finishedSnapshots.Add(snapshot);
 
         await using var bpmnStream = CreateSimpleProcessStream();
-        await coreEngine.LoadBpmnFile(bpmnStream, verify: true);
+        await coreEngine.LoadBpmnFile(bpmnStream);
 
         var instanceId = Guid.NewGuid();
 
@@ -126,13 +142,15 @@ public class CoreEngineTest
         {
             InstanceId = instanceId,
             BpmnNodeId = "UserTask_1",
+            InteractionId = startResult.Instance.Interactions[0].InteractionId,
             AdditionalData = new Dictionary<string, object?> { ["approval"] = "approved" }
         });
 
         var serviceTaskResult = await coreEngine.HandleEvent(new CoreEventData
         {
             InstanceId = instanceId,
-            BpmnNodeId = "ServiceTask_1"
+            BpmnNodeId = "ServiceTask_1",
+            InteractionId = userTaskResult.Instance.Interactions[0].InteractionId
         });
 
         startResult.Instance.Interactions.Should().ContainSingle();
@@ -144,6 +162,109 @@ public class CoreEngineTest
         serviceTaskResult.Instance.Interactions.Should().BeEmpty();
         finishedSnapshots.Should().HaveCount(3);
         finishedSnapshots[^1].State.Should().Be(ProcessInstanceState.Completed);
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task HandleEvent_ShouldAllowRestartAfterCompletedInstanceWasCleanedUp()
+    {
+        var coreEngine = new CoreEngine(FlowzerConfig.CreateForTests());
+
+        await using var bpmnStream = CreateSimpleProcessStream();
+        await coreEngine.LoadBpmnFile(bpmnStream);
+
+        var instanceId = Guid.NewGuid();
+
+        var startResult = await coreEngine.HandleEvent(new CoreEventData
+        {
+            InstanceId = instanceId,
+            BpmnNodeId = "StartEvent_1"
+        });
+
+        var userTaskResult = await coreEngine.HandleEvent(new CoreEventData
+        {
+            InstanceId = instanceId,
+            BpmnNodeId = "UserTask_1",
+            InteractionId = startResult.Instance.Interactions[0].InteractionId,
+            AdditionalData = new Dictionary<string, object?> { ["approval"] = "approved" }
+        });
+
+        var completedResult = await coreEngine.HandleEvent(new CoreEventData
+        {
+            InstanceId = instanceId,
+            BpmnNodeId = "ServiceTask_1",
+            InteractionId = userTaskResult.Instance.Interactions[0].InteractionId
+        });
+
+        completedResult.Instance.State.Should().Be(ProcessInstanceState.Completed);
+
+        var restartedResult = await coreEngine.HandleEvent(new CoreEventData
+        {
+            InstanceId = instanceId,
+            BpmnNodeId = "StartEvent_1"
+        });
+
+        restartedResult.Instance.State.Should().Be(ProcessInstanceState.Waiting);
+        restartedResult.Instance.Interactions.Should().ContainSingle();
+        restartedResult.Instance.Interactions[0].NodeId.Should().Be("UserTask_1");
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task HandleEvent_ShouldRequireInteractionId_WhenMultipleActiveInteractionsShareTheSameNode()
+    {
+        var coreEngine = new CoreEngine(FlowzerConfig.CreateForTests());
+
+        await using var bpmnStream = File.OpenRead("embeddings/ParallelFlowWithCompletingConditionTest.bpmn");
+        await coreEngine.LoadBpmnFile(bpmnStream);
+
+        var instanceId = Guid.NewGuid();
+        var startResult = await coreEngine.HandleEvent(new CoreEventData
+        {
+            InstanceId = instanceId,
+            BpmnNodeId = "StartEvent_1"
+        });
+
+        startResult.Instance.Interactions.Should().HaveCountGreaterThan(1);
+        startResult.Instance.Interactions.Select(interaction => interaction.NodeId).Should().OnlyContain(nodeId => nodeId == "TestTask");
+
+        var ambiguousAction = async () => await coreEngine.HandleEvent(new CoreEventData
+        {
+            InstanceId = instanceId,
+            BpmnNodeId = "TestTask",
+            AdditionalData = new Dictionary<string, object?> { ["HatZeit"] = true }
+        });
+
+        await ambiguousAction.Should()
+            .ThrowAsync<NotSupportedException>()
+            .WithMessage("*InteractionId*");
+
+        var continueResult = await coreEngine.HandleEvent(new CoreEventData
+        {
+            InstanceId = instanceId,
+            BpmnNodeId = startResult.Instance.Interactions[0].NodeId,
+            InteractionId = startResult.Instance.Interactions[0].InteractionId,
+            AdditionalData = new Dictionary<string, object?> { ["HatZeit"] = true }
+        });
+
+        continueResult.Instance.State.Should().Be(ProcessInstanceState.Completed);
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task LoadBpmnFile_ShouldClearState_WhenReloadFails()
+    {
+        var coreEngine = new CoreEngine(FlowzerConfig.CreateForTests());
+
+        await using var validStream = CreateSimpleProcessStream();
+        await coreEngine.LoadBpmnFile(validStream);
+
+        (await coreEngine.GetInitialSubscriptions()).Should().ContainSingle();
+
+        await using var invalidStream = CreateInvalidProcessStream();
+        var loadAction = async () => await coreEngine.LoadBpmnFile(invalidStream);
+
+        await loadAction.Should().ThrowAsync<Exception>();
+
+        var subscriptionsAction = async () => await coreEngine.GetInitialSubscriptions();
+        await subscriptionsAction.Should().ThrowAsync<InvalidOperationException>();
     }
 
     private static MemoryStream CreateSimpleProcessStream()
@@ -181,6 +302,45 @@ public class CoreEngineTest
                                    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="UserTask_1" />
                                    <bpmn:sequenceFlow id="Flow_2" sourceRef="UserTask_1" targetRef="ServiceTask_1" />
                                    <bpmn:sequenceFlow id="Flow_3" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
+                                 </bpmn:process>
+                               </bpmn:definitions>
+                               """;
+
+        return new MemoryStream(Encoding.UTF8.GetBytes(bpmnXml));
+    }
+
+    private static MemoryStream CreateMultiPlainStartProcessStream()
+    {
+        const string bpmnXml = """
+                               <?xml version="1.0" encoding="UTF-8"?>
+                               <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                                 xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                                                 xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                                                 xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                                                 xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                                                 id="Definitions_MultiPlainStart"
+                                                 targetNamespace="http://bpmn.io/schema/bpmn">
+                                 <bpmn:process id="MultiPlainStartProcess" isExecutable="true">
+                                   <bpmn:startEvent id="StartEvent_A" name="Start A">
+                                     <bpmn:outgoing>Flow_A</bpmn:outgoing>
+                                   </bpmn:startEvent>
+                                   <bpmn:startEvent id="StartEvent_B" name="Start B">
+                                     <bpmn:outgoing>Flow_B</bpmn:outgoing>
+                                   </bpmn:startEvent>
+                                   <bpmn:userTask id="UserTask_A" name="Task A">
+                                     <bpmn:extensionElements>
+                                       <zeebe:formDefinition formKey="form-a" />
+                                     </bpmn:extensionElements>
+                                     <bpmn:incoming>Flow_A</bpmn:incoming>
+                                   </bpmn:userTask>
+                                   <bpmn:userTask id="UserTask_B" name="Task B">
+                                     <bpmn:extensionElements>
+                                       <zeebe:formDefinition formKey="form-b" />
+                                     </bpmn:extensionElements>
+                                     <bpmn:incoming>Flow_B</bpmn:incoming>
+                                   </bpmn:userTask>
+                                   <bpmn:sequenceFlow id="Flow_A" sourceRef="StartEvent_A" targetRef="UserTask_A" />
+                                   <bpmn:sequenceFlow id="Flow_B" sourceRef="StartEvent_B" targetRef="UserTask_B" />
                                  </bpmn:process>
                                </bpmn:definitions>
                                """;
@@ -234,6 +394,31 @@ public class CoreEngineTest
                                    <bpmn:sequenceFlow id="Flow_Message_2" sourceRef="MessageUserTask_1" targetRef="EndEvent_Message" />
                                    <bpmn:sequenceFlow id="Flow_Signal_1" sourceRef="StartEvent_Signal" targetRef="SignalUserTask_1" />
                                    <bpmn:sequenceFlow id="Flow_Signal_2" sourceRef="SignalUserTask_1" targetRef="EndEvent_Signal" />
+                                 </bpmn:process>
+                               </bpmn:definitions>
+                               """;
+
+        return new MemoryStream(Encoding.UTF8.GetBytes(bpmnXml));
+    }
+
+    private static MemoryStream CreateInvalidProcessStream()
+    {
+        const string bpmnXml = """
+                               <?xml version="1.0" encoding="UTF-8"?>
+                               <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                                 xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                                                 xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                                                 xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                                                 id="Definitions_Invalid"
+                                                 targetNamespace="http://bpmn.io/schema/bpmn">
+                                 <bpmn:process id="InvalidProcess" isExecutable="true">
+                                   <bpmn:startEvent id="StartEvent_Invalid">
+                                     <bpmn:outgoing>Flow_Invalid_1</bpmn:outgoing>
+                                   </bpmn:startEvent>
+                                   <bpmn:userTask id="UserTask_Invalid" name="Broken User Task">
+                                     <bpmn:incoming>Flow_Invalid_1</bpmn:incoming>
+                                   </bpmn:userTask>
+                                   <bpmn:sequenceFlow id="Flow_Invalid_1" sourceRef="StartEvent_Invalid" targetRef="UserTask_Invalid" />
                                  </bpmn:process>
                                </bpmn:definitions>
                                """;

--- a/src/core-engine/CoreEngine.cs
+++ b/src/core-engine/CoreEngine.cs
@@ -16,7 +16,7 @@ public class CoreEngine(FlowzerConfig? flowzerConfig = null) : ICore
 
     public event EventHandler<CoreInstance>? InteractionFinished;
 
-    public async System.Threading.Tasks.Task LoadBpmnFile(Stream xmlDataStream, bool verify, CancellationToken cancellationToken = default)
+    public async System.Threading.Tasks.Task LoadBpmnFile(Stream xmlDataStream, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(xmlDataStream);
         cancellationToken.ThrowIfCancellationRequested();
@@ -24,8 +24,8 @@ public class CoreEngine(FlowzerConfig? flowzerConfig = null) : ICore
         using var reader = new StreamReader(xmlDataStream, Encoding.UTF8, leaveOpen: true);
         var xml = await reader.ReadToEndAsync(cancellationToken);
 
-        // Der Parser validiert aktuell bereits beim Einlesen.
-        _ = verify;
+        _process = null;
+        _instances.Clear();
 
         var definitions = ModelParser.ParseModel(xml);
         var processes = definitions.GetProcesses().ToArray();
@@ -43,8 +43,21 @@ public class CoreEngine(FlowzerConfig? flowzerConfig = null) : ICore
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var subscriptions = GetLoadedProcess()
+        var startFlowNodes = GetLoadedProcess()
             .GetStartFlowNodes()
+            .ToArray();
+        var plainStartNodes = startFlowNodes
+            .Where(node => node is StartEvent && node is not FlowzerMessageStartEvent && node is not FlowzerSignalStartEvent)
+            .ToArray();
+
+        var subscriptions = startFlowNodes
+            .Where(node =>
+                node is FlowzerMessageStartEvent ||
+                node is FlowzerSignalStartEvent ||
+                plainStartNodes.Length == 1 &&
+                node is StartEvent &&
+                node is not FlowzerMessageStartEvent &&
+                node is not FlowzerSignalStartEvent)
             .Select(MapInitialSubscription)
             .ToArray();
 
@@ -70,6 +83,10 @@ public class CoreEngine(FlowzerConfig? flowzerConfig = null) : ICore
 
         var snapshot = CreateInstanceSnapshot(eventData.InstanceId, instanceEngine);
         InteractionFinished?.Invoke(this, snapshot);
+        if (instanceEngine.IsFinished)
+        {
+            _instances.Remove(eventData.InstanceId);
+        }
 
         return System.Threading.Tasks.Task.FromResult(new CoreEventResult
         {
@@ -155,10 +172,7 @@ public class CoreEngine(FlowzerConfig? flowzerConfig = null) : ICore
 
     private static void CompleteInteraction(InstanceEngine instanceEngine, CoreEventData eventData)
     {
-        var token = instanceEngine
-            .GetActiveTasks()
-            .SingleOrDefault(activeToken =>
-                string.Equals(activeToken.CurrentFlowNode?.Id, eventData.BpmnNodeId, StringComparison.Ordinal));
+        var token = ResolveActiveInteraction(instanceEngine, eventData);
 
         if (token == null)
         {
@@ -167,6 +181,44 @@ public class CoreEngine(FlowzerConfig? flowzerConfig = null) : ICore
         }
 
         instanceEngine.HandleTaskResult(token.Id, ToVariables(eventData.AdditionalData));
+    }
+
+    private static Token? ResolveActiveInteraction(InstanceEngine instanceEngine, CoreEventData eventData)
+    {
+        if (eventData.InteractionId is Guid interactionId)
+        {
+            var tokenById = instanceEngine
+                .GetActiveTasks()
+                .SingleOrDefault(activeToken => activeToken.Id == interactionId);
+
+            if (tokenById == null)
+            {
+                throw new InvalidOperationException(
+                    $"Für die Instanz {eventData.InstanceId} wurde keine aktive Interaktion mit der ID \"{interactionId}\" gefunden.");
+            }
+
+            if (!string.Equals(tokenById.CurrentFlowNode?.Id, eventData.BpmnNodeId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Die Interaktion \"{interactionId}\" gehört nicht zum BPMN-Knoten \"{eventData.BpmnNodeId}\".");
+            }
+
+            return tokenById;
+        }
+
+        var tokensByNode = instanceEngine
+            .GetActiveTasks()
+            .Where(activeToken =>
+                string.Equals(activeToken.CurrentFlowNode?.Id, eventData.BpmnNodeId, StringComparison.Ordinal))
+            .ToArray();
+
+        return tokensByNode.Length switch
+        {
+            0 => null,
+            1 => tokensByNode[0],
+            _ => throw new NotSupportedException(
+                $"Für den BPMN-Knoten \"{eventData.BpmnNodeId}\" existieren mehrere aktive Interaktionen. Bitte die eindeutige InteractionId verwenden.")
+        };
     }
 
     private static Variables? ToVariables(IReadOnlyDictionary<string, object?> additionalData)
@@ -223,6 +275,7 @@ public class CoreEngine(FlowzerConfig? flowzerConfig = null) : ICore
 
         interactions.AddRange(instanceEngine.GetActiveUserTasks().Select(token => new CoreInteraction
         {
+            InteractionId = token.Id,
             Type = CoreInteractionType.UserTask,
             NodeId = token.CurrentFlowNode!.Id,
             Name = token.CurrentFlowNode.Name ?? token.CurrentFlowNode.Id,
@@ -231,6 +284,7 @@ public class CoreEngine(FlowzerConfig? flowzerConfig = null) : ICore
 
         interactions.AddRange(instanceEngine.GetActiveServiceTasks().Select(token => new CoreInteraction
         {
+            InteractionId = token.Id,
             Type = CoreInteractionType.ServiceTask,
             NodeId = token.CurrentFlowNode!.Id,
             Name = token.CurrentFlowNode.Name ?? token.CurrentFlowNode.Id,

--- a/src/core-engine/CoreEngine.cs
+++ b/src/core-engine/CoreEngine.cs
@@ -1,0 +1,272 @@
+using System.Text;
+using core_engine.Extensions;
+using Newtonsoft.Json;
+
+namespace core_engine;
+
+/// <summary>
+/// Ein schlanker, in-memory Kernvertrag oberhalb von <see cref="ProcessEngine"/> und <see cref="InstanceEngine"/>.
+/// Fokus der ersten Version sind ein geladener Prozess sowie Plain-Start-Events und aktive User-/Service-Tasks.
+/// </summary>
+public class CoreEngine(FlowzerConfig? flowzerConfig = null) : ICore
+{
+    private readonly Dictionary<Guid, InstanceEngine> _instances = new();
+    private readonly FlowzerConfig _flowzerConfig = flowzerConfig ?? FlowzerConfig.Default;
+    private Process? _process;
+
+    public event EventHandler<CoreInstance>? InteractionFinished;
+
+    public async System.Threading.Tasks.Task LoadBpmnFile(Stream xmlDataStream, bool verify, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(xmlDataStream);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using var reader = new StreamReader(xmlDataStream, Encoding.UTF8, leaveOpen: true);
+        var xml = await reader.ReadToEndAsync(cancellationToken);
+
+        // Der Parser validiert aktuell bereits beim Einlesen.
+        _ = verify;
+
+        var definitions = ModelParser.ParseModel(xml);
+        var processes = definitions.GetProcesses().ToArray();
+
+        if (processes.Length != 1)
+        {
+            throw new NotSupportedException("CoreEngine unterstützt aktuell genau einen Prozess pro geladener Definition.");
+        }
+
+        _process = processes[0];
+        _instances.Clear();
+    }
+
+    public System.Threading.Tasks.Task<CoreSubscription[]> GetInitialSubscriptions(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var subscriptions = GetLoadedProcess()
+            .GetStartFlowNodes()
+            .Select(MapInitialSubscription)
+            .ToArray();
+
+        return System.Threading.Tasks.Task.FromResult(subscriptions);
+    }
+
+    public System.Threading.Tasks.Task<CoreEventResult> HandleEvent(CoreEventData eventData, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(eventData);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        InstanceEngine instanceEngine;
+        if (_instances.TryGetValue(eventData.InstanceId, out var existingInstance))
+        {
+            instanceEngine = existingInstance;
+            CompleteInteraction(instanceEngine, eventData);
+        }
+        else
+        {
+            instanceEngine = StartNewInstance(eventData);
+            _instances[eventData.InstanceId] = instanceEngine;
+        }
+
+        var snapshot = CreateInstanceSnapshot(eventData.InstanceId, instanceEngine);
+        InteractionFinished?.Invoke(this, snapshot);
+
+        return System.Threading.Tasks.Task.FromResult(new CoreEventResult
+        {
+            Instance = snapshot
+        });
+    }
+
+    private InstanceEngine StartNewInstance(CoreEventData eventData)
+    {
+        var process = GetLoadedProcess();
+        var selectedStartNode = process
+            .GetStartFlowNodes()
+            .SingleOrDefault(node => string.Equals(node.Id, eventData.BpmnNodeId, StringComparison.Ordinal));
+
+        if (selectedStartNode == null)
+        {
+            throw new InvalidOperationException(
+                $"Das Start-Event \"{eventData.BpmnNodeId}\" wurde in der geladenen Definition nicht gefunden.");
+        }
+
+        return selectedStartNode switch
+        {
+            FlowzerMessageStartEvent messageStartEvent => StartNewMessageInstance(process, messageStartEvent, eventData),
+            FlowzerSignalStartEvent signalStartEvent => StartNewSignalInstance(process, signalStartEvent, eventData),
+            StartEvent => StartNewPlainInstance(process, eventData),
+            _ => throw new NotSupportedException(
+                $"Der Einstieg über den Knotentyp \"{selectedStartNode.GetType().Name}\" wird vom CoreEngine-Vertrag aktuell nicht unterstützt.")
+        };
+    }
+
+    private InstanceEngine StartNewPlainInstance(Process process, CoreEventData eventData)
+    {
+        var plainStartNodes = process
+            .GetStartFlowNodes()
+            .Where(node => node is StartEvent && node is not FlowzerMessageStartEvent && node is not FlowzerSignalStartEvent)
+            .ToArray();
+
+        if (plainStartNodes.Length != 1 ||
+            !string.Equals(plainStartNodes[0].Id, eventData.BpmnNodeId, StringComparison.Ordinal))
+        {
+            throw new NotSupportedException(
+                "CoreEngine unterstützt aktuell nur Definitionen mit genau einem expliziten Plain-Start-Event.");
+        }
+
+        var processEngine = new ProcessEngine(process, _flowzerConfig);
+        var instanceEngine = processEngine.StartProcess(ToVariables(eventData.AdditionalData));
+        instanceEngine.InstanceId = eventData.InstanceId;
+
+        return instanceEngine;
+    }
+
+    private InstanceEngine StartNewMessageInstance(
+        Process process,
+        FlowzerMessageStartEvent messageStartEvent,
+        CoreEventData eventData)
+    {
+        var processEngine = new ProcessEngine(process, _flowzerConfig);
+        var instanceEngine = processEngine.HandleMessage(new Message
+        {
+            Name = messageStartEvent.MessageDefinition.Name,
+            Variables = SerializeAdditionalData(eventData.AdditionalData),
+            InstanceId = eventData.InstanceId
+        });
+        instanceEngine.InstanceId = eventData.InstanceId;
+
+        return instanceEngine;
+    }
+
+    private InstanceEngine StartNewSignalInstance(
+        Process process,
+        FlowzerSignalStartEvent signalStartEvent,
+        CoreEventData eventData)
+    {
+        var instanceEngine = CreateInstanceEngine(process);
+        instanceEngine.HandleSignal(
+            signalStartEvent.Signal.Name,
+            SerializeAdditionalData(eventData.AdditionalData),
+            signalStartEvent);
+        instanceEngine.InstanceId = eventData.InstanceId;
+
+        return instanceEngine;
+    }
+
+    private static void CompleteInteraction(InstanceEngine instanceEngine, CoreEventData eventData)
+    {
+        var token = instanceEngine
+            .GetActiveTasks()
+            .SingleOrDefault(activeToken =>
+                string.Equals(activeToken.CurrentFlowNode?.Id, eventData.BpmnNodeId, StringComparison.Ordinal));
+
+        if (token == null)
+        {
+            throw new InvalidOperationException(
+                $"Für die Instanz {eventData.InstanceId} wartet keine aktive Interaktion auf dem Knoten \"{eventData.BpmnNodeId}\".");
+        }
+
+        instanceEngine.HandleTaskResult(token.Id, ToVariables(eventData.AdditionalData));
+    }
+
+    private static Variables? ToVariables(IReadOnlyDictionary<string, object?> additionalData)
+    {
+        if (additionalData.Count == 0)
+        {
+            return null;
+        }
+
+        var variables = new Variables();
+        foreach (var entry in additionalData)
+        {
+            variables.SetValue(entry.Key, entry.Value);
+        }
+
+        return variables;
+    }
+
+    private static string SerializeAdditionalData(IReadOnlyDictionary<string, object?> additionalData)
+    {
+        return additionalData.Count == 0
+            ? "{}"
+            : JsonConvert.SerializeObject(additionalData);
+    }
+
+    private InstanceEngine CreateInstanceEngine(Process process)
+    {
+        var masterToken = new Token
+        {
+            CurrentBaseElement = process,
+            State = FlowNodeState.Active,
+            Variables = new Variables(),
+            ParentTokenId = null,
+            ActiveBoundaryEvents = [],
+            ProcessInstanceId = Guid.NewGuid()
+        };
+
+        return new InstanceEngine([masterToken], _flowzerConfig);
+    }
+
+    private CoreInstance CreateInstanceSnapshot(Guid instanceId, InstanceEngine instanceEngine)
+    {
+        return new CoreInstance
+        {
+            Id = instanceId,
+            State = instanceEngine.State,
+            Interactions = CollectInteractions(instanceEngine)
+        };
+    }
+
+    private static IReadOnlyList<CoreInteraction> CollectInteractions(InstanceEngine instanceEngine)
+    {
+        var interactions = new List<CoreInteraction>();
+
+        interactions.AddRange(instanceEngine.GetActiveUserTasks().Select(token => new CoreInteraction
+        {
+            Type = CoreInteractionType.UserTask,
+            NodeId = token.CurrentFlowNode!.Id,
+            Name = token.CurrentFlowNode.Name ?? token.CurrentFlowNode.Id,
+            Implementation = ((UserTask)token.CurrentFlowNode).Implementation
+        }));
+
+        interactions.AddRange(instanceEngine.GetActiveServiceTasks().Select(token => new CoreInteraction
+        {
+            Type = CoreInteractionType.ServiceTask,
+            NodeId = token.CurrentFlowNode!.Id,
+            Name = token.CurrentFlowNode.Name ?? token.CurrentFlowNode.Id,
+            Implementation = ((ServiceTask)token.CurrentFlowNode).Implementation
+        }));
+
+        return interactions;
+    }
+
+    private static CoreSubscription MapInitialSubscription(FlowNode flowNode)
+    {
+        return flowNode switch
+        {
+            FlowzerMessageStartEvent messageStartEvent => new CoreSubscription
+            {
+                Type = CoreSubscriptionType.Message,
+                BpmnNodeId = messageStartEvent.Id,
+                Name = messageStartEvent.MessageDefinition.Name
+            },
+            FlowzerSignalStartEvent signalStartEvent => new CoreSubscription
+            {
+                Type = CoreSubscriptionType.Signal,
+                BpmnNodeId = signalStartEvent.Id,
+                Name = signalStartEvent.Signal.Name
+            },
+            _ => new CoreSubscription
+            {
+                Type = CoreSubscriptionType.Start,
+                BpmnNodeId = flowNode.Id,
+                Name = flowNode.Name ?? flowNode.Id
+            }
+        };
+    }
+
+    private Process GetLoadedProcess()
+    {
+        return _process ?? throw new InvalidOperationException("Es wurde noch keine BPMN-Definition geladen.");
+    }
+}

--- a/src/core-engine/PublicApi/CoreEventData.cs
+++ b/src/core-engine/PublicApi/CoreEventData.cs
@@ -1,0 +1,13 @@
+namespace core_engine;
+
+/// <summary>
+/// Beschreibt ein eingehendes Ereignis für den Kernvertrag.
+/// </summary>
+public class CoreEventData
+{
+    public required Guid InstanceId { get; init; }
+
+    public required string BpmnNodeId { get; init; }
+
+    public IReadOnlyDictionary<string, object?> AdditionalData { get; init; } = new Dictionary<string, object?>();
+}

--- a/src/core-engine/PublicApi/CoreEventData.cs
+++ b/src/core-engine/PublicApi/CoreEventData.cs
@@ -9,5 +9,7 @@ public class CoreEventData
 
     public required string BpmnNodeId { get; init; }
 
+    public Guid? InteractionId { get; init; }
+
     public IReadOnlyDictionary<string, object?> AdditionalData { get; init; } = new Dictionary<string, object?>();
 }

--- a/src/core-engine/PublicApi/CoreEventResult.cs
+++ b/src/core-engine/PublicApi/CoreEventResult.cs
@@ -1,0 +1,9 @@
+namespace core_engine;
+
+/// <summary>
+/// Ergebnis einer verarbeiteten Kerninteraktion.
+/// </summary>
+public class CoreEventResult
+{
+    public required CoreInstance Instance { get; init; }
+}

--- a/src/core-engine/PublicApi/CoreInstance.cs
+++ b/src/core-engine/PublicApi/CoreInstance.cs
@@ -1,0 +1,13 @@
+namespace core_engine;
+
+/// <summary>
+/// Öffentliche Sicht auf eine laufende oder abgeschlossene Instanz.
+/// </summary>
+public class CoreInstance
+{
+    public required Guid Id { get; init; }
+
+    public required ProcessInstanceState State { get; init; }
+
+    public required IReadOnlyList<CoreInteraction> Interactions { get; init; }
+}

--- a/src/core-engine/PublicApi/CoreInteraction.cs
+++ b/src/core-engine/PublicApi/CoreInteraction.cs
@@ -5,6 +5,8 @@ namespace core_engine;
 /// </summary>
 public class CoreInteraction
 {
+    public required Guid InteractionId { get; init; }
+
     public required CoreInteractionType Type { get; init; }
 
     public required string NodeId { get; init; }

--- a/src/core-engine/PublicApi/CoreInteraction.cs
+++ b/src/core-engine/PublicApi/CoreInteraction.cs
@@ -1,0 +1,21 @@
+namespace core_engine;
+
+/// <summary>
+/// Beschreibt eine aktuell wartende Interaktion der Engine.
+/// </summary>
+public class CoreInteraction
+{
+    public required CoreInteractionType Type { get; init; }
+
+    public required string NodeId { get; init; }
+
+    public required string Name { get; init; }
+
+    public string? Implementation { get; init; }
+}
+
+public enum CoreInteractionType
+{
+    UserTask,
+    ServiceTask
+}

--- a/src/core-engine/PublicApi/CoreSubscription.cs
+++ b/src/core-engine/PublicApi/CoreSubscription.cs
@@ -1,0 +1,20 @@
+namespace core_engine;
+
+/// <summary>
+/// Beschreibt einen initialen Einstiegspunkt in eine geladene Definition.
+/// </summary>
+public class CoreSubscription
+{
+    public required CoreSubscriptionType Type { get; init; }
+
+    public required string BpmnNodeId { get; init; }
+
+    public required string Name { get; init; }
+}
+
+public enum CoreSubscriptionType
+{
+    Start,
+    Message,
+    Signal
+}

--- a/src/core-engine/PublicApi/ICore.cs
+++ b/src/core-engine/PublicApi/ICore.cs
@@ -8,7 +8,7 @@ public interface ICore
 {
     event EventHandler<CoreInstance>? InteractionFinished;
 
-    System.Threading.Tasks.Task LoadBpmnFile(Stream xmlDataStream, bool verify, CancellationToken cancellationToken = default);
+    System.Threading.Tasks.Task LoadBpmnFile(Stream xmlDataStream, CancellationToken cancellationToken = default);
 
     System.Threading.Tasks.Task<CoreSubscription[]> GetInitialSubscriptions(CancellationToken cancellationToken = default);
 

--- a/src/core-engine/PublicApi/ICore.cs
+++ b/src/core-engine/PublicApi/ICore.cs
@@ -1,0 +1,16 @@
+namespace core_engine;
+
+/// <summary>
+/// Minimale öffentliche Kernschnittstelle für das Laden einer BPMN-Definition
+/// und das Anstoßen/Weiterführen von Interaktionen ohne Web- oder Storage-Abhängigkeiten.
+/// </summary>
+public interface ICore
+{
+    event EventHandler<CoreInstance>? InteractionFinished;
+
+    System.Threading.Tasks.Task LoadBpmnFile(Stream xmlDataStream, bool verify, CancellationToken cancellationToken = default);
+
+    System.Threading.Tasks.Task<CoreSubscription[]> GetInitialSubscriptions(CancellationToken cancellationToken = default);
+
+    System.Threading.Tasks.Task<CoreEventResult> HandleEvent(CoreEventData eventData, CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
## Ziel

Schließt die offene Architekturarbeit aus #5 und führt einen bewusst kleinen öffentlichen Kernvertrag für die Engine ein.

## Was enthalten ist

- neues `ICore`-Interface als minimaler Integrationsvertrag
- neue öffentliche Kernmodelle für Events, Instanzen, Interaktionen und Start-Subscriptions
- `CoreEngine` als in-memory Adapter oberhalb von `ProcessEngine` und `InstanceEngine`
- unterstützte Einstiege für:
  - Plain Start Events
  - Message Start Events
  - Signal Start Events
- Regressionstests für den bevorzugten Integrationspfad
- dokumentierter Nutzungsweg in README, `docs/ICORE.md` und dem Beispiel unter `examples/`

## Tests

- `dotnet build core-engine.sln --no-restore --configuration Release`
- `dotnet test src/core-engine-tests/core-engine-tests.csproj --no-restore --no-build --configuration Release --logger 'console;verbosity=minimal'`
- `dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --no-restore --no-build --configuration Release --logger 'console;verbosity=minimal'`

## Hinweise

- der Vertrag bleibt absichtlich klein und leakt keine WebAPI-, Storage- oder UI-spezifischen Details
- Plain-Start-Pfade bleiben aktuell bewusst auf Definitionen mit genau einem expliziten Plain-Start-Event begrenzt

Closes #5
