### PR TITLE
Formularpfad von Storage bis Frontend stabilisieren

### DIFF
--- a/Model/Version.cs
+++ b/Model/Version.cs
@@ -22,8 +22,7 @@ public class Version: IComparable<Version>, IEquatable<Version>
     //+ operator which increases the minor version
     public static Version operator +(Version version, int increase)
     {
-        version.Minor += increase;
-        return version;
+        return new Version(version.Major, version.Minor + increase);
     }
 
     public override string ToString()

--- a/Model/Version.cs
+++ b/Model/Version.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Model;
 
 
-public class Version: IComparable<Version>
+public class Version: IComparable<Version>, IEquatable<Version>
 {
     public Version()
     {
@@ -38,6 +38,35 @@ public class Version: IComparable<Version>
         if (Major == other.Major)
             return Minor.CompareTo(other.Minor);
         return Major.CompareTo(other.Major);
+    }
+
+    public bool Equals(Version? other)
+    {
+        // Versionen sind fachlich Wertobjekte und müssen deshalb über ihre Bestandteile verglichen werden.
+        if (other is null)
+            return false;
+
+        return Major == other.Major && Minor == other.Minor;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is Version other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Major, Minor);
+    }
+
+    public static bool operator ==(Version? left, Version? right)
+    {
+        return Equals(left, right);
+    }
+
+    public static bool operator !=(Version? left, Version? right)
+    {
+        return !Equals(left, right);
     }
 
     public static Version FromString(string versionString)

--- a/src/FilesystemStorageSystem/FormStorage.cs
+++ b/src/FilesystemStorageSystem/FormStorage.cs
@@ -23,14 +23,29 @@ public class FormStorage : IFormStorage
     {
         if (!Directory.Exists(_basePath))
             Directory.CreateDirectory(_basePath);
-        if (!Directory.Exists(_basePath))
-            Directory.CreateDirectory(_basePath);
+        if (!Directory.Exists(_metaPath))
+            Directory.CreateDirectory(_metaPath);
+    }
+
+    private string GetMetaFilePath(Guid formId)
+    {
+        return Path.Combine(_metaPath, $"{formId}.json");
+    }
+
+    private string GetFormSearchPattern(Guid formId)
+    {
+        return $"{formId}_*.json";
+    }
+
+    private string? GetFormFilePath(Guid id)
+    {
+        return Directory.GetFiles(_basePath, $"*_{id}.json").SingleOrDefault();
     }
 
     public async Task SaveFormMetaData(FormMetadata formMetadata)
     {
         EnsureDirectoryCreated();
-        var fullFileName = Path.Combine(_metaPath, $"{formMetadata.FormId}.json");
+        var fullFileName = GetMetaFilePath(formMetadata.FormId);
         var data = JsonConvert.SerializeObject(formMetadata, _storage.NewtonSoftDefaultSettings);
         await File.WriteAllTextAsync(fullFileName, data);
     }
@@ -38,33 +53,52 @@ public class FormStorage : IFormStorage
     public Task<FormMetadata> GetFormMetaData(Guid formId)
     {
         EnsureDirectoryCreated();
-        var fullFileName = Path.Combine(_metaPath, $"{formId}.json");
+        var fullFileName = GetMetaFilePath(formId);
         var data = File.ReadAllText(fullFileName);
         return Task.FromResult(JsonConvert.DeserializeObject<FormMetadata>(data, _storage.NewtonSoftDefaultSettings)!);
     }
 
-    public async Task<IEnumerable<FormMetadata>> GetFormMetadatas()
+    public Task<IEnumerable<FormMetadata>> GetFormMetadatas()
     {
-
         EnsureDirectoryCreated();
-        
-        return Directory.GetFiles(_metaPath, "*.json")
+
+        var metadatas = Directory.GetFiles(_metaPath, "*.json")
             .Select(filePath =>
             {
                 var data = File.ReadAllText(filePath);
                 return JsonConvert.DeserializeObject<FormMetadata>(data, _storage.NewtonSoftDefaultSettings)!;
             });
 
+        return Task.FromResult(metadatas);
     }
 
