### PR TITLE
Web-API für Health, Fehlerverträge und User-Kontext härten

### DIFF
--- a/src/WebApiEngine.Shared/HealthStatusDto.cs
+++ b/src/WebApiEngine.Shared/HealthStatusDto.cs
@@ -1,0 +1,9 @@
+namespace WebApiEngine.Shared;
+
+public class HealthStatusDto
+{
+    public required string Status { get; set; }
+    public required DateTime CheckedAtUtc { get; set; }
+    public required string Environment { get; set; }
+    public required string Storage { get; set; }
+}

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -1,0 +1,404 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Model;
+using StorageSystem;
+using WebApiEngine.Auth;
+using WebApiEngine.Shared;
+
+namespace WebApiEngine.Tests;
+
+public class ApiHardeningIntegrationTest
+{
+    [Test]
+    public async Task Health_ShouldReturnSuccessfulLivenessPayload()
+    {
+        var storage = new TestStorage();
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/health");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<HealthStatusDto>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeTrue();
+        payload.Result.Should().NotBeNull();
+        payload.Result!.Status.Should().Be("Healthy");
+        payload.Result.Storage.Should().Be("NotChecked");
+    }
+
+    [Test]
+    public async Task ReadyHealth_ShouldReturnServiceUnavailable_WhenStorageProbeFails()
+    {
+        var storage = new TestStorage
+        {
+            ThrowOnGetAllDefinitions = true
+        };
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/health/ready");
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<HealthStatusDto>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeFalse();
+        payload.Result.Should().NotBeNull();
+        payload.Result!.Status.Should().Be("Unhealthy");
+        payload.Result.Storage.Should().Be("Unavailable");
+        payload.ErrorMessage.Should().Contain("Storage is unavailable");
+    }
+
+    [Test]
+    public async Task UploadDefinition_ShouldUseTechnicalUserHeader_WhenNoAuthenticationExistsYet()
+    {
+        var storage = new TestStorage();
+        var expectedUserId = Guid.NewGuid();
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(HttpContextCurrentUserContextAccessor.UserIdHeaderName, expectedUserId.ToString());
+
+        var xml = """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+                    <bpmn:process id="Process_Invoice" isExecutable="true" />
+                  </bpmn:definitions>
+                  """;
+
+        var response = await client.PostAsync("/definition", new StringContent(xml));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<BpmnDefinitionDto>();
+        payload.Should().NotBeNull();
+        payload!.SavedByUser.Should().Be(expectedUserId);
+        storage.StoredDefinitions.Should().ContainSingle();
+        storage.StoredDefinitions[0].SavedByUser.Should().Be(expectedUserId);
+    }
+
+    [Test]
+    public async Task GetAllUserTasks_ShouldUseFallbackUserId_WhenNoAuthenticationDataIsPresent()
+    {
+        var storage = new TestStorage();
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/usertask");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        storage.LastRequestedExtendedUserTaskUserId.Should().Be(HttpContextCurrentUserContextAccessor.FallbackUserId);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<ExtendedUserTaskSubscriptionDto[]>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeTrue();
+        payload.Result.Should().NotBeNull();
+        payload.Result.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task MissingFormMetadata_ShouldReturnJsonApiContract_WhenControllerThrowsFileNotFound()
+    {
+        var storage = new TestStorage
+        {
+            ThrowOnGetFormMetadata = true
+        };
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync($"/form/meta/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<FormMetaDataDto>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeFalse();
+        payload.ErrorMessage.Should().Contain("Form metadata was not found");
+    }
+
+    [Test]
+    public async Task MessageEndpoint_ShouldReturnApiStatusResult_WhenNoSubscriptionMatches()
+    {
+        var storage = new TestStorage();
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/message", new MessageDto
+        {
+            Name = "InvoiceReceived",
+            CorrelationKey = "INV-1000"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<string>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeFalse();
+        payload.ErrorMessage.Should().Contain("No process instance is waiting for a message");
+    }
+
+    private sealed class TestWebApplicationFactory(TestStorage storage) : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IStorageSystem>();
+                services.RemoveAll<ITransactionalStorageProvider>();
+
+                services.AddSingleton<IStorageSystem>(storage);
+                services.AddSingleton<ITransactionalStorageProvider>(new TestTransactionalStorageProvider(storage));
+            });
+        }
+    }
+
+    private sealed class TestTransactionalStorageProvider(TestStorage storage) : ITransactionalStorageProvider
+    {
+        public ITransactionalStorage GetTransactionalStorage()
+        {
+            return storage;
+        }
+    }
+
+    private sealed class TestStorage : ITransactionalStorage
+    {
+        public bool ThrowOnGetAllDefinitions { get; set; }
+        public bool ThrowOnGetFormMetadata { get; set; }
+        public Guid? LastRequestedExtendedUserTaskUserId { get; set; }
+        public List<BpmnDefinition> StoredDefinitions { get; } = [];
+        public Dictionary<Guid, string> StoredBinaries { get; } = [];
+
+        public IDefinitionStorage DefinitionStorage => new TestDefinitionStorage(this);
+        public IMessageSubscriptionStorage SubscriptionStorage => new TestSubscriptionStorage(this);
+        public IInstanceStorage InstanceStorage { get; } = new TestInstanceStorage();
+        public IFormStorage FormStorage => new TestFormStorage(this);
+
+        public void CommitChanges()
+        {
+        }
+
+        public void RollbackTransaction()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class TestDefinitionStorage(TestStorage storage) : IDefinitionStorage
+    {
+        public Task StoreBinary(Guid guid, string data)
+        {
+            storage.StoredBinaries[guid] = data;
+            return Task.CompletedTask;
+        }
+
+        public Task<string> GetBinary(Guid guid)
+        {
+            if (storage.StoredBinaries.TryGetValue(guid, out var data))
+            {
+                return Task.FromResult(data);
+            }
+
+            throw new FileNotFoundException($"Binary definition {guid} was not found.");
+        }
+
+        public Task<Guid[]> GetAllBinaryDefinitions()
+        {
+            return Task.FromResult(storage.StoredDefinitions.Select(definition => definition.Id).ToArray());
+        }
+
+        public Task<BpmnDefinition[]> GetAllDefinitions()
+        {
+            if (storage.ThrowOnGetAllDefinitions)
+            {
+                throw new IOException("Definitions directory is currently unavailable.");
+            }
+
+            return Task.FromResult(storage.StoredDefinitions.ToArray());
+        }
+
+        public Task StoreDefinition(BpmnDefinition definition)
+        {
+            storage.StoredDefinitions.RemoveAll(existing => existing.Id == definition.Id);
+            storage.StoredDefinitions.Add(definition);
+            return Task.CompletedTask;
+        }
+
+        public Task<Model.Version?> GetMaxVersionId(string modelId)
+        {
+            var version = storage.StoredDefinitions
+                .Where(definition => definition.DefinitionId == modelId)
+                .OrderByDescending(definition => definition.Version)
+                .Select(definition => definition.Version)
+                .Cast<Model.Version?>()
+                .FirstOrDefault();
+
+            return Task.FromResult(version);
+        }
+
+        public Task<BpmnDefinition> GetDefinitionById(Guid id)
+        {
+            var definition = storage.StoredDefinitions.SingleOrDefault(existing => existing.Id == id)
+                             ?? throw new FileNotFoundException($"Definition {id} was not found.");
+
+            return Task.FromResult(definition);
+        }
+
+        public Task<BpmnDefinition> GetLatestDefinition(string definitionId)
+        {
+            var definition = storage.StoredDefinitions
+                .Where(existing => existing.DefinitionId == definitionId)
+                .OrderByDescending(existing => existing.Version)
+                .FirstOrDefault()
+                             ?? throw new FileNotFoundException($"Latest definition for {definitionId} was not found.");
+
+            return Task.FromResult(definition);
+        }
+
+        public Task<BpmnDefinition?> GetDeployedDefinition(string definitionDefinitionId)
+        {
+            var definition = storage.StoredDefinitions
+                .SingleOrDefault(existing => existing.DefinitionId == definitionDefinitionId && existing.IsActive);
+
+            return Task.FromResult(definition);
+        }
+
+        public Task<ExtendedBpmnMetaDefinition[]> GetAllMetaDefinitions()
+        {
+            return Task.FromResult(Array.Empty<ExtendedBpmnMetaDefinition>());
+        }
+
+        public Task StoreMetaDefinition(BpmnMetaDefinition metaDefinition)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task UpdateMetaDefinition(BpmnMetaDefinition metaDefinition)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task<BpmnMetaDefinition> GetMetaDefinitionById(string id)
+        {
+            throw new FileNotFoundException($"Meta definition {id} was not found.");
+        }
+    }
+
+    private sealed class TestSubscriptionStorage(TestStorage storage) : IMessageSubscriptionStorage
+    {
+        public Task<IEnumerable<MessageSubscription>> GetAllMessageSubscriptions() =>
+            Task.FromResult(Enumerable.Empty<MessageSubscription>());
+
+        public Task<IEnumerable<MessageSubscription>> GetMessageSubscription(string messageName, string? correlationKey, Guid? messageInstanceId) =>
+            Task.FromResult(Enumerable.Empty<MessageSubscription>());
+
+        public Task<IEnumerable<MessageSubscription>> GetMessageSubscription(Guid instanceId) =>
+            Task.FromResult(Enumerable.Empty<MessageSubscription>());
+
+        public Task AddMessageSubscription(MessageSubscription messageSubscription) => Task.CompletedTask;
+
+        public Task RemoveProcessMessageSubscriptionsByProcessInstanceId(Guid instanceId) => Task.CompletedTask;
+
+        public Task RemoveAllProcessMessageSubscriptionsWithNoInstancedId(string metaDefinitionId) => Task.CompletedTask;
+
+        public Task RemoveAllProcessSignalSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
+
+        public void AddSignalSubscription(SignalSubscription signalSubscription)
+        {
+        }
+
+        public Task<IEnumerable<SignalSubscription>> GetSignalSubscriptions(Guid instanceId) =>
+            Task.FromResult(Enumerable.Empty<SignalSubscription>());
+
+        public void RemoveProcessSingalSubscriptionsByProcessInstanceId(Guid instanceId)
+        {
+        }
+
+        public Task<IEnumerable<UserTaskSubscription>> GetAllUserTasks(Guid instanceId) =>
+            Task.FromResult(Enumerable.Empty<UserTaskSubscription>());
+
+        public Task<IEnumerable<ExtendedUserTaskSubscription>> GetAllUserTasksExtended(Guid userId)
+        {
+            storage.LastRequestedExtendedUserTaskUserId = userId;
+            return Task.FromResult(Enumerable.Empty<ExtendedUserTaskSubscription>());
+        }
+
+        public Task AddUserTaskSubscription(UserTaskSubscription userTasks) => Task.CompletedTask;
+
+        public Task RemoveUserTaskSubscription(Guid userTaskSubscriptionId) => Task.CompletedTask;
+
+        public void RemoveAllUserTaskSubscriptionsByInstanceId(Guid instanceId)
+        {
+        }
+
+        public Task RemoveAllUserTaskSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
+    }
+
+    private sealed class TestInstanceStorage : IInstanceStorage
+    {
+        public Task<ProcessInstanceInfo> GetProcessInstance(Guid processInstanceId)
+        {
+            throw new FileNotFoundException($"Process instance {processInstanceId} was not found.");
+        }
+
+        public Task AddOrUpdateInstance(ProcessInstanceInfo processInstanceInfo)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task<IEnumerable<ProcessInstanceInfo>> GetAllActiveInstances()
+        {
+            return Task.FromResult(Enumerable.Empty<ProcessInstanceInfo>());
+        }
+    }
+
+    private sealed class TestFormStorage(TestStorage storage) : IFormStorage
+    {
+        public Task SaveFormMetaData(FormMetadata formMetadata) => Task.CompletedTask;
+
+        public Task<FormMetadata> GetFormMetaData(Guid formId)
+        {
+            if (storage.ThrowOnGetFormMetadata)
+            {
+                throw new FileNotFoundException($"Form metadata was not found for {formId}.");
+            }
+
+            throw new NotImplementedException();
+        }
+
+        public Task<IEnumerable<FormMetadata>> GetFormMetadatas()
+        {
+            return Task.FromResult(Enumerable.Empty<FormMetadata>());
+        }
+
+        public Task UpdateFormMetaData(FormMetadata formMetaData) => Task.CompletedTask;
+
+        public Task DeleteFormMetaData(Guid formId) => Task.CompletedTask;
+
+        public Task SaveForm(Form form) => Task.CompletedTask;
+
+        public Task<Form> GetForm(Guid id)
+        {
+            throw new FileNotFoundException($"Form {id} was not found.");
+        }
+
+        public Task<IEnumerable<Form>> GetForms(Guid formId)
+        {
+            return Task.FromResult(Enumerable.Empty<Form>());
+        }
+
+        public Task DeleteForm(Guid id) => Task.CompletedTask;
+
+        public Task<Model.Version> GetMaxVersion(Guid formId)
+        {
+            return Task.FromResult(new Model.Version());
+        }
+    }
+}

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -1,6 +1,9 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
 using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -52,7 +55,7 @@ public class ApiHardeningIntegrationTest
         payload.Result.Should().NotBeNull();
         payload.Result!.Status.Should().Be("Unhealthy");
         payload.Result.Storage.Should().Be("Unavailable");
