### PR TITLE
Instanz-Subscriptions für Signale und Service-Tasks vollständig bereitstellen

### DIFF
--- a/src/FilesystemStorageSystem/MessageSubscriptionStorage.cs
+++ b/src/FilesystemStorageSystem/MessageSubscriptionStorage.cs
@@ -103,6 +103,18 @@ public class MessageSubscriptionStorage : IMessageSubscriptionStorage
         File.WriteAllText(fullFileName, data);
     }
 
+    public Task<IEnumerable<SignalSubscription>> GetSignalSubscriptions(Guid instanceId)
+    {
+        var files = Directory.GetFiles(_messageSubscriptionsPath, $"signal_*_{instanceId}.json");
+        var subscriptions = files.Select(file =>
+        {
+            var content = File.ReadAllText(file);
+            return JsonConvert.DeserializeObject<SignalSubscription>(content, _newtonSoftDefaultSettings)!;
+        });
+
+        return Task.FromResult(subscriptions);
+    }
+
     public void RemoveProcessSingalSubscriptionsByProcessInstanceId(Guid instanceId)
     {
         var files = Directory.GetFiles(_messageSubscriptionsPath, $"signal_*_{instanceId}.json");

--- a/src/FilesystemStorageSystem/MessageSubscriptionStorage.cs
+++ b/src/FilesystemStorageSystem/MessageSubscriptionStorage.cs
@@ -98,29 +98,35 @@ public class MessageSubscriptionStorage : IMessageSubscriptionStorage
 
     public void AddSignalSubscription(SignalSubscription signalSubscription)
     {
-        var fullFileName = Path.Combine(_messageSubscriptionsPath, $"signal_{signalSubscription.RelatedDefinitionId}_{Guid.NewGuid()}.json");
+        var fileIdentifier = signalSubscription.ProcessInstanceId ?? Guid.NewGuid();
+        var fullFileName = Path.Combine(_messageSubscriptionsPath, $"signal_{signalSubscription.RelatedDefinitionId}_{fileIdentifier}.json");
         var data = JsonConvert.SerializeObject(signalSubscription, _newtonSoftDefaultSettings);
         File.WriteAllText(fullFileName, data);
     }
 
     public Task<IEnumerable<SignalSubscription>> GetSignalSubscriptions(Guid instanceId)
     {
-        var files = Directory.GetFiles(_messageSubscriptionsPath, $"signal_*_{instanceId}.json");
+        var files = Directory.GetFiles(_messageSubscriptionsPath, "signal_*.json");
         var subscriptions = files.Select(file =>
         {
             var content = File.ReadAllText(file);
             return JsonConvert.DeserializeObject<SignalSubscription>(content, _newtonSoftDefaultSettings)!;
-        });
+        }).Where(subscription => subscription.ProcessInstanceId == instanceId);
 
         return Task.FromResult(subscriptions);
     }
 
     public void RemoveProcessSingalSubscriptionsByProcessInstanceId(Guid instanceId)
     {
-        var files = Directory.GetFiles(_messageSubscriptionsPath, $"signal_*_{instanceId}.json");
+        var files = Directory.GetFiles(_messageSubscriptionsPath, "signal_*.json");
         foreach (var file in files)
         {
-            File.Delete(file);
+            var content = File.ReadAllText(file);
+            var subscription = JsonConvert.DeserializeObject<SignalSubscription>(content, _newtonSoftDefaultSettings);
+            if (subscription?.ProcessInstanceId == instanceId)
+            {
+                File.Delete(file);
+            }
         }
     }
 

--- a/src/FlowzerFrontend.Tests/FlowzerApiOptionsTest.cs
+++ b/src/FlowzerFrontend.Tests/FlowzerApiOptionsTest.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using FluentAssertions;
 using FlowzerFrontend;
+using WebApiEngine.Shared;
 
 namespace FlowzerFrontend.Tests;
 