-    public Task UpdateFormMetaData(FormMetadata formMetaData)
+    public async Task UpdateFormMetaData(FormMetadata formMetaData)
     {
-        throw new NotImplementedException();
+        EnsureDirectoryCreated();
+
+        var metadataPath = GetMetaFilePath(formMetaData.FormId);
+        if (!File.Exists(metadataPath))
+            throw new FileNotFoundException($"Form metadata not found with id: {formMetaData.FormId}", metadataPath);
+
+        await SaveFormMetaData(formMetaData);
     }
 
     public Task DeleteFormMetaData(Guid formId)
     {
-        throw new NotImplementedException();
+        EnsureDirectoryCreated();
+
+        var metadataPath = GetMetaFilePath(formId);
+        if (File.Exists(metadataPath))
+            File.Delete(metadataPath);
+
+        // Zu einer Form gehörende Versionen werden gemeinsam mit dem Metadatensatz entfernt,
+        // damit kein verwaister Formularbestand im Dateisystem liegen bleibt.
+        foreach (var file in Directory.GetFiles(_basePath, GetFormSearchPattern(formId)))
+        {
+            File.Delete(file);
+        }
+
+        return Task.CompletedTask;
     }
 
     public async Task SaveForm(Form form)
@@ -78,33 +112,47 @@ public class FormStorage : IFormStorage
     public Task<Form> GetForm(Guid id)
     {
         EnsureDirectoryCreated();
-        var fullFileName = Directory.GetFiles(_basePath, $"*_{id}.json").SingleOrDefault();
+        var fullFileName = GetFormFilePath(id);
         if (string.IsNullOrEmpty(fullFileName))
-            throw new Exception("Form not found with id: " + id);
-        
+            throw new FileNotFoundException("Form not found with id: " + id);
+
         var data = File.ReadAllText(fullFileName);
         return Task.FromResult(JsonConvert.DeserializeObject<Form>(data, _storage.NewtonSoftDefaultSettings)!);
     }
 
-    public async Task<IEnumerable<Form>> GetForms(Guid formId)
+    public Task<IEnumerable<Form>> GetForms(Guid formId)
     {
         EnsureDirectoryCreated();
-        return Directory.GetFiles(_basePath, $"{formId}_*.json")
+        var forms = Directory.GetFiles(_basePath, GetFormSearchPattern(formId))
             .Select(filePath =>
             {
                 var data = File.ReadAllText(filePath);
                 return JsonConvert.DeserializeObject<Form>(data, _storage.NewtonSoftDefaultSettings)!;
             });
+
+        return Task.FromResult(forms);
     }
 
     public Task DeleteForm(Guid id)
     {
-        throw new NotImplementedException();
+        EnsureDirectoryCreated();
+
+        var fullFileName = GetFormFilePath(id);
+        if (!string.IsNullOrEmpty(fullFileName) && File.Exists(fullFileName))
+            File.Delete(fullFileName);
+
+        return Task.CompletedTask;
     }
 
     public async Task<Version> GetMaxVersion(Guid formId)
     {
-        var maxVersion = (await GetForms(formId)).Max(x => x.Version);
+        // Für den ersten Speichervorgang wird bewusst auf 0.0 zurückgefallen;
+        // die Business-Logik erhöht anschließend auf die erste fachliche Version.
+        var maxVersion = (await GetForms(formId))
+            .OrderByDescending(x => x.Version)
+            .Select(x => x.Version)
+            .FirstOrDefault();
+
         return maxVersion ?? new Version();
     }
 }

--- a/src/FilesystemStorageSystem/FormStorage.cs
+++ b/src/FilesystemStorageSystem/FormStorage.cs
@@ -67,9 +67,10 @@ public class FormStorage : IFormStorage
             {
                 var data = File.ReadAllText(filePath);
                 return JsonConvert.DeserializeObject<FormMetadata>(data, _storage.NewtonSoftDefaultSettings)!;
-            });
+            })
+            .ToList();
 
