### PR TITLE
Frontend-Nullability und defensive Guards in den Kernseiten härten

### DIFF
--- a/src/FlowzerFrontend.Tests/TokenDisplayHelperTest.cs
+++ b/src/FlowzerFrontend.Tests/TokenDisplayHelperTest.cs
@@ -31,6 +31,22 @@ public class TokenDisplayHelperTest
     }
 
     [Test]
+    public void GetImplementation_ShouldReturnNull_WhenExpandoContainsNullValue()
+    {
+        dynamic flowElement = new ExpandoObject();
+        flowElement.Implementation = null;
+
+        var token = new TokenDto
+        {
+            CurrentFlowElement = flowElement
+        };
+
+        var result = TokenDisplayHelper.GetImplementation(token);
+
+        result.Should().BeNull();
+    }
+
+    [Test]
     public void GetDisplayName_ShouldPreferName_AndFallbackToId()
     {
         dynamic flowElement = new ExpandoObject();

--- a/src/FlowzerFrontend.Tests/TokenDisplayHelperTest.cs
+++ b/src/FlowzerFrontend.Tests/TokenDisplayHelperTest.cs
@@ -1,0 +1,49 @@
+using System.Dynamic;
+using FluentAssertions;
+using FlowzerFrontend.BusinessLogic;
+using WebApiEngine.Shared;
+
+namespace FlowzerFrontend.Tests;
+
+public class TokenDisplayHelperTest
+{
+    [Test]
+    public void GetImplementation_ShouldReturnNull_WhenCurrentFlowElementIsMissing()
+    {
+        var token = new TokenDto();
+
+        var result = TokenDisplayHelper.GetImplementation(token);
+
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public void GetFlowElementId_ShouldFallbackToCurrentFlowNodeId_WhenExpandoValueIsMissing()
+    {
+        var token = new TokenDto
+        {
+            CurrentFlowNodeId = "Activity_UserTask"
+        };
+
+        var result = TokenDisplayHelper.GetFlowElementId(token);
+
+        result.Should().Be("Activity_UserTask");
+    }
+
+    [Test]
+    public void GetDisplayName_ShouldPreferName_AndFallbackToId()
+    {
+        dynamic flowElement = new ExpandoObject();
+        flowElement.Name = "Approve invoice";
+        flowElement.Id = "Activity_UserTask";
+
+        var token = new TokenDto
+        {
+            CurrentFlowElement = flowElement
+        };
+
+        var result = TokenDisplayHelper.GetDisplayName(token, "(fallback)");
+
+        result.Should().Be("Approve invoice");
+    }
+}

--- a/src/FlowzerFrontend/BusinessLogic/TokenDisplayHelper.cs
+++ b/src/FlowzerFrontend/BusinessLogic/TokenDisplayHelper.cs
@@ -8,24 +8,39 @@ namespace FlowzerFrontend.BusinessLogic;
 /// </summary>
 public static class TokenDisplayHelper
 {
-    public static string? GetImplementation(TokenDto token)
+    private static string? GetOptionalString(TokenDto token, string key, string? fallback)
     {
         ArgumentNullException.ThrowIfNull(token);
-        return token.CurrentFlowElement.GetValue<string>("Implementation", null);
+
+        if (token.CurrentFlowElement is not IDictionary<string, object?> values)
+        {
+            return fallback;
+        }
+
+        if (!values.TryGetValue(key, out var value) || value is null)
+        {
+            return fallback;
+        }
+
+        return value as string ?? fallback;
+    }
+
+    public static string? GetImplementation(TokenDto token)
+    {
+        return GetOptionalString(token, "Implementation", null);
     }
 
     public static string? GetFlowElementId(TokenDto token)
     {
-        ArgumentNullException.ThrowIfNull(token);
-        return token.CurrentFlowElement.GetValue<string>("Id", token.CurrentFlowNodeId);
+        return GetOptionalString(token, "Id", token.CurrentFlowNodeId);
     }
 
     public static string GetDisplayName(TokenDto token, string fallback)
     {
         ArgumentNullException.ThrowIfNull(token);
 
-        return token.CurrentFlowElement.GetValue<string>("Name", null)
-               ?? token.CurrentFlowElement.GetValue<string>("Id", fallback)
+        return GetOptionalString(token, "Name", null)
+               ?? GetOptionalString(token, "Id", fallback)
                ?? fallback;
     }
 }

--- a/src/FlowzerFrontend/BusinessLogic/TokenDisplayHelper.cs
+++ b/src/FlowzerFrontend/BusinessLogic/TokenDisplayHelper.cs
@@ -1,0 +1,31 @@
+using WebApiEngine.Shared;
+
+namespace FlowzerFrontend.BusinessLogic;
+
+/// <summary>
+/// Liest häufig benötigte Anzeigeinformationen defensiv aus Token-Daten aus.
+/// So bleiben UI-Komponenten auch dann stabil, wenn optionale Expando-Felder fehlen.
+/// </summary>
+public static class TokenDisplayHelper
+{
+    public static string? GetImplementation(TokenDto token)
+    {
+        ArgumentNullException.ThrowIfNull(token);
+        return token.CurrentFlowElement.GetValue<string>("Implementation", null);
+    }
+
+    public static string? GetFlowElementId(TokenDto token)
+    {
+        ArgumentNullException.ThrowIfNull(token);
+        return token.CurrentFlowElement.GetValue<string>("Id", token.CurrentFlowNodeId);
+    }
+
+    public static string GetDisplayName(TokenDto token, string fallback)
+    {
+        ArgumentNullException.ThrowIfNull(token);
+
+        return token.CurrentFlowElement.GetValue<string>("Name", null)
+               ?? token.CurrentFlowElement.GetValue<string>("Id", fallback)
+               ?? fallback;
+    }
+}

--- a/src/FlowzerFrontend/Components/FormComponent.razor.cs
+++ b/src/FlowzerFrontend/Components/FormComponent.razor.cs
@@ -11,7 +11,7 @@ public partial class FormComponent : ComponentBase
     [Inject] public required IJSRuntime JsRuntime { get; set; }
     [Inject] public required ILogger<FormComponent> Logger { get; set; }
 
-    public string Debug { get; set; }
+    public string Debug { get; set; } = string.Empty;
     
     [Parameter] public string Schema { get; set; } = string.Empty;
     [Parameter] public string OutData { get; set; } = string.Empty;

--- a/src/FlowzerFrontend/Components/LabelWithEdit.razor.cs
+++ b/src/FlowzerFrontend/Components/LabelWithEdit.razor.cs
@@ -7,7 +7,7 @@ public partial class LabelWithEdit : ComponentBase
 {
     
     [Parameter]
-    public string Label { get; set; }
+    public string Label { get; set; } = string.Empty;
     
     [Parameter]
     public EventCallback<string>? LabelChanged { get; set; }

--- a/src/FlowzerFrontend/Pages/EditForm.razor.cs
+++ b/src/FlowzerFrontend/Pages/EditForm.razor.cs
@@ -20,7 +20,10 @@ public partial class EditForm : FlowzerComponentBase
     public bool IsNew { get; set; }
 
     public FormMetaDataDto CurrentFormMeta { get; set; } 
-    public FormDto FormData { get; set; }
+    public FormDto FormData { get; set; } = new()
+    {
+        FormId = Guid.Empty
+    };
 
 
     public EditForm()
@@ -103,7 +106,7 @@ public partial class EditForm : FlowzerComponentBase
         }
     }
 
-    private async Task<string?> GetFormData()
+    private async Task<string> GetFormData()
     {
         var ret = await JsRuntime.InvokeAsyncNoneCached<object>("executeInIframe", "iframe", "GetFormData");
         return ((JsonElement)ret).GetRawText();

--- a/src/FlowzerFrontend/Pages/FilloutForm.razor
+++ b/src/FlowzerFrontend/Pages/FilloutForm.razor
@@ -2,4 +2,7 @@
 @using Microsoft.FluentUI.AspNetCore.Components
 @implements Microsoft.FluentUI.AspNetCore.Components.IDialogContentComponent<FilloutFormParameter>
 
-<FormComponent Schema="@Content.Schema" @bind-Data="@Content.Data" @bind-OutData="@Content.OutData"></FormComponent>
+@if (Content is not null)
+{
+    <FormComponent Schema="@Content.Schema" @bind-Data="@Content.Data" @bind-OutData="@Content.OutData"></FormComponent>
+}

--- a/src/FlowzerFrontend/Pages/FilloutFormParameter.cs
+++ b/src/FlowzerFrontend/Pages/FilloutFormParameter.cs
@@ -2,7 +2,7 @@ namespace FlowzerFrontend;
 
 public class FilloutFormParameter
 {
-    public string Schema { get; set; }
-    public string Data { get; set; }
-    public string OutData { get; set; }
+    public string Schema { get; set; } = string.Empty;
+    public string Data { get; set; } = string.Empty;
+    public string OutData { get; set; } = string.Empty;
 }

--- a/src/FlowzerFrontend/Pages/Home.razor.cs
+++ b/src/FlowzerFrontend/Pages/Home.razor.cs
@@ -1,4 +1,5 @@
 using System.Dynamic;
+using FlowzerFrontend.BusinessLogic;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Newtonsoft.Json;
@@ -19,10 +20,11 @@ public partial class Home : FlowzerComponentBase
     
     private async void OnCardClick(ExtendedUserTaskSubscriptionDto userTaskSubscription)
     {
-        var formName = (string)((dynamic)userTaskSubscription.Token.CurrentFlowElement!).Implementation;
-        if (string.IsNullOrEmpty(formName))
+        var formName = TokenDisplayHelper.GetImplementation(userTaskSubscription.Token);
+        if (string.IsNullOrWhiteSpace(formName))
         {
             ErrorDialog("Form Name ('Implementation') is missing in BPMNN file");
+            return;
         }
 
         string? version = null;
@@ -82,12 +84,19 @@ public partial class Home : FlowzerComponentBase
         IDialogReference dialog = await DialogService.ShowDialogAsync<FilloutForm>(data, parameters);
         DialogResult? result = await dialog.Result;
         
-        if (!result.Cancelled)
+        if (!result.Cancelled && result.Data is FilloutFormParameter formResult && !string.IsNullOrWhiteSpace(formResult.OutData))
         {
-            var dataObj = JsonConvert.DeserializeObject<ExpandoObject>(((FilloutFormParameter)result.Data).OutData);
+            var dataObj = JsonConvert.DeserializeObject<ExpandoObject>(formResult.OutData) ?? new ExpandoObject();
+            var flowNodeId = TokenDisplayHelper.GetFlowElementId(userTaskSubscription.Token);
+            if (string.IsNullOrWhiteSpace(flowNodeId))
+            {
+                ErrorDialog("FlowNode Id is missing in token data.");
+                return;
+            }
+
             var userTaskResult = new UserTaskResultDto()
             {
-                FlowNodeId = (string)((dynamic)userTaskSubscription.Token.CurrentFlowElement!).Id,
+                FlowNodeId = flowNodeId,
                 TokenId = userTaskSubscription.Token.Id,
                 ProcessInstanceId = userTaskSubscription.ProcessInstanceId,
                 Data = dataObj

--- a/src/FlowzerFrontend/Pages/Instance.razor.cs
+++ b/src/FlowzerFrontend/Pages/Instance.razor.cs
@@ -23,13 +23,13 @@ public partial class Instance
     [Inject] public required FlowzerApi FlowzerApi { get; set; }
 
     
-    public IEnumerable<ITreeViewItem>? VariableItems = new List<ITreeViewItem>();
+    public IEnumerable<ITreeViewItem> VariableItems = [];
     
     public string? VariableContent;
 
-    private IEnumerable<ITreeViewItem>? Items = new List<ITreeViewItem>();
+    private IEnumerable<ITreeViewItem> Items = [];
     
-    public string ErrorString { get; set; }
+    public string ErrorString { get; set; } = string.Empty;
 
     
     private ITreeViewItem? _currentSelectedToken;
@@ -59,8 +59,7 @@ public partial class Instance
 
     private bool _trapFocus = true;
     private bool _modal = true;
-    private ITreeViewItem? _selectedItem;
-    private  Dictionary<string, object> _treeItemMappings = new Dictionary<string, object>();
+    private readonly Dictionary<string, object> _treeItemMappings = new();
     
 
 
@@ -86,21 +85,18 @@ public partial class Instance
         if (rootTokens.Count != 1)
         {
             throw new Exception("There should be exactly one root token");
-            return;
         }
         VariableItems =  GetTokenTreeViewItem(instanceTokens, rootTokens);
         
         await InvokeAsync(StateHasChanged);
     }
 
-    private IEnumerable<ITreeViewItem>? GetTokenTreeViewItem(List<TokenDto> allTokens, List<TokenDto> list)
+    private IEnumerable<ITreeViewItem> GetTokenTreeViewItem(List<TokenDto> allTokens, List<TokenDto> list)
     {
         var result = new List<ITreeViewItem>();
         foreach (var x in list)
         {
-            var text = x.CurrentFlowElement.GetValue<string>("Name", null);
-            if (string.IsNullOrEmpty(text))
-                text = x.CurrentFlowElement.GetValue<string>("Id", "(root token)")!;
+            var text = TokenDisplayHelper.GetDisplayName(x, "(root token)");
 
             var subTokens = allTokens.Where(y => y.ParentTokenId == x.Id).ToList();
             var subItems = GetTokenTreeViewItem(allTokens, subTokens);
@@ -184,10 +180,10 @@ public partial class Instance
 
     }
 
-    private async Task<IEnumerable<ITreeViewItem>?> LoadMessageSubscriptions()
+    private async Task<IEnumerable<ITreeViewItem>> LoadMessageSubscriptions()
     {
         if (_instance == null)
-            return null;
+            return [];
         return (await FlowzerApi.GetMessageSubscriptions(_instance.InstanceId)).Select(
             x =>
             {
@@ -198,24 +194,24 @@ public partial class Instance
             });
     }
 
-    private async Task<IEnumerable<ITreeViewItem>?> LoadServiceSubscriptions()
+    private async Task<IEnumerable<ITreeViewItem>> LoadServiceSubscriptions()
     {
         if (_instance == null)
-            return new List<ITreeViewItem>();
+            return [];
         return (await FlowzerApi.GetServiceSubscriptions(_instance.InstanceId)).Select(
             x =>
             {
-                var implementationName = (string)(((IDictionary<string, object>)x.CurrentFlowElement!)!)["Implementation"];
+                var implementationName = TokenDisplayHelper.GetImplementation(x) ?? x.CurrentFlowNodeId ?? "(service task)";
                 var treeViewItem = new TreeViewItem(x.Id.ToString(), implementationName);
                 return treeViewItem;
             });
     }
 
 
-    private async Task<IEnumerable<ITreeViewItem>?> LoadSignalSubscriptions()
+    private async Task<IEnumerable<ITreeViewItem>> LoadSignalSubscriptions()
     {
         if (_instance == null)
-            return new List<ITreeViewItem>();
+            return [];
         return (await FlowzerApi.GetSignalSubscriptions(_instance.InstanceId)).Select(
             x =>
             {
@@ -224,16 +220,16 @@ public partial class Instance
             });
     }
 
-    private async Task<IEnumerable<ITreeViewItem>?> LoadUserTaskSubscriptions()
+    private async Task<IEnumerable<ITreeViewItem>> LoadUserTaskSubscriptions()
     {
         if (_instance == null)
-            return new List<ITreeViewItem>();
+            return [];
         
         
         return (await FlowzerApi.GetUserTasks(_instance.InstanceId)).Select(
             x =>
             {
-                var implementationName = (string)(((IDictionary<string, object>)x.CurrentFlowElement!)!)["Implementation"];
+                var implementationName = TokenDisplayHelper.GetImplementation(x) ?? x.CurrentFlowNodeId ?? "(user task)";
                 var treeViewItem = new TreeViewItem(x.Id.ToString(), implementationName);
                 return treeViewItem;
             });
@@ -289,7 +285,7 @@ public partial class Instance
     private async Task LoadDiagramXml(string xml)
     {
         await JsRuntime.InvokeVoidAsync("window.bpmnViewer.importXML", xml);
-        ErrorString = null;
+        ErrorString = string.Empty;
     }
 
 
@@ -338,4 +334,3 @@ public partial class Instance
         await LoadData();
     }
 }
-

--- a/src/FlowzerFrontend/Pages/RestDialog.razor.cs
+++ b/src/FlowzerFrontend/Pages/RestDialog.razor.cs
@@ -6,7 +6,14 @@ public partial class RestDialog
 {
     [Inject] public required FlowzerApi FlowzerApi { get; set; }
     
-    [Parameter] public RestDialogParams Content { get; set; }
+    [Parameter] public RestDialogParams Content { get; set; } = new()
+    {
+        RestExampleRequest = new FlowzerFrontend.Models.RestExampleRequest
+        {
+            Url = string.Empty,
+            Body = string.Empty
+        }
+    };
 
     public string? Result { get; set; }
     

--- a/src/FlowzerFrontend/Pages/TestFormParameters.cs
+++ b/src/FlowzerFrontend/Pages/TestFormParameters.cs
@@ -2,6 +2,6 @@ namespace FlowzerFrontend;
 
 public class TestFormParameters
 {
-    public string? Data { get; set; }
-    public string? Schema { get; set; }
+    public string Data { get; set; } = "{}";
+    public string Schema { get; set; } = string.Empty;
 }

--- a/src/FlowzerFrontend/Pages/Testform.razor.cs
+++ b/src/FlowzerFrontend/Pages/Testform.razor.cs
@@ -4,6 +4,6 @@ namespace FlowzerFrontend.Pages;
 
 public partial class Testform
 {
-    [Parameter] public TestFormParameters Content { get; set; }
-    public string OutData { get; set; }
+    [Parameter] public TestFormParameters Content { get; set; } = new();
+    public string OutData { get; set; } = string.Empty;
 }

--- a/src/FlowzerFrontend/Pages/Testform.razor.cs
+++ b/src/FlowzerFrontend/Pages/Testform.razor.cs
@@ -5,5 +5,6 @@ namespace FlowzerFrontend.Pages;
 public partial class Testform
 {
     [Parameter] public TestFormParameters Content { get; set; } = new();
+
     public string OutData { get; set; } = string.Empty;
 }


### PR DESCRIPTION
## Zusammenfassung

Dieser PR härtet mehrere Kernseiten des Frontends gegen leere Initialzustände, fehlende Expando-Felder und späte Datenbindungen.

Dadurch werden typische Nullability-Probleme im UI reduziert, ohne den Benutzerfluss zu verändern.

Closes #45

## Änderungen im Detail

- sichere Defaultwerte für Formular-/Dialog-Parameter und UI-Zustände
- defensive Guards in `Home`, `Instance`, `RestDialog`, `EditForm` und `FilloutForm`
- neue Hilfsklasse `TokenDisplayHelper` für robustes Lesen von Token-Anzeigedaten
- neue Frontend-Tests für die neue Helper-Logik

## Wirkung

- der reine Frontend-Build läuft jetzt ohne Frontend-spezifische Nullability-Warnungen
- der Solution-Build reduziert sich dadurch sichtbar auf die verbleibenden Warnungen außerhalb des Frontends
- bestehende UI-Smoke-Tests bleiben grün

## Validierung

- `dotnet build core-engine.sln --configuration Release`
- `dotnet build src/FlowzerFrontend/FlowzerFrontend.csproj --configuration Release`
- `dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --logger 'console;verbosity=minimal'`
- `cd tests/ui-smoke && CI=1 npm test`