@@ -64,8 +65,75 @@ public class FlowzerApiOptionsTest
         handler.LastContent.Should().Be(payload);
     }
 
+    [Test]
+    public async Task GetSignalSubscriptions_ShouldUseSignalsRoute()
+    {
+        var instanceId = Guid.NewGuid();
+        var handler = new RecordingHttpMessageHandler(CreateApiStatusResultJson(new[]
+        {
+            new SignalSubscriptionDto
+            {
+                Signal = "InvoiceReceived",
+                ProcessId = "Process_Invoice",
+                RelatedDefinitionId = "invoice-process",
+                DefinitionId = Guid.NewGuid(),
+                ProcessInstanceId = instanceId
+            }
+        }));
+
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost:5182/")
+        };
+
+        var api = new FlowzerApi(httpClient);
+
+        var result = await api.GetSignalSubscriptions(instanceId);
+
+        result.Should().HaveCount(1);
+        handler.LastRequestUri.Should().Be(new Uri($"http://localhost:5182/instance/{instanceId}/subscription/signals"));
+    }
+
+    [Test]
+    public async Task GetServiceSubscriptions_ShouldUseServicesRoute()
+    {
+        var instanceId = Guid.NewGuid();
+        var handler = new RecordingHttpMessageHandler(CreateApiStatusResultJson(new[]
+        {
+            new TokenDto
+            {
+                CurrentFlowNodeId = "Activity_ServiceTask",
+                State = FlowNodeStateDto.Active
+            }
+        }));
+
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost:5182/")
+        };
+
+        var api = new FlowzerApi(httpClient);
+
+        var result = await api.GetServiceSubscriptions(instanceId);
+
+        result.Should().HaveCount(1);
+        handler.LastRequestUri.Should().Be(new Uri($"http://localhost:5182/instance/{instanceId}/subscription/services"));
+    }
+
+    private static string CreateApiStatusResultJson<T>(T result)
+    {
+        return System.Text.Json.JsonSerializer.Serialize(new ApiStatusResult<T>(result));
+    }
+
     private sealed class RecordingHttpMessageHandler : HttpMessageHandler
     {
+        private readonly string _responseContent;
+
+        public RecordingHttpMessageHandler(string responseContent = "{}")
+        {
+            _responseContent = responseContent;
+        }
+
         public HttpMethod? LastMethod { get; private set; }
         public Uri? LastRequestUri { get; private set; }
         public string? LastContentType { get; private set; }
@@ -82,7 +150,7 @@ public class FlowzerApiOptionsTest
 
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
-                Content = new StringContent("{}", Encoding.UTF8, "application/json")
+                Content = new StringContent(_responseContent, Encoding.UTF8, "application/json")
             };
         }
     }

--- a/src/FlowzerFrontend/FlowzerApi.cs
+++ b/src/FlowzerFrontend/FlowzerApi.cs
@@ -102,7 +102,7 @@ public class FlowzerApi: ApiBase
 
     public async Task<SignalSubscriptionDto[]> GetSignalSubscriptions(Guid instanceGuid)
     {
-        return await GetAsJsonAndThrowOnErrorAsync<SignalSubscriptionDto[]>("instance/" + instanceGuid + "/subscription/singals");
+        return await GetAsJsonAndThrowOnErrorAsync<SignalSubscriptionDto[]>("instance/" + instanceGuid + "/subscription/signals");
     }
 
     public async Task<TokenDto[]> GetUserTasks(Guid instanceGuid)

--- a/src/StorageSystemShared/IMessageSubscriptionStorage.cs
+++ b/src/StorageSystemShared/IMessageSubscriptionStorage.cs
@@ -18,6 +18,7 @@ public interface IMessageSubscriptionStorage
 
     Task RemoveAllProcessSignalSubscriptionsWithNoInstanceId(string relatedDefinitionId);
     void AddSignalSubscription(SignalSubscription signalSubscription);