-        return Task.FromResult(metadatas);
+        return Task.FromResult<IEnumerable<FormMetadata>>(metadatas);
     }
 
     public async Task UpdateFormMetaData(FormMetadata formMetaData)
@@ -128,9 +129,10 @@ public class FormStorage : IFormStorage
             {
                 var data = File.ReadAllText(filePath);
                 return JsonConvert.DeserializeObject<Form>(data, _storage.NewtonSoftDefaultSettings)!;
-            });
+            })
+            .ToList();
 
-        return Task.FromResult(forms);
+        return Task.FromResult<IEnumerable<Form>>(forms);
     }
 
     public Task DeleteForm(Guid id)
@@ -148,11 +150,10 @@ public class FormStorage : IFormStorage
     {
         // Für den ersten Speichervorgang wird bewusst auf 0.0 zurückgefallen;
         // die Business-Logik erhöht anschließend auf die erste fachliche Version.
-        var maxVersion = (await GetForms(formId))
-            .OrderByDescending(x => x.Version)
-            .Select(x => x.Version)
-            .FirstOrDefault();
+        var forms = (await GetForms(formId)).ToList();
+        if (forms.Count == 0)
+            return new Version();
 
-        return maxVersion ?? new Version();
+        return forms.Max(x => x.Version) ?? new Version();
     }
 }

--- a/src/FlowzerFrontend.Tests/FlowzerApiOptionsTest.cs
+++ b/src/FlowzerFrontend.Tests/FlowzerApiOptionsTest.cs
@@ -120,6 +120,57 @@ public class FlowzerApiOptionsTest
         handler.LastRequestUri.Should().Be(new Uri($"http://localhost:5182/instance/{instanceId}/subscription/services"));
     }
 