-        payload.ErrorMessage.Should().Contain("Storage is unavailable");
+        payload.ErrorMessage.Should().Be("Storage is unavailable.");
     }
 
     [Test]
@@ -78,6 +81,7 @@ public class ApiHardeningIntegrationTest
         var payload = await response.Content.ReadFromJsonAsync<BpmnDefinitionDto>();
         payload.Should().NotBeNull();
         payload!.SavedByUser.Should().Be(expectedUserId);
+        payload.Hash.Should().Be(Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(xml))));
         storage.StoredDefinitions.Should().ContainSingle();
         storage.StoredDefinitions[0].SavedByUser.Should().Be(expectedUserId);
     }
@@ -146,6 +150,7 @@ public class ApiHardeningIntegrationTest
     {
         protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
         {
+            builder.UseSetting(WebHostDefaults.EnvironmentKey, "Development");
             builder.ConfigureServices(services =>
             {
                 services.RemoveAll<IStorageSystem>();

--- a/src/WebApiEngine/Auth/CurrentUserContext.cs
+++ b/src/WebApiEngine/Auth/CurrentUserContext.cs
@@ -1,0 +1,12 @@
+namespace WebApiEngine.Auth;
+
+/// <summary>
+/// Kapselt den aktuell aufgelösten Benutzerkontext der API.
+/// Solange noch keine vollständige Authentifizierung aktiv ist, kann die API
+/// damit sauber zwischen Header-/Claim-basierten Benutzern und einem
+/// kontrollierten System-Fallback unterscheiden.
+/// </summary>
+public sealed record CurrentUserContext(
+    Guid UserId,
+    string Source,
+    bool IsFallback);

--- a/src/WebApiEngine/Auth/HttpContextCurrentUserContextAccessor.cs
+++ b/src/WebApiEngine/Auth/HttpContextCurrentUserContextAccessor.cs
@@ -1,14 +1,18 @@
 using System.Security.Claims;
+using Microsoft.Extensions.Hosting;
 
 namespace WebApiEngine.Auth;
 
 /// <summary>
 /// Liest den aktuellen Benutzerkontext bevorzugt aus Auth-Claims und erlaubt
-/// als Übergangslösung zusätzlich einen technischen Header. Fehlt beides,
+/// im Development-Modus zusätzlich einen technischen Header. Fehlt beides,
 /// wird ein stabiler Systembenutzer zurückgegeben, sodass die restliche API
-/// keine Guid.Empty-/Magic-Value-Platzhalter mehr benötigt.
+/// keine Guid.Empty-/Magic-Value-Platzhalter mehr benötigt und in Produktion
+/// kein frei setzbarer Impersonation-Header akzeptiert wird.
 /// </summary>
-public sealed class HttpContextCurrentUserContextAccessor(IHttpContextAccessor httpContextAccessor)
+public sealed class HttpContextCurrentUserContextAccessor(
+    IHttpContextAccessor httpContextAccessor,
+    IHostEnvironment hostEnvironment)
     : ICurrentUserContextAccessor
 {
     public const string UserIdHeaderName = "X-Flowzer-UserId";
@@ -28,7 +32,7 @@ public sealed class HttpContextCurrentUserContextAccessor(IHttpContextAccessor h
         }
 
         var headerValue = httpContext?.Request.Headers[UserIdHeaderName].FirstOrDefault();
-        if (Guid.TryParse(headerValue, out var headerUserId))
+        if (hostEnvironment.IsDevelopment() && Guid.TryParse(headerValue, out var headerUserId))
         {
             return new CurrentUserContext(headerUserId, "header:x-flowzer-userid", false);
         }

--- a/src/WebApiEngine/Auth/HttpContextCurrentUserContextAccessor.cs
+++ b/src/WebApiEngine/Auth/HttpContextCurrentUserContextAccessor.cs
@@ -1,0 +1,52 @@
+using System.Security.Claims;
+
+namespace WebApiEngine.Auth;
+
+/// <summary>
+/// Liest den aktuellen Benutzerkontext bevorzugt aus Auth-Claims und erlaubt
+/// als Übergangslösung zusätzlich einen technischen Header. Fehlt beides,
+/// wird ein stabiler Systembenutzer zurückgegeben, sodass die restliche API
+/// keine Guid.Empty-/Magic-Value-Platzhalter mehr benötigt.
+/// </summary>
+public sealed class HttpContextCurrentUserContextAccessor(IHttpContextAccessor httpContextAccessor)
+    : ICurrentUserContextAccessor
+{
+    public const string UserIdHeaderName = "X-Flowzer-UserId";
+    public static readonly Guid FallbackUserId = Guid.Parse("D266F2B6-E96E-4D4A-9C20-C8E541394DF0");
+
+    public CurrentUserContext GetCurrentUser()
+    {
+        var httpContext = httpContextAccessor.HttpContext;
+        var user = httpContext?.User;
+
+        var claimBasedUser = TryResolveClaim(user, ClaimTypes.NameIdentifier, "claim:nameidentifier")
+                             ?? TryResolveClaim(user, "sub", "claim:sub")
+                             ?? TryResolveClaim(user, "oid", "claim:oid");
+        if (claimBasedUser is not null)
+        {
+            return claimBasedUser;
+        }
+
+        var headerValue = httpContext?.Request.Headers[UserIdHeaderName].FirstOrDefault();
+        if (Guid.TryParse(headerValue, out var headerUserId))
+        {
+            return new CurrentUserContext(headerUserId, "header:x-flowzer-userid", false);
+        }
+
+        return new CurrentUserContext(FallbackUserId, "fallback:system-user", true);
+    }
+
+    private static CurrentUserContext? TryResolveClaim(
+        ClaimsPrincipal? user,
+        string claimType,
+        string source)
+    {
+        var claimValue = user?.FindFirstValue(claimType);
+        if (!Guid.TryParse(claimValue, out var userId))
+        {
+            return null;
+        }
+
+        return new CurrentUserContext(userId, source, false);
+    }
+}

--- a/src/WebApiEngine/Auth/ICurrentUserContextAccessor.cs
+++ b/src/WebApiEngine/Auth/ICurrentUserContextAccessor.cs
@@ -1,0 +1,6 @@
+namespace WebApiEngine.Auth;
+
+public interface ICurrentUserContextAccessor
+{
+    CurrentUserContext GetCurrentUser();
+}

--- a/src/WebApiEngine/BusinessLogic/DefinitionBusinessLogic.cs
+++ b/src/WebApiEngine/BusinessLogic/DefinitionBusinessLogic.cs
@@ -1,11 +1,14 @@
 using BPMN.Infrastructure;
 using core_engine;
 using Model;
+using WebApiEngine.Auth;
 using Version = Model.Version;
 
 namespace WebApiEngine.BusinessLogic;
 
-public class DefinitionBusinessLogic(IStorageSystem storageSystem)
+public class DefinitionBusinessLogic(
+    IStorageSystem storageSystem,
+    ICurrentUserContextAccessor currentUserContextAccessor)
 {
     
     public async Task<BpmnDefinition> StoreDefinition(string rawContent, Guid? previousGuid, bool deploy = false)
@@ -33,13 +36,15 @@ public class DefinitionBusinessLogic(IStorageSystem storageSystem)
     
         
                 
+        var currentUser = currentUserContextAccessor.GetCurrentUser();
+
         var definition = new BpmnDefinition()
         {
             Id = Guid.NewGuid(),
             DefinitionId = model.Id,
             PreviousGuid = previousGuid,
             Hash = rawContent.GetHashCode().ToString(),
-            SavedByUser = Guid.Parse("D266F2B6-E96E-4D4A-9C20-C8E541394DF0"), // User.Claims["guid"] or something like that
+            SavedByUser = currentUser.UserId,
             SavedOn = DateTime.UtcNow,
             Version = highestVersion,
             IsActive = false

--- a/src/WebApiEngine/BusinessLogic/DefinitionBusinessLogic.cs
+++ b/src/WebApiEngine/BusinessLogic/DefinitionBusinessLogic.cs
@@ -1,6 +1,8 @@
 using BPMN.Infrastructure;
 using core_engine;
 using Model;
+using System.Security.Cryptography;
+using System.Text;
 using WebApiEngine.Auth;
 using Version = Model.Version;
 
@@ -43,7 +45,7 @@ public class DefinitionBusinessLogic(
             Id = Guid.NewGuid(),
             DefinitionId = model.Id,
             PreviousGuid = previousGuid,
-            Hash = rawContent.GetHashCode().ToString(),
+            Hash = ComputeStableHash(rawContent),
             SavedByUser = currentUser.UserId,
             SavedOn = DateTime.UtcNow,
             Version = highestVersion,
@@ -54,5 +56,12 @@ public class DefinitionBusinessLogic(
         await storageSystem.DefinitionStorage.StoreBinary(definition.Id, rawContent);
 
         return definition;
+    }
+
+    private static string ComputeStableHash(string rawContent)
+    {
+        var contentBytes = Encoding.UTF8.GetBytes(rawContent);
+        var hashBytes = SHA256.HashData(contentBytes);
+        return Convert.ToHexString(hashBytes);
     }
 }

--- a/src/WebApiEngine/Controller/FormController.cs
+++ b/src/WebApiEngine/Controller/FormController.cs
@@ -1,6 +1,7 @@
 using WebApiEngine.BusinessLogic;
 using WebApiEngine.Mappers;
 using WebApiEngine.Shared;
+using WebApiEngine.Auth;
 
 namespace WebApiEngine.Controller;
 
@@ -8,7 +9,8 @@ namespace WebApiEngine.Controller;
 public class FormController(
     IStorageSystem storageSystem,
     FormBusinessLogic formBusinessLogic,
-    BpmnBusinessLogic bpmnBusinessLogic): ControllerBase
+    BpmnBusinessLogic bpmnBusinessLogic,
+    ICurrentUserContextAccessor currentUserContextAccessor): ControllerBase
 {
 
     [HttpPost()]
@@ -117,7 +119,8 @@ public class FormController(
         try
         {
             var data = formMetadataDto.ToModel();
-            await bpmnBusinessLogic.HandleUserTask(data, Guid.Empty);
+            var currentUser = currentUserContextAccessor.GetCurrentUser();
+            await bpmnBusinessLogic.HandleUserTask(data, currentUser.UserId);
             return Ok(new ApiStatusResult() {Successful = true});
         }
         catch (Exception e)

--- a/src/WebApiEngine/Controller/HealthController.cs
+++ b/src/WebApiEngine/Controller/HealthController.cs
@@ -1,0 +1,60 @@
+using WebApiEngine.Shared;
+
+namespace WebApiEngine.Controller;
+
+[ApiController, Route("[controller]")]
+public class HealthController(
+    ITransactionalStorageProvider storageProvider,
+    IHostEnvironment environment) : ControllerBase
+{
+    [HttpGet]
+    public ActionResult<ApiStatusResult<HealthStatusDto>> GetLiveness()
+    {
+        var payload = new HealthStatusDto
+        {
+            Status = "Healthy",
+            CheckedAtUtc = DateTime.UtcNow,
+            Environment = environment.EnvironmentName,
+            Storage = "NotChecked"
+        };
+
+        return Ok(new ApiStatusResult<HealthStatusDto>(payload));
+    }
+
+    [HttpGet("ready")]
+    public async Task<ActionResult<ApiStatusResult<HealthStatusDto>>> GetReadiness()
+    {
+        try
+        {
+            using var storage = storageProvider.GetTransactionalStorage();
+            _ = await storage.DefinitionStorage.GetAllDefinitions();
+
+            var payload = new HealthStatusDto
+            {
+                Status = "Healthy",
+                CheckedAtUtc = DateTime.UtcNow,
+                Environment = environment.EnvironmentName,
+                Storage = "Ready"
+            };
+
+            return Ok(new ApiStatusResult<HealthStatusDto>(payload));
+        }
+        catch (Exception exception)
+        {
+            var payload = new HealthStatusDto
+            {
+                Status = "Unhealthy",
+                CheckedAtUtc = DateTime.UtcNow,
+                Environment = environment.EnvironmentName,
+                Storage = "Unavailable"
+            };
+
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new ApiStatusResult<HealthStatusDto>
+            {
+                Successful = false,
+                ErrorMessage = $"Storage is unavailable: {exception.Message}",
+                Result = payload
+            });
+        }
+    }
+}

--- a/src/WebApiEngine/Controller/HealthController.cs
+++ b/src/WebApiEngine/Controller/HealthController.cs
@@ -5,7 +5,8 @@ namespace WebApiEngine.Controller;
 [ApiController, Route("[controller]")]
 public class HealthController(
     ITransactionalStorageProvider storageProvider,
-    IHostEnvironment environment) : ControllerBase
+    IHostEnvironment environment,
+    ILogger<HealthController> logger) : ControllerBase
 {
     [HttpGet]
     public ActionResult<ApiStatusResult<HealthStatusDto>> GetLiveness()
@@ -41,6 +42,7 @@ public class HealthController(
         }
         catch (Exception exception)
         {
+            logger.LogWarning(exception, "Readiness probe failed because the storage backend is currently unavailable.");
             var payload = new HealthStatusDto
             {
                 Status = "Unhealthy",
@@ -52,7 +54,7 @@ public class HealthController(
             return StatusCode(StatusCodes.Status503ServiceUnavailable, new ApiStatusResult<HealthStatusDto>
             {
                 Successful = false,
-                ErrorMessage = $"Storage is unavailable: {exception.Message}",
+                ErrorMessage = "Storage is unavailable.",
                 Result = payload
             });
         }

--- a/src/WebApiEngine/Controller/MessageController.cs
+++ b/src/WebApiEngine/Controller/MessageController.cs
@@ -24,7 +24,7 @@ public class MessageController(IStorageSystem storageSystem,
         }
         catch (Exception e)
         {
-            return BadRequest(new ApiStatusResult<string>(e.Message));
+            return BadRequest(new ApiStatusResult<string>(errorMessage: e.Message));
         }
         string correlationText = "";
         if (messageDto.CorrelationKey != null)

--- a/src/WebApiEngine/Controller/MessageController.cs
+++ b/src/WebApiEngine/Controller/MessageController.cs
@@ -15,7 +15,7 @@ public class MessageController(IStorageSystem storageSystem,
     }
 
     [HttpPost]
-    public async Task<IActionResult> HandleMessage([FromBody] MessageDto messageDto)
+    public async Task<ActionResult<ApiStatusResult<string>>> HandleMessage([FromBody] MessageDto messageDto)
     {
         try
         {
@@ -24,7 +24,7 @@ public class MessageController(IStorageSystem storageSystem,
         }
         catch (Exception e)
         {
-            return BadRequest(e.Message);
+            return BadRequest(new ApiStatusResult<string>(e.Message));
         }
         string correlationText = "";
         if (messageDto.CorrelationKey != null)
@@ -32,6 +32,6 @@ public class MessageController(IStorageSystem storageSystem,
         var response =
             $"Message '{messageDto.Name}'{correlationText} was sent to the process instance.";
 
-        return Ok(response);
+        return Ok(new ApiStatusResult<string>(response));
     }
 }

--- a/src/WebApiEngine/Controller/UserTaskController.cs
+++ b/src/WebApiEngine/Controller/UserTaskController.cs
@@ -1,6 +1,7 @@
 using WebApiEngine.BusinessLogic;
 using WebApiEngine.Mappers;
 using WebApiEngine.Shared;
+using WebApiEngine.Auth;
 
 namespace WebApiEngine.Controller;
 
@@ -8,15 +9,15 @@ namespace WebApiEngine.Controller;
 [ApiController, Route("[controller]")]
 public class UserTaskController(
     IStorageSystem storageSystem,
-    BpmnBusinessLogic bpmnBusinessLogic) : FlowzerControllerBase
+    BpmnBusinessLogic bpmnBusinessLogic,
+    ICurrentUserContextAccessor currentUserContextAccessor) : FlowzerControllerBase
 {
 
     [HttpGet]
     public async Task<ActionResult<ApiStatusResult<ExtendedUserTaskSubscriptionDto[]>>> GetAllUserTasks()
     {
-        //Todo nur für den user
-
-        var userTaskSubscriptions = await storageSystem.SubscriptionStorage.GetAllUserTasksExtended(Guid.Empty);
+        var currentUser = currentUserContextAccessor.GetCurrentUser();
+        var userTaskSubscriptions = await storageSystem.SubscriptionStorage.GetAllUserTasksExtended(currentUser.UserId);
         var dtos = userTaskSubscriptions.Select(subscription => subscription.ToDto()).ToArray();
         return Ok(new ApiStatusResult<ExtendedUserTaskSubscriptionDto[]>(dtos));
     }
@@ -26,10 +27,10 @@ public class UserTaskController(
     [HttpPost]
     public async Task<ActionResult<ApiStatusResult>> HandleUserTaskResult([FromBody] UserTaskResultDto messageDto)
     {
-
         var userTaskResult = messageDto.ToModel();
-        await bpmnBusinessLogic.HandleUserTask(userTaskResult, new Guid()); //TODO: implement authentication
+        var currentUser = currentUserContextAccessor.GetCurrentUser();
+        await bpmnBusinessLogic.HandleUserTask(userTaskResult, currentUser.UserId);
 
-        return Ok();
+        return Ok(new ApiStatusResult { Successful = true });
     }
 }

--- a/src/WebApiEngine/Middleware/ApiExceptionHandlingExtensions.cs
+++ b/src/WebApiEngine/Middleware/ApiExceptionHandlingExtensions.cs
@@ -39,7 +39,7 @@ public static class ApiExceptionHandlingExtensions
                     ErrorMessage = errorMessage
                 };
 
-                await context.Response.WriteAsJsonAsync(payload, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+                await context.Response.WriteAsJsonAsync(payload);
             });
         });
     }

--- a/src/WebApiEngine/Middleware/ApiExceptionHandlingExtensions.cs
+++ b/src/WebApiEngine/Middleware/ApiExceptionHandlingExtensions.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Diagnostics;
+using WebApiEngine.Shared;
+
+namespace WebApiEngine.Middleware;
+
+public static class ApiExceptionHandlingExtensions
+{
+    /// <summary>
+    /// Liefert auch für unbehandelte Fehler konsistente JSON-Fehlerverträge,
+    /// damit Frontend, Tests und Monitoring keine HTML-Fehlerseiten oder
+    /// framework-spezifische Antworten interpretieren müssen.
+    /// </summary>
+    public static IApplicationBuilder UseFlowzerApiExceptionHandling(this IApplicationBuilder app)
+    {
+        return app.UseExceptionHandler(exceptionHandlerApp =>
+        {
+            exceptionHandlerApp.Run(async context =>
+            {
+                var exception = context.Features.Get<IExceptionHandlerPathFeature>()?.Error;
+                if (exception is null)
+                {
+                    context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+                    context.Response.ContentType = "application/json";
+                    await context.Response.WriteAsJsonAsync(new ApiStatusResult("An unexpected server error occurred."));
+                    return;
+                }
+
+                context.Response.StatusCode = MapStatusCode(exception);
+                context.Response.ContentType = "application/json";
+
+                var errorMessage = context.Response.StatusCode >= StatusCodes.Status500InternalServerError
+                    ? "An unexpected server error occurred."
+                    : exception.Message;
+
+                var payload = new ApiStatusResult
+                {
+                    Successful = false,
+                    ErrorMessage = errorMessage
+                };
+
+                await context.Response.WriteAsJsonAsync(payload, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+            });
+        });
+    }
+
+    private static int MapStatusCode(Exception exception)
+    {
+        return exception switch
+        {
+            FileNotFoundException or KeyNotFoundException => StatusCodes.Status404NotFound,
+            ArgumentException or FormatException or JsonException => StatusCodes.Status400BadRequest,
+            UnauthorizedAccessException => StatusCodes.Status401Unauthorized,
+            NotImplementedException => StatusCodes.Status501NotImplemented,
+            _ => StatusCodes.Status500InternalServerError
+        };
+    }
+}

--- a/src/WebApiEngine/Program.cs
+++ b/src/WebApiEngine/Program.cs
@@ -1,5 +1,7 @@
 using WebApiEngine;
+using WebApiEngine.Auth;
 using WebApiEngine.BusinessLogic;
+using WebApiEngine.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,9 +16,11 @@ builder.Services.AddControllers().AddJsonOptions(options =>
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddHttpContextAccessor();
 //builder.Services.AddSingleton<IStorageSystem, MemoryStorageSystem.MemoryStorageSystem>();
 builder.Services.AddSingleton<ITransactionalStorageProvider, FilesystemStorageSystem.FileSystemTransactionalStorageProvider>();
 builder.Services.AddSingleton<IStorageSystem, FilesystemStorageSystem.Storage>();
+builder.Services.AddSingleton<ICurrentUserContextAccessor, HttpContextCurrentUserContextAccessor>();
 builder.Services.AddSingleton<FormBusinessLogic>();
 builder.Services.AddSingleton<DefinitionBusinessLogic>();
 builder.Services.AddSingleton<BpmnBusinessLogic>();
@@ -32,6 +36,8 @@ builder.Services.AddCors(options =>
 });
 
 var app = builder.Build();
+
+app.UseFlowzerApiExceptionHandling();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())


### PR DESCRIPTION
## Zusammenfassung

Dieses PR härtet die Web-API in drei Bereichen:

- konsistente JSON-Fehlerverträge auch bei unbehandelten Fehlern
- einfache Health- und Readiness-Endpunkte für Betrieb und Monitoring
- gekapselter Benutzerkontext statt verteilter `Guid.Empty`-/Magic-Value-Platzhalter

## Änderungen

- `ICurrentUserContextAccessor` mit Claim-/Header-Auflösung und stabilem System-Fallback ergänzt
- Benutzerauflösung in `DefinitionBusinessLogic`, `UserTaskController` und `FormController` verdrahtet
- globale Exception-Behandlung mit `ApiStatusResult`-Antworten für 400/404/401/501/500 ergänzt
- neuen `HealthController` mit `/health` und `/health/ready` ergänzt
- `MessageController` liefert jetzt ebenfalls einen konsistenten `ApiStatusResult<string>`-Vertrag
- neue API-Integrationstests für Health, Fehlerpfade und Benutzerkontext ergänzt

## Tests

- `dotnet build core-engine.sln --configuration Release --no-restore`
- `dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-restore --logger 'console;verbosity=minimal'`
- `dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-restore --logger 'console;verbosity=minimal'`
- `dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-restore --logger 'console;verbosity=minimal'`
- `cd tests/ui-smoke && npm test`

## Bezug

Closes #52