+    Task<IEnumerable<SignalSubscription>> GetSignalSubscriptions(Guid instanceId);
     void RemoveProcessSingalSubscriptionsByProcessInstanceId(Guid instanceId);
     
 

--- a/src/WebApiEngine.Tests/InstanceControllerIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/InstanceControllerIntegrationTest.cs
@@ -1,0 +1,270 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Model;
+using StorageSystem;
+using WebApiEngine.Shared;
+using BpmnServiceTask = BPMN.Activities.ServiceTask;
+
+namespace WebApiEngine.Tests;
+
+public class InstanceControllerIntegrationTest
+{
+    [Test]
+    public async Task GetSignalSubscriptions_ShouldReturnSubscriptionsForInstance()
+    {
+        var instanceId = Guid.NewGuid();
+        var storage = TestStorage.CreateWithInstance(instanceId);
+        storage.SubscriptionStorageSeed.SignalSubscriptions.Add(
+            new SignalSubscription(
+                "InvoiceReceived",
+                "Process_Invoice",
+                "invoice-process",
+                storage.DefinitionId,
+                instanceId));
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync($"/instance/{instanceId}/subscription/signals");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<SignalSubscriptionDto[]>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeTrue();
+        payload.Result.Should().ContainSingle();
+        payload.Result![0].Signal.Should().Be("InvoiceReceived");
+        payload.Result[0].ProcessInstanceId.Should().Be(instanceId);
+    }
+
+    [Test]
+    public async Task GetServiceSubscriptions_ShouldReturnActiveServiceTaskTokens()
+    {
+        var instanceId = Guid.NewGuid();
+        var storage = TestStorage.CreateWithInstance(instanceId);
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync($"/instance/{instanceId}/subscription/services");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<TokenDto[]>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeTrue();
+        payload.Result.Should().ContainSingle();
+        payload.Result![0].CurrentFlowNodeId.Should().Be("Activity_ServiceTask");
+        payload.Result[0].State.Should().Be(FlowNodeStateDto.Active);
+    }
+
+    /// <summary>
+    /// Kleine Test-Factory, die die produktiven Storage-Services durch einen in-memory Test-Store ersetzt.
+    /// Damit werden die echten Controller, das Routing und die Serialisierung gegen einen realen Testserver geprüft.
+    /// </summary>
+    private sealed class TestWebApplicationFactory(TestStorage storage) : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IStorageSystem>();
+                services.RemoveAll<ITransactionalStorageProvider>();
+
+                services.AddSingleton<IStorageSystem>(storage);
+                services.AddSingleton<ITransactionalStorageProvider>(new TestTransactionalStorageProvider(storage));
+            });
+        }
+    }
+
+    private sealed class TestTransactionalStorageProvider(TestStorage storage) : ITransactionalStorageProvider
+    {
+        public ITransactionalStorage GetTransactionalStorage()
+        {
+            return storage;
+        }
+    }
+
+    /// <summary>
+    /// In-memory Test-Storage für API-Integrationstests. Nur die tatsächlich benötigten Pfade sind implementiert.
+    /// Nicht genutzte Methoden werfen bewusst, damit ein Test schnell zeigt, wenn sich die API-Abhängigkeiten ändern.
+    /// </summary>
+    private sealed class TestStorage : ITransactionalStorage
+    {
+        public Guid DefinitionId { get; }
+        public TestDefinitionStorage DefinitionStorageSeed { get; }
+        public TestMessageSubscriptionStorage SubscriptionStorageSeed { get; }
+        public TestInstanceStorage InstanceStorageSeed { get; }
+
+        private TestStorage(
+            Guid definitionId,
+            TestDefinitionStorage definitionStorage,
+            TestMessageSubscriptionStorage subscriptionStorage,
+            TestInstanceStorage instanceStorage)
+        {
+            DefinitionId = definitionId;
+            DefinitionStorageSeed = definitionStorage;
+            SubscriptionStorageSeed = subscriptionStorage;
+            InstanceStorageSeed = instanceStorage;
+        }
+
+        public static TestStorage CreateWithInstance(Guid instanceId)
+        {
+            var definitionId = Guid.NewGuid();
+            var definitionStorage = new TestDefinitionStorage(
+                new BpmnMetaDefinition
+                {
+                    DefinitionId = "invoice-process",
+                    Name = "Invoice Process"
+                });
+
+            var serviceTaskToken = new Token
+            {
+                ProcessInstanceId = instanceId,
+                CurrentBaseElement = new BpmnServiceTask
+                {
+                    Id = "Activity_ServiceTask",
+                    Name = "Notify accounting",
+                    Implementation = "notify-accounting"
+                },
+                ActiveBoundaryEvents = [],
+                State = FlowNodeState.Active
+            };
+
+            var instanceStorage = new TestInstanceStorage(
+                new ProcessInstanceInfo
+                {
+                    InstanceId = instanceId,
+                    metaDefinitionId = "invoice-process",
+                    DefinitionId = definitionId,
+                    ProcessId = "Process_Invoice",
+                    Tokens = [serviceTaskToken],
+                    IsFinished = false,
+                    State = ProcessInstanceState.Running,
+                    MessageSubscriptionCount = 0,
+                    SignalSubscriptionCount = 1,
+                    UserTaskSubscriptionCount = 0,
+                    ServiceSubscriptionCount = 1
+                });
+
+            var subscriptionStorage = new TestMessageSubscriptionStorage();
+            var storage = new TestStorage(definitionId, definitionStorage, subscriptionStorage, instanceStorage);
+
+            return storage;
+        }
+
+        public IDefinitionStorage DefinitionStorage => DefinitionStorageSeed;
+        public IMessageSubscriptionStorage SubscriptionStorage => SubscriptionStorageSeed;
+        public IInstanceStorage InstanceStorage => InstanceStorageSeed;
+        public IFormStorage FormStorage { get; } = new TestFormStorage();
+
+        public void CommitChanges()
+        {
+        }
+
+        public void RollbackTransaction()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+
+        private TestStorage()
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed class TestDefinitionStorage(BpmnMetaDefinition metaDefinition) : IDefinitionStorage
+    {
+        public Task<string> GetBinary(Guid guid) => throw new NotSupportedException();
+        public Task<Guid[]> GetAllBinaryDefinitions() => Task.FromResult(Array.Empty<Guid>());
+        public Task<BpmnDefinition[]> GetAllDefinitions() => Task.FromResult(Array.Empty<BpmnDefinition>());
+        public Task StoreDefinition(BpmnDefinition definition) => Task.CompletedTask;
+        public Task StoreBinary(Guid guid, string data) => Task.CompletedTask;
+        public Task<Model.Version?> GetMaxVersionId(string modelId) => Task.FromResult<Model.Version?>(null);
+        public Task<BpmnDefinition> GetDefinitionById(Guid id) => throw new NotSupportedException();
+        public Task<BpmnDefinition> GetLatestDefinition(string definitionId) => throw new NotSupportedException();
+        public Task<BpmnDefinition?> GetDeployedDefinition(string definitionDefinitionId) => Task.FromResult<BpmnDefinition?>(null);
+        public Task<ExtendedBpmnMetaDefinition[]> GetAllMetaDefinitions() => Task.FromResult(Array.Empty<ExtendedBpmnMetaDefinition>());
+        public Task StoreMetaDefinition(BpmnMetaDefinition metaDefinition) => Task.CompletedTask;
+        public Task UpdateMetaDefinition(BpmnMetaDefinition metaDefinition) => Task.CompletedTask;
+        public Task<BpmnMetaDefinition> GetMetaDefinitionById(string id) => Task.FromResult(metaDefinition);
+    }
+
+    private sealed class TestMessageSubscriptionStorage : IMessageSubscriptionStorage
+    {
+        public List<SignalSubscription> SignalSubscriptions { get; } = [];
+
+        public Task<IEnumerable<MessageSubscription>> GetAllMessageSubscriptions() =>
+            Task.FromResult(Enumerable.Empty<MessageSubscription>());
+
+        public Task<IEnumerable<MessageSubscription>> GetMessageSubscription(string messageName, string? correlationKey, Guid? messageInstanceId) =>
+            Task.FromResult(Enumerable.Empty<MessageSubscription>());
+
+        public Task<IEnumerable<MessageSubscription>> GetMessageSubscription(Guid instanceId) =>
+            Task.FromResult(Enumerable.Empty<MessageSubscription>());
+
+        public Task AddMessageSubscription(MessageSubscription messageSubscription) => Task.CompletedTask;
+        public Task RemoveProcessMessageSubscriptionsByProcessInstanceId(Guid instanceId) => Task.CompletedTask;
+        public Task RemoveAllProcessMessageSubscriptionsWithNoInstancedId(string metaDefinitionId) => Task.CompletedTask;
+        public Task RemoveAllProcessSignalSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
+        public void AddSignalSubscription(SignalSubscription signalSubscription) => SignalSubscriptions.Add(signalSubscription);
+
+        public Task<IEnumerable<SignalSubscription>> GetSignalSubscriptions(Guid instanceId)
+        {
+            return Task.FromResult(
+                SignalSubscriptions
+                    .Where(subscription => subscription.ProcessInstanceId == instanceId)
+                    .AsEnumerable());
+        }
+
+        public void RemoveProcessSingalSubscriptionsByProcessInstanceId(Guid instanceId)
+        {
+            SignalSubscriptions.RemoveAll(subscription => subscription.ProcessInstanceId == instanceId);
+        }
+
+        public Task<IEnumerable<UserTaskSubscription>> GetAllUserTasks(Guid instanceId) =>
+            Task.FromResult(Enumerable.Empty<UserTaskSubscription>());
+
+        public Task<IEnumerable<ExtendedUserTaskSubscription>> GetAllUserTasksExtended(Guid userId) =>
+            Task.FromResult(Enumerable.Empty<ExtendedUserTaskSubscription>());
+
+        public Task AddUserTaskSubscription(UserTaskSubscription userTasks) => Task.CompletedTask;
+        public Task RemoveUserTaskSubscription(Guid userTaskSubscriptionId) => Task.CompletedTask;
+        public void RemoveAllUserTaskSubscriptionsByInstanceId(Guid instanceId) { }
+        public Task RemoveAllUserTaskSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
+    }
+
+    private sealed class TestInstanceStorage(ProcessInstanceInfo instance) : IInstanceStorage
+    {
+        public Task<ProcessInstanceInfo> GetProcessInstance(Guid processInstanceId)
+        {
+            return processInstanceId == instance.InstanceId
+                ? Task.FromResult(instance)
+                : throw new KeyNotFoundException($"Unknown process instance: {processInstanceId}");
+        }
+
+        public Task AddOrUpdateInstance(ProcessInstanceInfo processInstanceInfo) => Task.CompletedTask;
+
+        public Task<IEnumerable<ProcessInstanceInfo>> GetAllActiveInstances() =>
+            Task.FromResult<IEnumerable<ProcessInstanceInfo>>([instance]);
+    }
+
+    private sealed class TestFormStorage : IFormStorage
+    {
+        public Task SaveFormMetaData(FormMetadata formMetadata) => Task.CompletedTask;
+        public Task<FormMetadata> GetFormMetaData(Guid formId) => throw new NotSupportedException();
+        public Task<IEnumerable<FormMetadata>> GetFormMetadatas() => Task.FromResult(Enumerable.Empty<FormMetadata>());
+        public Task UpdateFormMetaData(FormMetadata formMetaData) => Task.CompletedTask;
+        public Task DeleteFormMetaData(Guid formId) => Task.CompletedTask;
+        public Task SaveForm(Form form) => Task.CompletedTask;
+        public Task<Form> GetForm(Guid id) => throw new NotSupportedException();
+        public Task<IEnumerable<Form>> GetForms(Guid formId) => Task.FromResult(Enumerable.Empty<Form>());
+        public Task DeleteForm(Guid id) => Task.CompletedTask;
+        public Task<Model.Version> GetMaxVersion(Guid formId) => Task.FromResult(new Model.Version(1, 0));
+    }
+}