+    [Test]
+    public async Task GetLatestForm_ShouldUseLatestFormRoute()
+    {
+        var formId = Guid.NewGuid();
+        var handler = new RecordingHttpMessageHandler(CreateApiStatusResultJson(new FormDto
+        {
+            Id = Guid.NewGuid(),
+            FormId = formId,
+            Version = new VersionDto(1, 2),
+            FormData = "{\"type\":\"form\"}"
+        }));
+
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost:5182/")
+        };
+
+        var api = new FlowzerApi(httpClient);
+
+        var result = await api.GetLatestForm(formId);
+
+        result.FormId.Should().Be(formId);
+        handler.LastRequestUri.Should().Be(new Uri($"http://localhost:5182/form/{formId}/latest"));
+    }
+
+    [Test]
+    public async Task GetForm_ShouldUseVersionedFormRoute()
+    {
+        var formId = Guid.NewGuid();
+        var version = new VersionDto(2, 1);
+        var handler = new RecordingHttpMessageHandler(CreateApiStatusResultJson(new FormDto
+        {
+            Id = Guid.NewGuid(),
+            FormId = formId,
+            Version = version,
+            FormData = "{\"type\":\"form\"}"
+        }));
+
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost:5182/")
+        };
+
+        var api = new FlowzerApi(httpClient);
+
+        var result = await api.GetForm(formId, version);
+
+        result.Version.Should().BeEquivalentTo(version);
+        handler.LastRequestUri.Should().Be(new Uri($"http://localhost:5182/form/{formId}/{version}"));
+    }
+
     private static string CreateApiStatusResultJson<T>(T result)
     {
         return System.Text.Json.JsonSerializer.Serialize(new ApiStatusResult<T>(result));

--- a/src/WebApiEngine.Tests/FormControllerIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/FormControllerIntegrationTest.cs
@@ -1,0 +1,276 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Model;
+using StorageSystem;
+using WebApiEngine.Shared;
+
+namespace WebApiEngine.Tests;
+
+public class FormControllerIntegrationTest
+{
+    [Test]
+    public async Task SaveForm_ShouldCreateInitialVersion_WhenNoVersionExists()
+    {
+        var storage = TestStorage.Create();
+        var formId = Guid.NewGuid();
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/form", new FormDto
+        {
+            FormId = formId,
+            FormData = "{\"type\":\"form\"}",
+            Version = new VersionDto()
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<FormDto>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeTrue();
+        payload.Result.Should().NotBeNull();
+        payload.Result!.Version.Major.Should().Be(0);
+        payload.Result.Version.Minor.Should().Be(1);
+        storage.FormStorageSeed.Forms.Should().ContainSingle(form =>
+            form.FormId == formId &&
+            form.Version.Major == 0 &&
+            form.Version.Minor == 1);
+    }
+
+    [Test]
+    public async Task GetForm_ShouldReturnSpecificVersion_WhenVersionIdentifierIsProvided()
+    {
+        var storage = TestStorage.Create();
+        var formId = Guid.NewGuid();
+        var oldForm = new Form
+        {
+            Id = Guid.NewGuid(),
+            FormId = formId,
+            Version = new Model.Version(1, 0),
+            FormData = "{\"version\":\"1.0\"}"
+        };
+        var newForm = new Form
+        {
+            Id = Guid.NewGuid(),
+            FormId = formId,
+            Version = new Model.Version(1, 1),
+            FormData = "{\"version\":\"1.1\"}"
+        };
+
+        storage.FormStorageSeed.FormMetadatas.Add(new FormMetadata { FormId = formId, Name = "Invoice" });
+        storage.FormStorageSeed.Forms.AddRange([oldForm, newForm]);
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync($"/form/{formId}/1.0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<FormDto>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeTrue();
+        payload.Result.Should().NotBeNull();
+        payload.Result!.Id.Should().Be(oldForm.Id);
+        payload.Result.FormData.Should().Be(oldForm.FormData);
+        payload.Result.Version.ToString().Should().Be("1.0");
+    }
+
+    [Test]
+    public async Task GetForm_ShouldReturnBadRequest_WhenVersionIdentifierIsInvalid()
+    {
+        var storage = TestStorage.Create();
+        var formId = Guid.NewGuid();
+        storage.FormStorageSeed.Forms.Add(new Form
+        {
+            Id = Guid.NewGuid(),
+            FormId = formId,
+            Version = new Model.Version(1, 0),
+            FormData = "{\"version\":\"1.0\"}"
+        });
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync($"/form/{formId}/invalid-version");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<FormDto>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeFalse();
+        payload.ErrorMessage.Should().Contain("Version string must have two parts separated by a dot.");
+    }
+
+    private sealed class TestWebApplicationFactory(TestStorage storage) : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IStorageSystem>();
+                services.RemoveAll<ITransactionalStorageProvider>();
+
+                services.AddSingleton<IStorageSystem>(storage);
+                services.AddSingleton<ITransactionalStorageProvider>(new TestTransactionalStorageProvider(storage));
+            });
+        }
+    }
+
+    private sealed class TestTransactionalStorageProvider(TestStorage storage) : ITransactionalStorageProvider
+    {
+        public ITransactionalStorage GetTransactionalStorage()
+        {
+            return storage;
+        }
+    }
+
+    private sealed class TestStorage(TestFormStorage formStorage) : ITransactionalStorage
+    {
+        public static TestStorage Create()
+        {
+            return new TestStorage(new TestFormStorage());
+        }
+
+        public TestFormStorage FormStorageSeed { get; } = formStorage;
+        public IDefinitionStorage DefinitionStorage { get; } = new NoOpDefinitionStorage();
+        public IMessageSubscriptionStorage SubscriptionStorage { get; } = new NoOpMessageSubscriptionStorage();
+        public IInstanceStorage InstanceStorage { get; } = new NoOpInstanceStorage();
+        public IFormStorage FormStorage { get; } = formStorage;
+
+        public void CommitChanges()
+        {
+        }
+
+        public void RollbackTransaction()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class TestFormStorage : IFormStorage
+    {
+        public List<FormMetadata> FormMetadatas { get; } = [];
+        public List<Form> Forms { get; } = [];
+
+        public Task SaveFormMetaData(FormMetadata formMetadata)
+        {
+            var existing = FormMetadatas.SingleOrDefault(metadata => metadata.FormId == formMetadata.FormId);
+            if (existing == null)
+            {
+                FormMetadatas.Add(formMetadata);
+            }
+            else
+            {
+                existing.Name = formMetadata.Name;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task<FormMetadata> GetFormMetaData(Guid formId)
+        {
+            var metadata = FormMetadatas.Single(metadata => metadata.FormId == formId);
+            return Task.FromResult(metadata);
+        }
+
+        public Task<IEnumerable<FormMetadata>> GetFormMetadatas()
+        {
+            return Task.FromResult(FormMetadatas.AsEnumerable());
+        }
+
+        public Task UpdateFormMetaData(FormMetadata formMetaData)
+        {
+            return SaveFormMetaData(formMetaData);
+        }
+
+        public Task DeleteFormMetaData(Guid formId)
+        {
+            FormMetadatas.RemoveAll(metadata => metadata.FormId == formId);
+            Forms.RemoveAll(form => form.FormId == formId);
+            return Task.CompletedTask;
+        }
+
+        public Task SaveForm(Form form)
+        {
+            Forms.Add(form);
+            return Task.CompletedTask;
+        }
+
+        public Task<Form> GetForm(Guid id)
+        {
+            return Task.FromResult(Forms.Single(form => form.Id == id));
+        }
+
+        public Task<IEnumerable<Form>> GetForms(Guid formId)
+        {
+            return Task.FromResult(Forms.Where(form => form.FormId == formId).AsEnumerable());
+        }
+
+        public Task DeleteForm(Guid id)
+        {
+            Forms.RemoveAll(form => form.Id == id);
+            return Task.CompletedTask;
+        }
+
+        public Task<Model.Version> GetMaxVersion(Guid formId)
+        {
+            var version = Forms
+                .Where(form => form.FormId == formId)
+                .OrderByDescending(form => form.Version)
+                .Select(form => form.Version)
+                .FirstOrDefault() ?? new Model.Version();
+
+            return Task.FromResult(version);
+        }
+    }
+
+    private sealed class NoOpDefinitionStorage : IDefinitionStorage
+    {
+        public Task<string> GetBinary(Guid guid) => throw new NotSupportedException();
+        public Task<Guid[]> GetAllBinaryDefinitions() => Task.FromResult(Array.Empty<Guid>());
+        public Task<BpmnDefinition[]> GetAllDefinitions() => Task.FromResult(Array.Empty<BpmnDefinition>());
+        public Task StoreDefinition(BpmnDefinition definition) => Task.CompletedTask;
+        public Task StoreBinary(Guid guid, string data) => Task.CompletedTask;
+        public Task<Model.Version?> GetMaxVersionId(string modelId) => Task.FromResult<Model.Version?>(null);
+        public Task<BpmnDefinition> GetDefinitionById(Guid id) => throw new NotSupportedException();
+        public Task<BpmnDefinition> GetLatestDefinition(string definitionId) => throw new NotSupportedException();
+        public Task<BpmnDefinition?> GetDeployedDefinition(string definitionDefinitionId) => Task.FromResult<BpmnDefinition?>(null);
+        public Task<ExtendedBpmnMetaDefinition[]> GetAllMetaDefinitions() => Task.FromResult(Array.Empty<ExtendedBpmnMetaDefinition>());
+        public Task StoreMetaDefinition(BpmnMetaDefinition metaDefinition) => Task.CompletedTask;
+        public Task UpdateMetaDefinition(BpmnMetaDefinition metaDefinition) => Task.CompletedTask;
+        public Task<BpmnMetaDefinition> GetMetaDefinitionById(string id) => throw new NotSupportedException();
+    }
+
+    private sealed class NoOpMessageSubscriptionStorage : IMessageSubscriptionStorage
+    {
+        public Task<IEnumerable<MessageSubscription>> GetAllMessageSubscriptions() => Task.FromResult(Enumerable.Empty<MessageSubscription>());
+        public Task<IEnumerable<MessageSubscription>> GetMessageSubscription(string messageName, string? correlationKey, Guid? messageInstanceId) => Task.FromResult(Enumerable.Empty<MessageSubscription>());
+        public Task<IEnumerable<MessageSubscription>> GetMessageSubscription(Guid instanceId) => Task.FromResult(Enumerable.Empty<MessageSubscription>());
+        public Task AddMessageSubscription(MessageSubscription messageSubscription) => Task.CompletedTask;
+        public Task RemoveProcessMessageSubscriptionsByProcessInstanceId(Guid instanceId) => Task.CompletedTask;
+        public Task RemoveAllProcessMessageSubscriptionsWithNoInstancedId(string metaDefinitionId) => Task.CompletedTask;
+        public Task RemoveAllProcessSignalSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
+        public void AddSignalSubscription(SignalSubscription signalSubscription) { }
+        public Task<IEnumerable<SignalSubscription>> GetSignalSubscriptions(Guid instanceId) => Task.FromResult(Enumerable.Empty<SignalSubscription>());
+        public void RemoveProcessSingalSubscriptionsByProcessInstanceId(Guid instanceId) { }
+        public Task<IEnumerable<UserTaskSubscription>> GetAllUserTasks(Guid instanceId) => Task.FromResult(Enumerable.Empty<UserTaskSubscription>());
+        public Task<IEnumerable<ExtendedUserTaskSubscription>> GetAllUserTasksExtended(Guid userId) => Task.FromResult(Enumerable.Empty<ExtendedUserTaskSubscription>());
+        public Task AddUserTaskSubscription(UserTaskSubscription userTasks) => Task.CompletedTask;
+        public Task RemoveUserTaskSubscription(Guid userTaskSubscriptionId) => Task.CompletedTask;
+        public void RemoveAllUserTaskSubscriptionsByInstanceId(Guid instanceId) { }
+        public Task RemoveAllUserTaskSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
+    }
+
+    private sealed class NoOpInstanceStorage : IInstanceStorage
+    {
+        public Task<ProcessInstanceInfo> GetProcessInstance(Guid processInstanceId) => throw new NotSupportedException();
+        public Task AddOrUpdateInstance(ProcessInstanceInfo processInstance) => Task.CompletedTask;
+        public Task<IEnumerable<ProcessInstanceInfo>> GetAllActiveInstances() => Task.FromResult(Enumerable.Empty<ProcessInstanceInfo>());
+    }
+}

--- a/src/WebApiEngine.Tests/FormStorageTest.cs
+++ b/src/WebApiEngine.Tests/FormStorageTest.cs
@@ -1,0 +1,128 @@
+using FilesystemStorageSystem;
+using FluentAssertions;
+using Model;
+
+namespace WebApiEngine.Tests;
+
+[NonParallelizable]
+public class FormStorageTest
+{
+    [Test]
+    public async Task GetMaxVersion_ShouldReturnZeroVersion_WhenNoFormsExist()
+    {
+        using var context = new FormStorageTestContext();
+
+        var version = await context.FormStorage.GetMaxVersion(context.FormId);
+
+        version.Major.Should().Be(0);
+        version.Minor.Should().Be(0);
+    }
+
+    [Test]
+    public async Task UpdateFormMetaData_ShouldOverwriteExistingMetadata()
+    {
+        using var context = new FormStorageTestContext();
+        await context.FormStorage.SaveFormMetaData(context.CreateMetadata("Alte Bezeichnung"));
+
+        await context.FormStorage.UpdateFormMetaData(context.CreateMetadata("Neue Bezeichnung"));
+        var metadata = await context.FormStorage.GetFormMetaData(context.FormId);
+
+        metadata.Name.Should().Be("Neue Bezeichnung");
+    }
+
+    [Test]
+    public async Task DeleteFormMetaData_ShouldDeleteMetadataAndAssociatedForms()
+    {
+        using var context = new FormStorageTestContext();
+        var firstForm = context.CreateForm(1, 0, "{\"version\":1}");
+        var secondForm = context.CreateForm(1, 1, "{\"version\":2}");
+
+        await context.FormStorage.SaveFormMetaData(context.CreateMetadata("Rechnung"));
+        await context.FormStorage.SaveForm(firstForm);
+        await context.FormStorage.SaveForm(secondForm);
+
+        await context.FormStorage.DeleteFormMetaData(context.FormId);
+
+        var metadatas = await context.FormStorage.GetFormMetadatas();
+        var forms = await context.FormStorage.GetForms(context.FormId);
+
+        metadatas.Should().NotContain(metadata => metadata.FormId == context.FormId);
+        forms.Should().BeEmpty();
+        await FluentActions.Awaiting(() => context.FormStorage.GetForm(firstForm.Id)).Should().ThrowAsync<FileNotFoundException>();
+    }
+
+    [Test]
+    public async Task DeleteForm_ShouldDeleteOnlyRequestedVersion()
+    {
+        using var context = new FormStorageTestContext();
+        var firstForm = context.CreateForm(1, 0, "{\"version\":1}");
+        var secondForm = context.CreateForm(1, 1, "{\"version\":2}");
+
+        await context.FormStorage.SaveForm(firstForm);
+        await context.FormStorage.SaveForm(secondForm);
+
+        await context.FormStorage.DeleteForm(firstForm.Id);
+        var forms = (await context.FormStorage.GetForms(context.FormId)).ToList();
+
+        forms.Should().ContainSingle();
+        forms[0].Id.Should().Be(secondForm.Id);
+        forms[0].Version.ToString().Should().Be("1.1");
+    }
+
+    private sealed class FormStorageTestContext : IDisposable
+    {
+        private readonly string _formsPath;
+        private readonly string _metaPath;
+
+        public FormStorageTestContext()
+        {
+            Storage = new Storage();
+            FormStorage = Storage.FormStorage;
+            FormId = Guid.NewGuid();
+            _formsPath = Storage.GetBasePath("FileStorage/Forms");
+            _metaPath = Storage.GetBasePath("FileStorage/Forms/Meta");
+            Cleanup();
+        }
+
+        public Storage Storage { get; }
+        public StorageSystem.IFormStorage FormStorage { get; }
+        public Guid FormId { get; }
+
+        public FormMetadata CreateMetadata(string name)
+        {
+            return new FormMetadata
+            {
+                FormId = FormId,
+                Name = name
+            };
+        }
+
+        public Form CreateForm(int major, int minor, string formData)
+        {
+            return new Form
+            {
+                Id = Guid.NewGuid(),
+                FormId = FormId,
+                Version = new Model.Version(major, minor),
+                FormData = formData
+            };
+        }
+
+        public void Dispose()
+        {
+            Cleanup();
+        }
+
+        private void Cleanup()
+        {
+            var metadataPath = Path.Combine(_metaPath, $"{FormId}.json");
+            if (File.Exists(metadataPath))
+                File.Delete(metadataPath);
+
+            foreach (var file in Directory.GetFiles(_formsPath, $"{FormId}_*.json"))
+            {
+                File.Delete(file);
+            }
+        }
+    }
+}

--- a/src/WebApiEngine.Tests/ModelVersionTest.cs
+++ b/src/WebApiEngine.Tests/ModelVersionTest.cs
@@ -17,4 +17,16 @@ public class ModelVersionTest
         left.Equals(equalRight).Should().BeTrue();
         left.GetHashCode().Should().Be(equalRight.GetHashCode());
     }
+
+    [Test]
+    public void PlusOperator_ShouldReturnNewInstance_WithoutMutatingOriginalVersion()
+    {
+        var original = new Model.Version(2, 4);
+
+        var incremented = original + 1;
+
+        original.ToString().Should().Be("2.4");
+        incremented.ToString().Should().Be("2.5");
+        incremented.Should().NotBeSameAs(original);
+    }
 }

--- a/src/WebApiEngine.Tests/ModelVersionTest.cs
+++ b/src/WebApiEngine.Tests/ModelVersionTest.cs
@@ -1,0 +1,20 @@
+using FluentAssertions;
+
+namespace WebApiEngine.Tests;
+
+public class ModelVersionTest
+{
+    [Test]
+    public void EqualityOperators_ShouldCompareMajorAndMinorValues()
+    {
+        var left = new Model.Version(1, 2);
+        var equalRight = new Model.Version(1, 2);
+        var differentRight = new Model.Version(1, 3);
+
+        (left == equalRight).Should().BeTrue();
+        (left != equalRight).Should().BeFalse();
+        (left == differentRight).Should().BeFalse();
+        left.Equals(equalRight).Should().BeTrue();
+        left.GetHashCode().Should().Be(equalRight.GetHashCode());
+    }
+}

--- a/src/WebApiEngine.Tests/WebApiEngine.Tests.csproj
+++ b/src/WebApiEngine.Tests/WebApiEngine.Tests.csproj
@@ -23,6 +23,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\FilesystemStorageSystem\FilesystemStorageSystem.csproj" />
         <ProjectReference Include="..\WebApiEngine\WebApiEngine.csproj" />
     </ItemGroup>
 

--- a/src/WebApiEngine/Controller/FormController.cs
+++ b/src/WebApiEngine/Controller/FormController.cs
@@ -50,11 +50,29 @@ public class FormController(
         }
         else
         {
-            var versionFromFormIdentifier = Model.Version.FromString(formIdentifier);
-            var foundVersion =  allVersions.SingleOrDefault(x => x.Version == versionFromFormIdentifier);
+            Model.Version versionFromFormIdentifier;
+            try
+            {
+                versionFromFormIdentifier = Model.Version.FromString(formIdentifier);
+            }
+            catch (ArgumentException e)
+            {
+                return BadRequest(new ApiStatusResult<FormDto>()
+                {
+                    Successful = false,
+                    ErrorMessage = e.Message
+                });
+            }
+
+            // Der API-Pfad arbeitet mit der stabilen FormId, gespeichert werden die Versionen aber
+            // unter ihrer konkreten Formular-Instanz-ID. Deshalb wird hier zuerst die Zielversion aufgelöst.
+            var foundVersion =  allVersions.SingleOrDefault(x => x.Version.Equals(versionFromFormIdentifier));
             if (foundVersion == null)
                 return NotFound(new ApiStatusResult<FormDto>(){Successful = false, ErrorMessage = "Version not found"});
+
+            formId = foundVersion.Id;
         }