--- a/src/WebApiEngine.Tests/InstanceControllerIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/InstanceControllerIntegrationTest.cs
@@ -58,6 +58,7 @@ public class InstanceControllerIntegrationTest
         payload.Result.Should().ContainSingle();
         payload.Result![0].CurrentFlowNodeId.Should().Be("Activity_ServiceTask");
         payload.Result[0].State.Should().Be(FlowNodeStateDto.Active);
+        payload.Result.Should().OnlyContain(token => token.State == FlowNodeStateDto.Active);
     }
 
     /// <summary>
@@ -133,6 +134,19 @@ public class InstanceControllerIntegrationTest
                 State = FlowNodeState.Active
             };
 
+            var completedServiceTaskToken = new Token
+            {
+                ProcessInstanceId = instanceId,
+                CurrentBaseElement = new BpmnServiceTask
+                {
+                    Id = "Activity_ServiceTask_Completed",
+                    Name = "Completed notification",
+                    Implementation = "notify-accounting-completed"
+                },
+                ActiveBoundaryEvents = [],
+                State = FlowNodeState.Completed
+            };
+
             var instanceStorage = new TestInstanceStorage(
                 new ProcessInstanceInfo
                 {
@@ -140,7 +154,7 @@ public class InstanceControllerIntegrationTest
                     metaDefinitionId = "invoice-process",
                     DefinitionId = definitionId,
                     ProcessId = "Process_Invoice",
-                    Tokens = [serviceTaskToken],
+                    Tokens = [serviceTaskToken, completedServiceTaskToken],
                     IsFinished = false,
                     State = ProcessInstanceState.Running,
                     MessageSubscriptionCount = 0,

--- a/src/WebApiEngine.Tests/WebApiEngine.Tests.csproj
+++ b/src/WebApiEngine.Tests/WebApiEngine.Tests.csproj
@@ -11,6 +11,7 @@
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.4" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NUnit" Version="3.14.0" />
         <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />

--- a/src/WebApiEngine/Controller/InstanceController.cs
+++ b/src/WebApiEngine/Controller/InstanceController.cs
@@ -74,7 +74,7 @@ public class InstanceController(
     {
         var instance = await storageSystem.InstanceStorage.GetProcessInstance(instanceId);
         var result = instance.Tokens
-            .Where(token => token.CurrentBaseElement is BpmnServiceTask)
+            .Where(token => token.CurrentBaseElement is BpmnServiceTask && token.State == FlowNodeState.Active)
             .Select(token => token.ToDto())
             .ToArray();
 

--- a/src/WebApiEngine/Controller/InstanceController.cs
+++ b/src/WebApiEngine/Controller/InstanceController.cs
@@ -1,3 +1,4 @@
+using BpmnServiceTask = BPMN.Activities.ServiceTask;
 using Flowzer.Shared;
 using WebApiEngine.BusinessLogic;
 using WebApiEngine.Mappers;
@@ -59,7 +60,27 @@ public class InstanceController(
         var result = messageSubscriptions.Select(subscription => subscription.ToDto()).ToArray();
         return Ok(new ApiStatusResult<MessageSubscriptionDto[]>(result));
     }
-    
+
+    [HttpGet("{instanceId}/subscription/signals")]
+    public async Task<ActionResult<SignalSubscriptionDto[]>> GetSignalSubscriptions(Guid instanceId)
+    {
+        var signalSubscriptions = await storageSystem.SubscriptionStorage.GetSignalSubscriptions(instanceId);
+        var result = signalSubscriptions.Select(subscription => subscription.ToDto()).ToArray();
+        return Ok(new ApiStatusResult<SignalSubscriptionDto[]>(result));
+    }
+
+    [HttpGet("{instanceId}/subscription/services")]
+    public async Task<ActionResult<TokenDto[]>> GetServiceSubscriptions(Guid instanceId)
+    {
+        var instance = await storageSystem.InstanceStorage.GetProcessInstance(instanceId);
+        var result = instance.Tokens
+            .Where(token => token.CurrentBaseElement is BpmnServiceTask)
+            .Select(token => token.ToDto())
+            .ToArray();
+
+        return Ok(new ApiStatusResult<TokenDto[]>(result));
+    }
+
     [HttpGet("{instanceId}/subscription/userTasks")]
     public async Task<ActionResult<TokenDto[]>> GetUserTasksSubscriptions(Guid instanceId)
     {

--- a/src/WebApiEngine/Mappers/InteractionMappingExtensions.cs
+++ b/src/WebApiEngine/Mappers/InteractionMappingExtensions.cs
@@ -79,6 +79,20 @@ public static class InteractionMappingExtensions
         };
     }
 
+    public static SignalSubscriptionDto ToDto(this SignalSubscription signalSubscription)
+    {
+        ArgumentNullException.ThrowIfNull(signalSubscription);
+
+        return new SignalSubscriptionDto
+        {
+            Signal = signalSubscription.Signal,
+            ProcessId = signalSubscription.ProcessId,
+            RelatedDefinitionId = signalSubscription.RelatedDefinitionId,
+            DefinitionId = signalSubscription.DefinitionId,
+            ProcessInstanceId = signalSubscription.ProcessInstanceId
+        };
+    }
+
     public static FormDto ToDto(this Form form)
     {
         ArgumentNullException.ThrowIfNull(form);

--- a/src/WebApiEngine/Program.cs
+++ b/src/WebApiEngine/Program.cs
@@ -49,3 +49,7 @@ app.MapControllers();
 app.Services.GetRequiredService<BpmnBusinessLogic>().Load();
 
 app.Run();
+
+public partial class Program
+{
+}


### PR DESCRIPTION
## Zusammenfassung

Dieser PR vervollständigt den Laufzeitpfad für die Instanz-Detailansicht im Frontend.

Bisher gab es zwei Lücken:

- die Signal-Route im Frontend war falsch geschrieben (`singals`)
- im Backend fehlten Endpunkte für Signal- und Service-Subscriptions pro Instanz

Dadurch konnten Teile der Instanz-Ansicht trotz vorhandener Zähler nicht sauber geladen werden.

Closes #43

## Änderungen im Detail

- neue API-Endpunkte für:
  - `GET /instance/{id}/subscription/signals`
  - `GET /instance/{id}/subscription/services`
- neues Mapping von `SignalSubscription` auf `SignalSubscriptionDto`
- Frontend-Request für Signal-Subscriptions auf die korrekte Route korrigiert
- API-Integrationstests für Signal- und Service-Subscriptions ergänzt
- Frontend-Regressionstests für die betroffenen Request-Pfade ergänzt
- `Program` als `partial` geöffnet, damit die Web-API testbar via `WebApplicationFactory` wird

## Validierung

- `dotnet build core-engine.sln --configuration Release`
- `dotnet test src/core-engine-tests/core-engine-tests.csproj --no-restore --no-build --configuration Release --logger 'console;verbosity=minimal'`
- `dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --no-restore --no-build --configuration Release --logger 'console;verbosity=minimal'`
- `dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --no-restore --no-build --configuration Release --logger 'console;verbosity=minimal'`
- `cd tests/ui-smoke && CI=1 npm test`