+
         var formMetaData = await storageSystem.FormStorage.GetForm(formId);
         return Ok(new ApiStatusResult<FormDto>(formMetaData.ToDto()));
     }

--- a/src/WebApiEngine/Controller/FormController.cs
+++ b/src/WebApiEngine/Controller/FormController.cs
@@ -57,11 +57,7 @@ public class FormController(
             }
             catch (ArgumentException e)
             {
-                return BadRequest(new ApiStatusResult<FormDto>()
-                {
-                    Successful = false,
-                    ErrorMessage = e.Message
-                });
+                return BadRequest(new ApiStatusResult<FormDto>(e.Message));
             }
 
             // Der API-Pfad arbeitet mit der stabilen FormId, gespeichert werden die Versionen aber


### PR DESCRIPTION
## Zusammenfassung

Dieser PR härtet den Formularpfad von Storage über Web-API bis in die Frontend-API-Anbindung.

## Änderungen

- `FormStorage` vollständig für Update-, Delete- und Max-Version-Fälle implementiert
- Wertobjekt-Semantik für `Model.Version` ergänzt, damit Versionsvergleiche fachlich korrekt funktionieren
- Formularabruf im `FormController` für konkrete Versionen korrigiert
- `BadRequest` für ungültige Versionsstrings ergänzt
- neue API- und Storage-Tests für Formularversionen, Metadaten und Löschpfade ergänzt
- Frontend-API-Tests für Formularrouten ergänzt

## Tests

- `dotnet build core-engine.sln --configuration Release --no-restore`
- `dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-restore --logger 'console;verbosity=minimal'`
- `dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-restore --logger 'console;verbosity=minimal'`
- `dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-restore --logger 'console;verbosity=minimal'`
- `cd tests/ui-smoke && npm ci && CI=1 npm test`

Closes #48
