### PR TITLE
Frontend-Navigation und Kernseiten weiter härten

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -68,6 +68,7 @@ Geprüft werden insbesondere:
 - Listen- und Startseiten zeigen bei Ladefehlern eine sichtbare Inline-Fehlermeldung statt still abzustürzen.
 - Leere Listen rendern einen expliziten Empty State.
 - Instanzfilter werden ausschließlich über gültige Frontend-Routen (`all`, `active`, `done`, `error`) adressiert.
+- Die Instanzliste lädt bewusst auch abgeschlossene bzw. fehlgeschlagene Instanzen, damit `done`- und `error`-Filter echte Daten anzeigen können.
 - Formularrouten werden defensiv geparst, damit ungültige URLs nicht in eine ungefangene `Guid.Parse`-Ausnahme laufen.
 
 ### Einmalig installieren

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -50,13 +50,25 @@ Die Smoke-Tests liegen unter `tests/ui-smoke` und prüfen aktuell die Kernrouten
 - `/models`
 - `/forms`
 - `/instances`
+- `/instances/all`
+- `/instances/active`
+- `/instances/done`
+- `/instances/error`
 
 Geprüft werden insbesondere:
 
 - erfolgreiche Seitennavigation
 - sichtbare Kern-UI je Route
+- funktionierende Filter-Navigation innerhalb der Instanzliste
 - kein sichtbarer Blazor-Fatalfehler
 - keine fehlgeschlagenen Browser-Requests
+
+## Aktuelle Frontend-Konventionen für Kernseiten
+
+- Listen- und Startseiten zeigen bei Ladefehlern eine sichtbare Inline-Fehlermeldung statt still abzustürzen.
+- Leere Listen rendern einen expliziten Empty State.
+- Instanzfilter werden ausschließlich über gültige Frontend-Routen (`all`, `active`, `done`, `error`) adressiert.
+- Formularrouten werden defensiv geparst, damit ungültige URLs nicht in eine ungefangene `Guid.Parse`-Ausnahme laufen.
 
 ### Einmalig installieren
 

--- a/src/FlowzerFrontend.Tests/FormRouteHelperTest.cs
+++ b/src/FlowzerFrontend.Tests/FormRouteHelperTest.cs
@@ -1,0 +1,39 @@
+using FluentAssertions;
+using FlowzerFrontend.BusinessLogic;
+
+namespace FlowzerFrontend.Tests;
+
+public class FormRouteHelperTest
+{
+    [Test]
+    public void Parse_ShouldRecognizeCreateRoute()
+    {
+        var result = FormRouteHelper.Parse("create");
+
+        result.IsCreate.Should().BeTrue();
+        result.FormId.Should().BeNull();
+        result.ErrorMessage.Should().BeNull();
+    }
+
+    [Test]
+    public void Parse_ShouldReturnGuid_WhenRouteContainsExistingFormId()
+    {
+        var formId = Guid.NewGuid();
+
+        var result = FormRouteHelper.Parse(formId.ToString());
+
+        result.IsCreate.Should().BeFalse();
+        result.FormId.Should().Be(formId);
+        result.ErrorMessage.Should().BeNull();
+    }
+
+    [Test]
+    public void Parse_ShouldReturnError_ForInvalidRouteValue()
+    {
+        var result = FormRouteHelper.Parse("not-a-guid");
+
+        result.IsCreate.Should().BeFalse();
+        result.FormId.Should().BeNull();
+        result.ErrorMessage.Should().Contain("not-a-guid");
+    }
+}

--- a/src/FlowzerFrontend.Tests/InstanceListFilterHelperTest.cs
+++ b/src/FlowzerFrontend.Tests/InstanceListFilterHelperTest.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using FlowzerFrontend.BusinessLogic;
+using WebApiEngine.Shared;
+
+namespace FlowzerFrontend.Tests;
+
+public class InstanceListFilterHelperTest
+{
+    [Test]
+    public void ParseOrDefault_ShouldFallbackToAll_ForUnknownValues()
+    {
+        var result = InstanceListFilterHelper.ParseOrDefault("unexpected");
+
+        result.Should().Be(InstanceListFilter.All);
+    }
+
+    [Test]
+    public void Apply_ShouldReturnOnlyActiveStates_ForActiveFilter()
+    {
+        var instances = new[]
+        {
+            CreateInstance(ProcessInstanceStateDto.Running),
+            CreateInstance(ProcessInstanceStateDto.Waiting),
+            CreateInstance(ProcessInstanceStateDto.Completed),
+            CreateInstance(ProcessInstanceStateDto.Failed)
+        };
+
+        var result = InstanceListFilterHelper.Apply(instances, InstanceListFilter.Active).ToArray();
+
+        result.Should().HaveCount(2);
+        result.Should().OnlyContain(instance =>
+            instance.State == ProcessInstanceStateDto.Running ||
+            instance.State == ProcessInstanceStateDto.Waiting);
+    }
+
+    [Test]
+    public void Apply_ShouldReturnOnlyDoneStates_ForDoneFilter()
+    {
+        var instances = new[]
+        {
+            CreateInstance(ProcessInstanceStateDto.Completed),
+            CreateInstance(ProcessInstanceStateDto.Terminated),
+            CreateInstance(ProcessInstanceStateDto.Running)
+        };
+
+        var result = InstanceListFilterHelper.Apply(instances, InstanceListFilter.Done).ToArray();
+
+        result.Should().HaveCount(2);
+        result.Should().OnlyContain(instance =>
+            instance.State == ProcessInstanceStateDto.Completed ||
+            instance.State == ProcessInstanceStateDto.Terminated);
+    }
+
+    [Test]
+    public void Apply_ShouldReturnOnlyErrorStates_ForErrorFilter()
+    {
+        var instances = new[]
+        {
+            CreateInstance(ProcessInstanceStateDto.Failing),
+            CreateInstance(ProcessInstanceStateDto.Failed),
+            CreateInstance(ProcessInstanceStateDto.Compensating)
+        };
+
+        var result = InstanceListFilterHelper.Apply(instances, InstanceListFilter.Error).ToArray();
+
+        result.Should().HaveCount(2);
+        result.Should().OnlyContain(instance =>
+            instance.State == ProcessInstanceStateDto.Failing ||
+            instance.State == ProcessInstanceStateDto.Failed);
+    }
+
+    [Test]
+    public void ToRouteSegment_ShouldReturnStableSegments()
+    {
+        InstanceListFilterHelper.ToRouteSegment(InstanceListFilter.All).Should().Be("all");
+        InstanceListFilterHelper.ToRouteSegment(InstanceListFilter.Active).Should().Be("active");
+        InstanceListFilterHelper.ToRouteSegment(InstanceListFilter.Done).Should().Be("done");
+        InstanceListFilterHelper.ToRouteSegment(InstanceListFilter.Error).Should().Be("error");
+    }
+
+    private static ProcessInstanceInfoDto CreateInstance(ProcessInstanceStateDto state)
+    {
+        return new ProcessInstanceInfoDto
+        {
+            InstanceId = Guid.NewGuid(),
+            DefinitionId = Guid.NewGuid(),
+            RelatedDefinitionId = "definition",
+            RelatedDefinitionName = "Demo process",
+            State = state
+        };
+    }
+}

--- a/src/FlowzerFrontend.Tests/ModelListViewHelperTest.cs
+++ b/src/FlowzerFrontend.Tests/ModelListViewHelperTest.cs
@@ -1,0 +1,71 @@
+using FluentAssertions;
+using FlowzerFrontend.BusinessLogic;
+using Microsoft.FluentUI.AspNetCore.Components;
+using WebApiEngine.Shared;
+
+namespace FlowzerFrontend.Tests;
+
+public class ModelListViewHelperTest
+{
+    [Test]
+    public void ApplyQuery_ShouldFilterAcrossNameDefinitionIdAndDescription()
+    {
+        var models = new[]
+        {
+            new ExtendedBpmnMetaDefinitionDto
+            {
+                DefinitionId = "invoice-process",
+                Name = "Invoice",
+                Description = "Handles invoices"
+            },
+            new ExtendedBpmnMetaDefinitionDto
+            {
+                DefinitionId = "shipment-process",
+                Name = "Shipment",
+                Description = "Ships packages"
+            }
+        };
+
+        var result = ModelListViewHelper.ApplyQuery(models, "invoice", SortDirection.Ascending).ToArray();
+
+        result.Should().ContainSingle();
+        result[0].DefinitionId.Should().Be("invoice-process");
+    }
+
+    [Test]
+    public void ApplyQuery_ShouldSortAscendingByName()
+    {
+        var models = new[]
+        {
+            CreateModel("zeta", "Zeta"),
+            CreateModel("alpha", "Alpha")
+        };
+
+        var result = ModelListViewHelper.ApplyQuery(models, null, SortDirection.Ascending).ToArray();
+
+        result.Select(model => model.Name).Should().Equal("Alpha", "Zeta");
+    }
+
+    [Test]
+    public void ApplyQuery_ShouldSortDescendingByName()
+    {
+        var models = new[]
+        {
+            CreateModel("zeta", "Zeta"),
+            CreateModel("alpha", "Alpha")
+        };
+
+        var result = ModelListViewHelper.ApplyQuery(models, null, SortDirection.Descending).ToArray();
+
+        result.Select(model => model.Name).Should().Equal("Zeta", "Alpha");
+    }
+
+    private static ExtendedBpmnMetaDefinitionDto CreateModel(string definitionId, string name)
+    {
+        return new ExtendedBpmnMetaDefinitionDto
+        {
+            DefinitionId = definitionId,
+            Name = name
+        };
+    }
+}

--- a/src/FlowzerFrontend.Tests/UriHelperTest.cs
+++ b/src/FlowzerFrontend.Tests/UriHelperTest.cs
@@ -1,0 +1,22 @@
+using FluentAssertions;
+
+namespace FlowzerFrontend.Tests;
+
+public class UriHelperTest
+{
+    [Test]
+    public void GetInstancesUrl_ShouldReturnBaseInstancesRoute_WhenNoFilterIsProvided()
+    {
+        var result = FlowzerFrontend.UriHelper.GetInstancesUrl();
+
+        result.Should().Be("/instances");
+    }
+
+    [Test]
+    public void GetInstancesUrl_ShouldAppendFilterSegment_WhenFilterIsProvided()
+    {
+        var result = FlowzerFrontend.UriHelper.GetInstancesUrl("error");
+
+        result.Should().Be("/instances/error");
+    }
+}

--- a/src/FlowzerFrontend/BusinessLogic/FormRouteHelper.cs
+++ b/src/FlowzerFrontend/BusinessLogic/FormRouteHelper.cs
@@ -1,0 +1,30 @@
+namespace FlowzerFrontend.BusinessLogic;
+
+/// <summary>
+/// Parst die Formularroute defensiv, damit ungültige URLs nicht die komplette
+/// Seite mit einer Guid.Parse-Ausnahme abbrechen lassen.
+/// </summary>
+public sealed record FormRouteState(
+    bool IsCreate,
+    Guid? FormId,
+    string? ErrorMessage);
+
+public static class FormRouteHelper
+{
+    public static FormRouteState Parse(string? formId)
+    {
+        if (string.IsNullOrWhiteSpace(formId))
+        {
+            return new FormRouteState(false, null, "No form id was provided in the route.");
+        }
+
+        if (string.Equals(formId, "create", StringComparison.OrdinalIgnoreCase))
+        {
+            return new FormRouteState(true, null, null);
+        }
+
+        return Guid.TryParse(formId, out var parsedFormId)
+            ? new FormRouteState(false, parsedFormId, null)
+            : new FormRouteState(false, null, $"The form route value '{formId}' is not a valid form id.");
+    }
+}

--- a/src/FlowzerFrontend/BusinessLogic/InstanceListFilterHelper.cs
+++ b/src/FlowzerFrontend/BusinessLogic/InstanceListFilterHelper.cs
@@ -1,0 +1,77 @@
+using WebApiEngine.Shared;
+
+namespace FlowzerFrontend.BusinessLogic;
+
+/// <summary>
+/// Kapselt die UI-seitige Filterlogik für die Instanzliste, damit Routing,
+/// Navigation und Tests dieselben Kategorien verwenden.
+/// </summary>
+public enum InstanceListFilter
+{
+    All,
+    Active,
+    Done,
+    Error
+}
+
+public static class InstanceListFilterHelper
+{
+    public static InstanceListFilter ParseOrDefault(string? filter)
+    {
+        return filter?.Trim().ToLowerInvariant() switch
+        {
+            "active" => InstanceListFilter.Active,
+            "done" => InstanceListFilter.Done,
+            "error" => InstanceListFilter.Error,
+            _ => InstanceListFilter.All
+        };
+    }
+
+    public static string ToRouteSegment(InstanceListFilter filter)
+    {
+        return filter switch
+        {
+            InstanceListFilter.Active => "active",
+            InstanceListFilter.Done => "done",
+            InstanceListFilter.Error => "error",
+            _ => "all"
+        };
+    }
+
+    public static string ToDisplayLabel(InstanceListFilter filter)
+    {
+        return filter switch
+        {
+            InstanceListFilter.Active => "Active instances",
+            InstanceListFilter.Done => "Completed instances",
+            InstanceListFilter.Error => "Failed instances",
+            _ => "All instances"
+        };
+    }
+
+    public static IEnumerable<ProcessInstanceInfoDto> Apply(
+        IEnumerable<ProcessInstanceInfoDto> instances,
+        InstanceListFilter filter)
+    {
+        ArgumentNullException.ThrowIfNull(instances);
+
+        return filter switch
+        {
+            InstanceListFilter.Active => instances.Where(instance => instance.State is
+                ProcessInstanceStateDto.Initialized or
+                ProcessInstanceStateDto.Running or
+                ProcessInstanceStateDto.Waiting or
+                ProcessInstanceStateDto.Completing or
+                ProcessInstanceStateDto.Terminating or
+                ProcessInstanceStateDto.Compensating),
+            InstanceListFilter.Done => instances.Where(instance => instance.State is
+                ProcessInstanceStateDto.Completed or
+                ProcessInstanceStateDto.Terminated or
+                ProcessInstanceStateDto.Compensated),
+            InstanceListFilter.Error => instances.Where(instance => instance.State is
+                ProcessInstanceStateDto.Failing or
+                ProcessInstanceStateDto.Failed),
+            _ => instances
+        };
+    }
+}

--- a/src/FlowzerFrontend/BusinessLogic/ModelListViewHelper.cs
+++ b/src/FlowzerFrontend/BusinessLogic/ModelListViewHelper.cs
@@ -1,0 +1,46 @@
+using Microsoft.FluentUI.AspNetCore.Components;
+using WebApiEngine.Shared;
+
+namespace FlowzerFrontend.BusinessLogic;
+
+/// <summary>
+/// Bündelt Such- und Sortierlogik der Modellliste, damit die Seite selbst nur
+/// noch Lade- und Navigationszustände verwalten muss.
+/// </summary>
+public static class ModelListViewHelper
+{
+    public static IEnumerable<ExtendedBpmnMetaDefinitionDto> ApplyQuery(
+        IEnumerable<ExtendedBpmnMetaDefinitionDto> models,
+        string? searchText,
+        SortDirection sortDirection)
+    {
+        ArgumentNullException.ThrowIfNull(models);
+
+        var filteredModels = models;
+        var normalizedSearch = searchText?.Trim();
+        if (!string.IsNullOrWhiteSpace(normalizedSearch))
+        {
+            filteredModels = filteredModels.Where(model => MatchesSearch(model, normalizedSearch));
+        }
+
+        return sortDirection == SortDirection.Descending
+            ? filteredModels
+                .OrderByDescending(model => model.Name, StringComparer.InvariantCultureIgnoreCase)
+                .ThenByDescending(model => model.DefinitionId, StringComparer.InvariantCultureIgnoreCase)
+            : filteredModels
+                .OrderBy(model => model.Name, StringComparer.InvariantCultureIgnoreCase)
+                .ThenBy(model => model.DefinitionId, StringComparer.InvariantCultureIgnoreCase);
+    }
+
+    private static bool MatchesSearch(ExtendedBpmnMetaDefinitionDto model, string normalizedSearch)
+    {
+        return Contains(model.Name, normalizedSearch)
+               || Contains(model.DefinitionId, normalizedSearch)
+               || Contains(model.Description, normalizedSearch);
+    }
+
+    private static bool Contains(string? value, string search)
+    {
+        return value?.Contains(search, StringComparison.InvariantCultureIgnoreCase) == true;
+    }
+}

--- a/src/FlowzerFrontend/Components/LabelWithEdit.razor.cs
+++ b/src/FlowzerFrontend/Components/LabelWithEdit.razor.cs
@@ -10,43 +10,40 @@ public partial class LabelWithEdit : ComponentBase
     public string Label { get; set; } = string.Empty;
     
     [Parameter]
-    public EventCallback<string>? LabelChanged { get; set; }
+    public EventCallback<string> LabelChanged { get; set; }
     
     [Parameter]
-    public Action<string>? AfterChanged { get; set; }
+    public EventCallback<string> AfterChanged { get; set; }
 
     
     private bool TitleEditMode { get; set; }
     
-    private async void ToggleTitleEditMode()
+    private async Task ToggleTitleEditMode()
     {
-        
         try
         {
             if (TitleEditMode)
             {
-                if (LabelChanged != null)
-                    await LabelChanged.Value.InvokeAsync(Label);
-                if (AfterChanged != null)
-                    AfterChanged.Invoke(Label);
-
-                
+                if (LabelChanged.HasDelegate)
+                    await LabelChanged.InvokeAsync(Label);
+                if (AfterChanged.HasDelegate)
+                    await AfterChanged.InvokeAsync(Label);
             }
-
         }
         catch (Exception e)
         {
             Console.WriteLine(e);
         }
+
         TitleEditMode = !TitleEditMode;
-        StateHasChanged();
+        await InvokeAsync(StateHasChanged);
     }
 
-    private void OnTitleEditKeyUp(KeyboardEventArgs keyboardEventArgs)
+    private async Task OnTitleEditKeyUp(KeyboardEventArgs keyboardEventArgs)
     {
         if (keyboardEventArgs.Key == "Enter")
         {
-            ToggleTitleEditMode();
+            await ToggleTitleEditMode();
         }
     }
     

--- a/src/FlowzerFrontend/FlowzerApi.cs
+++ b/src/FlowzerFrontend/FlowzerApi.cs
@@ -78,7 +78,7 @@ public class FlowzerApi: ApiBase
     }
 
 
-    public async Task<List<ProcessInstanceInfoDto>> GetAllRunningInstances()
+    public async Task<List<ProcessInstanceInfoDto>> GetAllInstances()
     {
         return await GetAsJsonAndThrowOnErrorAsync<List<ProcessInstanceInfoDto>>("instance");
     }

--- a/src/FlowzerFrontend/Pages/EditDefinition.razor.cs
+++ b/src/FlowzerFrontend/Pages/EditDefinition.razor.cs
@@ -41,11 +41,11 @@ public partial class EditDefinition
     protected override async Task OnInitializedAsync()
     {
         await JsRuntime.EvalCodeBehindJsScripts(this);
-        InitEditor();
+        await InitEditor();
     }
 
 
-    private async void InitEditor()
+    private async Task InitEditor()
     {
         await JsRuntime.InvokeVoidAsync("InitEdit");
         await LoadModel();
@@ -111,15 +111,15 @@ public partial class EditDefinition
         ErrorString = null;
     }
 
-    private async void OnSaveClick()
+    private async Task OnSaveClick()
     {
         var xmlData = await GetXmlData();
         var definition = await FlowzerApi.UploadDefinition(xmlData);
         CurrentDefinition = definition;
-        StateHasChanged();
+        await InvokeAsync(StateHasChanged);
     }
 
-    private async void OnDeployClick()
+    private async Task OnDeployClick()
     {
         var xmlData = await GetXmlData();
         try
@@ -133,7 +133,7 @@ public partial class EditDefinition
             await dialog.Result;
         }
  
-        StateHasChanged();
+        await InvokeAsync(StateHasChanged);
     }
 
     private async Task<string> GetXmlData()
@@ -143,7 +143,7 @@ public partial class EditDefinition
         return xmlData;
     }
 
-    private async void AfterChanged(string obj)
+    private async Task AfterChanged(string obj)
     {
         await FlowzerApi.UpdateMetaDefinition(CurrentMetaDefinition);
     }

--- a/src/FlowzerFrontend/Pages/EditForm.razor
+++ b/src/FlowzerFrontend/Pages/EditForm.razor
@@ -1,6 +1,7 @@
 @page "/forms/{FormId}"
 @inherits FlowzerComponentBase
 @using Microsoft.FluentUI.AspNetCore.Components
+@using FlowzerFrontend.BusinessLogic
 @using FlowzerFrontend.Components
 
 
@@ -25,11 +26,21 @@
         </RigthSide>
     </HeaderElement>
 
-    <div class="iframe-container">
-        <iframe src="/formio" width="100%" height="100%"></iframe>
-    </div>
+    @if (IsLoading)
+    {
+        <p id="edit-form-loading-state">Loading form...</p>
+    }
+    else if (!string.IsNullOrWhiteSpace(ErrorString))
+    {
+        <p id="edit-form-error" role="alert">@ErrorString</p>
+    }
+    else
+    {
+        <div class="iframe-container">
+            <iframe src="/formio" width="100%" height="100%"></iframe>
+        </div>
+    }
     
 
 </div>
-
 

--- a/src/FlowzerFrontend/Pages/EditForm.razor.cs
+++ b/src/FlowzerFrontend/Pages/EditForm.razor.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using FlowzerFrontend.BusinessLogic;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -16,6 +17,8 @@ public partial class EditForm : FlowzerComponentBase
 
     
     [Parameter] public string FormId { get; set; } = string.Empty;
+    public string? ErrorString { get; set; }
+    public bool IsLoading { get; set; } = true;
 
     public bool IsNew { get; set; }
 
@@ -37,27 +40,49 @@ public partial class EditForm : FlowzerComponentBase
 
     protected override async Task OnInitializedAsync()
     {
-        if (string.Compare(FormId, "create", StringComparison.OrdinalIgnoreCase) == 0)
+        var routeState = FormRouteHelper.Parse(FormId);
+        if (!string.IsNullOrWhiteSpace(routeState.ErrorMessage))
         {
-            IsNew = true;
-            CurrentFormMeta = new FormMetaDataDto()
-            {
-                FormId = Guid.NewGuid(),
-                Name = "Unnamed Form",
-            };
-            FormData = new FormDto()
-            {
-                Id = Guid.NewGuid(),
-                FormId = CurrentFormMeta.FormId,
-            };
+            ErrorString = routeState.ErrorMessage;
+            IsLoading = false;
+            return;
         }
-        else
+
+        try
         {
-            IsNew = false;
-            CurrentFormMeta = await FlowzerApi.GetFormMetaData(Guid.Parse(FormId));    
-            FormData = await FlowzerApi.GetLatestForm(Guid.Parse(FormId));
-            if (!string.IsNullOrEmpty(FormData.FormData))
-                await LoadFormData(FormData.FormData);
+            if (routeState.IsCreate)
+            {
+                IsNew = true;
+                CurrentFormMeta = new FormMetaDataDto()
+                {
+                    FormId = Guid.NewGuid(),
+                    Name = "Unnamed Form",
+                };
+                FormData = new FormDto()
+                {
+                    Id = Guid.NewGuid(),
+                    FormId = CurrentFormMeta.FormId,
+                };
+            }
+            else
+            {
+                IsNew = false;
+                var existingFormId = routeState.FormId!.Value;
+                CurrentFormMeta = await FlowzerApi.GetFormMetaData(existingFormId);    
+                FormData = await FlowzerApi.GetLatestForm(existingFormId);
+                if (!string.IsNullOrEmpty(FormData.FormData))
+                    await LoadFormData(FormData.FormData);
+            }
+
+            ErrorString = null;
+        }
+        catch (Exception exception)
+        {
+            ErrorString = $"Could not load form. {exception.Message}";
+        }
+        finally
+        {
+            IsLoading = false;
         }
     }
 
@@ -85,7 +110,7 @@ public partial class EditForm : FlowzerComponentBase
     }
 
 
-    private async void SaveFormClicked(MouseEventArgs obj)
+    private async Task SaveFormClicked(MouseEventArgs obj)
     {
         try
         {
@@ -112,13 +137,13 @@ public partial class EditForm : FlowzerComponentBase
         return ((JsonElement)ret).GetRawText();
     }
     
-    private async void AfterTitleChanged(string obj)
+    private async Task AfterTitleChanged(string obj)
     {
         if (!IsNew) //if the object is new (it was never saved yet) we don't have to inform the server about the change
             await FlowzerApi.SaveFormMetaData(CurrentFormMeta);
     }
 
-    private async void TestFormClicked(MouseEventArgs obj)
+    private async Task TestFormClicked(MouseEventArgs obj)
     {
         DialogParameters parameters = new()
         {
@@ -145,7 +170,6 @@ public partial class EditForm : FlowzerComponentBase
                    """
         };
         IDialogReference dialog = await DialogService.ShowDialogAsync<Testform>(testFormParameters, parameters);
-        DialogResult? result = await dialog.Result;
-
+        await dialog.Result;
     }
 }

--- a/src/FlowzerFrontend/Pages/Forms.razor
+++ b/src/FlowzerFrontend/Pages/Forms.razor
@@ -37,7 +37,7 @@
                     <div class="list-header">
                         <FluentDataGrid Items="@Data" style="width: 100%;" GridTemplateColumns="80px 1fr auto" ShowHover="true">
                             <SelectColumn TGridItem="FormMetaDataDto" SelectMode="DataGridSelectMode.Multiple" @bind-SelectedItems="@SelectedItems"/>
-                            <TemplateColumn Title="Titel">
+                            <TemplateColumn Title="Title">
                                 <div class="grid-row-title"><a href="@UriHelper.GetShowFormUrl(@context.FormId)">@context.Name</a></div>
                                 <div class="grid-row-subtitle">Instance @context.FormId</div>
                             </TemplateColumn>

--- a/src/FlowzerFrontend/Pages/Forms.razor
+++ b/src/FlowzerFrontend/Pages/Forms.razor
@@ -20,15 +20,30 @@
             <FluentStack Orientation="Orientation.Vertical" Width="100%">
                 <h1>Forms</h1>
 
-                <div class="list-header">
-                    <FluentDataGrid Items="@Data" style="width: 100%;" GridTemplateColumns="80px 1fr auto" ShowHover="true">
-                        <SelectColumn TGridItem="FormMetaDataDto" SelectMode="DataGridSelectMode.Multiple" @bind-SelectedItems="@SelectedItems"/>
-                        <TemplateColumn Title="Titel">
-                            <div class="grid-row-title"><a href="@UriHelper.GetShowFormUrl(@context.FormId)">@context.Name</a></div>
-                            <div class="grid-row-subtitle">Instance @context.FormId</div>
-                        </TemplateColumn>
-                    </FluentDataGrid>
-                </div>
+                @if (IsLoading)
+                {
+                    <p id="forms-loading-state">Loading forms...</p>
+                }
+                else if (!string.IsNullOrWhiteSpace(LoadErrorMessage))
+                {
+                    <p id="forms-load-error" role="alert">@LoadErrorMessage</p>
+                }
+                else if (!Data.Any())
+                {
+                    <p id="forms-empty-state">No forms are available yet.</p>
+                }
+                else
+                {
+                    <div class="list-header">
+                        <FluentDataGrid Items="@Data" style="width: 100%;" GridTemplateColumns="80px 1fr auto" ShowHover="true">
+                            <SelectColumn TGridItem="FormMetaDataDto" SelectMode="DataGridSelectMode.Multiple" @bind-SelectedItems="@SelectedItems"/>
+                            <TemplateColumn Title="Titel">
+                                <div class="grid-row-title"><a href="@UriHelper.GetShowFormUrl(@context.FormId)">@context.Name</a></div>
+                                <div class="grid-row-subtitle">Instance @context.FormId</div>
+                            </TemplateColumn>
+                        </FluentDataGrid>
+                    </div>
+                }
 
             </FluentStack>
         </MainContent>

--- a/src/FlowzerFrontend/Pages/Forms.razor.cs
+++ b/src/FlowzerFrontend/Pages/Forms.razor.cs
@@ -13,11 +13,26 @@ public partial class Forms : ComponentBase
     
     public IQueryable<FormMetaDataDto> Data { get; set; } = new List<FormMetaDataDto>().AsQueryable();
     public IEnumerable<FormMetaDataDto> SelectedItems { get; set; } = new List<FormMetaDataDto>();
+    private bool IsLoading { get; set; } = true;
+    private string? LoadErrorMessage { get; set; }
 
 
     protected override async Task OnInitializedAsync()
     {
-        Data = (await FlowzerApi.GetFormMetaDatas()).AsQueryable();
+        try
+        {
+            Data = (await FlowzerApi.GetFormMetaDatas()).AsQueryable();
+            LoadErrorMessage = null;
+        }
+        catch (Exception exception)
+        {
+            Data = Array.Empty<FormMetaDataDto>().AsQueryable();
+            LoadErrorMessage = $"Could not load forms. {exception.Message}";
+        }
+        finally
+        {
+            IsLoading = false;
+        }
     }
 
     private void OnNewClick(MouseEventArgs obj)

--- a/src/FlowzerFrontend/Pages/Home.razor
+++ b/src/FlowzerFrontend/Pages/Home.razor
@@ -2,23 +2,33 @@
 @using Microsoft.FluentUI.AspNetCore.Components
 @inherits FlowzerComponentBase
 
-
 <div class="main-content">
     <h1>Welcome to Flowzer</h1>
 
-    <FluentGrid>
-        
-        @foreach (var userTaskSubscriptionDto in _tasks)
-        {
-            <FluentGridItem xs="12" sm="6">
-                <FluentCard @onclick="() => OnCardClick(userTaskSubscriptionDto)" Class="user-task-card" >
-                    <h2>@userTaskSubscriptionDto.Name</h2>
-                    <div>@userTaskSubscriptionDto.DefinitionMetaName</div>
-                </FluentCard>
-            </FluentGridItem>
-        }
-        
-    </FluentGrid>
-    
-
+    @if (IsLoading)
+    {
+        <p id="home-loading-state">Loading open user tasks...</p>
+    }
+    else if (!string.IsNullOrWhiteSpace(LoadErrorMessage))
+    {
+        <p id="home-load-error" role="alert">@LoadErrorMessage</p>
+    }
+    else if (_tasks.Length == 0)
+    {
+        <p id="home-empty-state">There are currently no open user tasks.</p>
+    }
+    else
+    {
+        <FluentGrid>
+            @foreach (var userTaskSubscriptionDto in _tasks)
+            {
+                <FluentGridItem xs="12" sm="6">
+                    <FluentCard @onclick="() => OnCardClick(userTaskSubscriptionDto)" Class="user-task-card">
+                        <h2>@userTaskSubscriptionDto.Name</h2>
+                        <div>@userTaskSubscriptionDto.DefinitionMetaName</div>
+                    </FluentCard>
+                </FluentGridItem>
+            }
+        </FluentGrid>
+    }
 </div>

--- a/src/FlowzerFrontend/Pages/Home.razor.cs
+++ b/src/FlowzerFrontend/Pages/Home.razor.cs
@@ -10,15 +10,31 @@ namespace FlowzerFrontend.Pages;
 public partial class Home : FlowzerComponentBase
 {
     private ExtendedUserTaskSubscriptionDto[] _tasks = [];
+    private bool IsLoading { get; set; } = true;
+    private string? LoadErrorMessage { get; set; }
+
     [Inject] public required FlowzerApi FlowzerApi { get; set; }
  
     
     protected override async Task OnInitializedAsync()
     {
-        _tasks = await FlowzerApi.GetAllUserTasks();
+        try
+        {
+            _tasks = await FlowzerApi.GetAllUserTasks();
+            LoadErrorMessage = null;
+        }
+        catch (Exception exception)
+        {
+            _tasks = [];
+            LoadErrorMessage = $"Could not load user tasks. {exception.Message}";
+        }
+        finally
+        {
+            IsLoading = false;
+        }
     }
     
-    private async void OnCardClick(ExtendedUserTaskSubscriptionDto userTaskSubscription)
+    private async Task OnCardClick(ExtendedUserTaskSubscriptionDto userTaskSubscription)
     {
         var formName = TokenDisplayHelper.GetImplementation(userTaskSubscription.Token);
         if (string.IsNullOrWhiteSpace(formName))

--- a/src/FlowzerFrontend/Pages/Instance.razor
+++ b/src/FlowzerFrontend/Pages/Instance.razor
@@ -8,7 +8,7 @@
 @inject ExampleRestRequestBuilder ExampleRestRequestBuilder
 
 <div class="main-content">
-    <HeaderElement Title="Hello world" BackLink="/instances">
+    <HeaderElement BackLink="/instances">
         <LeftSide>
             <span id="instance-name">@_instance?.RelatedDefinitionName - @_instance?.InstanceId</span>
             
@@ -76,4 +76,3 @@
     }
 
 </div>
-

--- a/src/FlowzerFrontend/Pages/Instance.razor
+++ b/src/FlowzerFrontend/Pages/Instance.razor
@@ -8,7 +8,7 @@
 @inject ExampleRestRequestBuilder ExampleRestRequestBuilder
 
 <div class="main-content">
-    <HeaderElement Title="Hello world" BackLink="/models">
+    <HeaderElement Title="Hello world" BackLink="/instances">
         <LeftSide>
             <span id="instance-name">@_instance?.RelatedDefinitionName - @_instance?.InstanceId</span>
             
@@ -16,56 +16,64 @@
         </LeftSide>
     </HeaderElement>
 
-    <div class="diagram-content with-diagram" id="designer-container">
-        <div class="canvas" id="js-canvas"></div>
-    </div>
+    @if (!string.IsNullOrWhiteSpace(ErrorString))
+    {
+        <p id="instance-load-error" role="alert">@ErrorString</p>
+    }
+    else if (_instance == null)
+    {
+        <p id="instance-loading-state">Loading instance...</p>
+    }
+    else
+    {
+        <div class="diagram-content with-diagram" id="designer-container">
+            <div class="canvas" id="js-canvas"></div>
+        </div>
 
 
-    <div id="information_container">
-        <FluentStack Orientation="Orientation.Horizontal">
+        <div id="information_container">
+            <FluentStack Orientation="Orientation.Horizontal">
 
-            <FluentCard Width="800px;">
-                <h3>Tokens</h3>
-                <FluentStack Orientation="Orientation.Horizontal">
-                    <FluentTreeView Items="@VariableItems" @bind-SelectedItem="@CurrentSelectedToken">
+                <FluentCard Width="800px;">
+                    <h3>Tokens</h3>
+                    <FluentStack Orientation="Orientation.Horizontal">
+                        <FluentTreeView Items="@VariableItems" @bind-SelectedItem="@CurrentSelectedToken">
+                        </FluentTreeView>
+                        <FluentTabs >
+                            <FluentTab Id="tab-1" Label="Output" IsActive="true">
+                                <FluentTextArea @bind-Value="@VariableContent" Cols="80" Rows="15" >
+                                </FluentTextArea>
+                            </FluentTab>
+                            <FluentTab Id="tab-2" Label="Variables">
+                                <FluentTextArea @bind-Value="@VariableContent" Cols="80" Rows="15" >
+                                </FluentTextArea>
+                            </FluentTab>
+                        </FluentTabs>
+                    </FluentStack>
+                </FluentCard>
+
+                
+                <FluentCard Width="400px" Height="400px">
+                    <h3>Subscriptions</h3>
+                    <FluentTreeView Items="@Items">
+                        <ItemTemplate>
+                            @if (GetTreeRelatedItem<MessageSubscriptionDto>(context.Id, out var item))
+                            {
+                                <span>Waiting for "@item.Message.Name"</span>
+                                <FluentButton @onclick="async args => await OpenSendRestRequestAsync(ExampleRestRequestBuilder.BuildMessageRequest(item.Message, _instance?.InstanceId))" Class="tree-button">Send request</FluentButton>
+                            }
+                            else
+                            {
+                                @context.Text
+                            }
+                        </ItemTemplate>
                     </FluentTreeView>
-                    <FluentTabs >
-                        <FluentTab Id="tab-1" Label="Output" IsActive="true">
-                            <FluentTextArea @bind-Value="@VariableContent" Cols="80" Rows="15" >
-                            </FluentTextArea>
-                        </FluentTab>
-                        <FluentTab Id="tab-2" Label="Variables">
-                            <FluentTextArea @bind-Value="@VariableContent" Cols="80" Rows="15" >
-                            </FluentTextArea>
-                        </FluentTab>
-                    </FluentTabs>
-                    
-                    
-                </FluentStack>
-            </FluentCard>
 
-            
-            <FluentCard Width="400px" Height="400px">
-                <h3>Subscriptions</h3>
-                <FluentTreeView Items="@Items">
-                    <ItemTemplate>
-                        @if (GetTreeRelatedItem<MessageSubscriptionDto>(context.Id, out var item))
-                        {
-                            <span>Waiting for "@item.Message.Name"</span>
-                            <FluentButton @onclick="async args => await OpenSendRestRequestAsync(ExampleRestRequestBuilder.BuildMessageRequest(item.Message, _instance?.InstanceId))" Class="tree-button">Send request</FluentButton>
-                        }
-                        else
-                        {
-                            @context.Text
-                        }
-                    </ItemTemplate>
-                </FluentTreeView>
+                </FluentCard>
+            </FluentStack>
 
-            </FluentCard>
-        </FluentStack>
-
-    </div>
+        </div>
+    }
 
 </div>
-
 

--- a/src/FlowzerFrontend/Pages/Instance.razor.cs
+++ b/src/FlowzerFrontend/Pages/Instance.razor.cs
@@ -82,9 +82,10 @@ public partial class Instance
     private async Task ShowVariables(List<TokenDto> instanceTokens)
     {
         var rootTokens = instanceTokens.Where(x => x.ParentTokenId == null || x.ParentTokenId == Guid.Empty).ToList();
-        if (rootTokens.Count != 1)
+        if (rootTokens.Count == 0)
         {
-            throw new Exception("There should be exactly one root token");
+            VariableItems = [];
+            return;
         }
         VariableItems =  GetTokenTreeViewItem(instanceTokens, rootTokens);
         
@@ -330,7 +331,18 @@ public partial class Instance
 
     private async Task Reload()
     {
-        await InitViewer();
-        await LoadData();
+        try
+        {
+            await InitViewer();
+            await LoadData();
+        }
+        catch (Exception exception)
+        {
+            _instance = null;
+            Items = [];
+            VariableItems = [];
+            VariableContent = null;
+            ErrorString = $"Could not load instance details. {exception.Message}";
+        }
     }
 }

--- a/src/FlowzerFrontend/Pages/Instances.razor
+++ b/src/FlowzerFrontend/Pages/Instances.razor
@@ -1,4 +1,6 @@
 @page "/instances"
+@page "/instances/{Filter}"
+@using FlowzerFrontend.BusinessLogic
 @using Microsoft.FluentUI.AspNetCore.Components
 @using WebApiEngine.Shared
 
@@ -8,56 +10,73 @@
     <LayoutWithLeftMenu>
         <MenuContent>
             <FluentNavMenu>
-                <FluentNavLink Icon="@(new Icons.Regular.Size20.PersonRunning())" Href="/instances/all">All Instances</FluentNavLink>
-                <FluentNavLink Icon="@(new Icons.Filled.Size20.RecordStop())" Href="/instances/done">Done</FluentNavLink>
-                <FluentNavLink Icon="@(new Icons.Regular.Size20.Warning())" Href="/instances/active">Error</FluentNavLink>
+                <FluentNavLink Icon="@(new Icons.Regular.Size20.PersonRunning())" Href="@UriHelper.GetInstancesUrl(InstanceListFilterHelper.ToRouteSegment(InstanceListFilter.All))">All Instances</FluentNavLink>
+                <FluentNavLink Icon="@(new Icons.Regular.Size20.Play())" Href="@UriHelper.GetInstancesUrl(InstanceListFilterHelper.ToRouteSegment(InstanceListFilter.Active))">Active Instances</FluentNavLink>
+                <FluentNavLink Icon="@(new Icons.Filled.Size20.RecordStop())" Href="@UriHelper.GetInstancesUrl(InstanceListFilterHelper.ToRouteSegment(InstanceListFilter.Done))">Done Instances</FluentNavLink>
+                <FluentNavLink Icon="@(new Icons.Regular.Size20.Warning())" Href="@UriHelper.GetInstancesUrl(InstanceListFilterHelper.ToRouteSegment(InstanceListFilter.Error))">Failed Instances</FluentNavLink>
             </FluentNavMenu>
         </MenuContent>
         <MainContent>
             <FluentStack Orientation="Orientation.Vertical" Width="100%">
                 <h1>Instances</h1>
+                <p id="instances-filter-label">Showing: @CurrentFilterLabel</p>
 
-                <div class="list-header">
-                    <FluentDataGrid Items="@Data" style="width: 100%;" GridTemplateColumns="80px 1fr auto" ShowHover="true">
-                        <SelectColumn TGridItem="ProcessInstanceInfoDto" SelectMode="DataGridSelectMode.Multiple" @bind-SelectedItems="@SelectedItems"/>
-                        <TemplateColumn Title="Workflow">
-                            <div class="grid-row-title"><a href="@UriHelper.GetShowInstanceUrl(@context.InstanceId)">@context.RelatedDefinitionName</a></div>
-                            <div class="grid-row-subtitle">Instance @context.InstanceId</div>
-                            <div class="grid-row-description">
-                                @if (context.MessageSubscriptionCount > 0)
-                                {
-                                    <div class="batch">
-                                        <i class="fa-regular fa-envelope"></i> @context.MessageSubscriptionCount Messages
-                                    </div>
-                                }
+                @if (IsLoading)
+                {
+                    <p id="instances-loading-state">Loading instances...</p>
+                }
+                else if (!string.IsNullOrWhiteSpace(LoadErrorMessage))
+                {
+                    <p id="instances-load-error" role="alert">@LoadErrorMessage</p>
+                }
+                else if (!Data.Any())
+                {
+                    <p id="instances-empty-state">No instances match the selected filter.</p>
+                }
+                else
+                {
+                    <div class="list-header">
+                        <FluentDataGrid Items="@Data" style="width: 100%;" GridTemplateColumns="80px 1fr auto" ShowHover="true">
+                            <SelectColumn TGridItem="ProcessInstanceInfoDto" SelectMode="DataGridSelectMode.Multiple" @bind-SelectedItems="@SelectedItems"/>
+                            <TemplateColumn Title="Workflow">
+                                <div class="grid-row-title"><a href="@UriHelper.GetShowInstanceUrl(@context.InstanceId)">@context.RelatedDefinitionName</a></div>
+                                <div class="grid-row-subtitle">Instance @context.InstanceId</div>
+                                <div class="grid-row-description">
+                                    @if (context.MessageSubscriptionCount > 0)
+                                    {
+                                        <div class="batch">
+                                            <i class="fa-regular fa-envelope"></i> @context.MessageSubscriptionCount Messages
+                                        </div>
+                                    }
 
-                                @if (context.SignalSubscriptionCount > 0)
-                                {
-                                    <div class="batch">
-                                        <i class="fa-solid fa-tower-broadcast"></i> @context.SignalSubscriptionCount Singals
-                                    </div>
-                                }
+                                    @if (context.SignalSubscriptionCount > 0)
+                                    {
+                                        <div class="batch">
+                                            <i class="fa-solid fa-tower-broadcast"></i> @context.SignalSubscriptionCount Singals
+                                        </div>
+                                    }
 
-                                @if (context.UserTaskSubscriptionCount > 0)
-                                {
-                                    <div class="batch">
-                                        <i class="fa-regular fa-user"></i> @context.UserTaskSubscriptionCount UserTasks
-                                    </div>
-                                }
-                                @if (context.ServiceSubscriptionCount > 0)
-                                {
-                                    <div class="batch">
-                                        <i class="fa-solid fa-robot"></i> @context.ServiceSubscriptionCount Services
-                                    </div>
-                                }
+                                    @if (context.UserTaskSubscriptionCount > 0)
+                                    {
+                                        <div class="batch">
+                                            <i class="fa-regular fa-user"></i> @context.UserTaskSubscriptionCount UserTasks
+                                        </div>
+                                    }
+                                    @if (context.ServiceSubscriptionCount > 0)
+                                    {
+                                        <div class="batch">
+                                            <i class="fa-solid fa-robot"></i> @context.ServiceSubscriptionCount Services
+                                        </div>
+                                    }
 
-                            </div>
-                        </TemplateColumn>
-                        <TemplateColumn Title="Status">
-                            <div class="state">@context.State</div>
-                        </TemplateColumn>
-                    </FluentDataGrid>
-                </div>
+                                </div>
+                            </TemplateColumn>
+                            <TemplateColumn Title="Status">
+                                <div class="state">@context.State</div>
+                            </TemplateColumn>
+                        </FluentDataGrid>
+                    </div>
+                }
 
             </FluentStack>
         </MainContent>

--- a/src/FlowzerFrontend/Pages/Instances.razor
+++ b/src/FlowzerFrontend/Pages/Instances.razor
@@ -20,6 +20,9 @@
             <FluentStack Orientation="Orientation.Vertical" Width="100%">
                 <h1>Instances</h1>
                 <p id="instances-filter-label">Showing: @CurrentFilterLabel</p>
+                @{
+                    var items = Data.ToList();
+                }
 
                 @if (IsLoading)
                 {
@@ -29,14 +32,14 @@
                 {
                     <p id="instances-load-error" role="alert">@LoadErrorMessage</p>
                 }
-                else if (!Data.Any())
+                else if (!items.Any())
                 {
                     <p id="instances-empty-state">No instances match the selected filter.</p>
                 }
                 else
                 {
                     <div class="list-header">
-                        <FluentDataGrid Items="@Data" style="width: 100%;" GridTemplateColumns="80px 1fr auto" ShowHover="true">
+                        <FluentDataGrid Items="@items.AsQueryable()" style="width: 100%;" GridTemplateColumns="80px 1fr auto" ShowHover="true">
                             <SelectColumn TGridItem="ProcessInstanceInfoDto" SelectMode="DataGridSelectMode.Multiple" @bind-SelectedItems="@SelectedItems"/>
                             <TemplateColumn Title="Workflow">
                                 <div class="grid-row-title"><a href="@UriHelper.GetShowInstanceUrl(@context.InstanceId)">@context.RelatedDefinitionName</a></div>
@@ -52,7 +55,7 @@
                                     @if (context.SignalSubscriptionCount > 0)
                                     {
                                         <div class="batch">
-                                            <i class="fa-solid fa-tower-broadcast"></i> @context.SignalSubscriptionCount Singals
+                                            <i class="fa-solid fa-tower-broadcast"></i> @context.SignalSubscriptionCount Signals
                                         </div>
                                     }
 

--- a/src/FlowzerFrontend/Pages/Instances.razor.cs
+++ b/src/FlowzerFrontend/Pages/Instances.razor.cs
@@ -1,25 +1,50 @@
 using Microsoft.AspNetCore.Components;
+using FlowzerFrontend.BusinessLogic;
 using WebApiEngine.Shared;
 
 namespace FlowzerFrontend.Pages;
 
 public partial class Instances : ComponentBase
 {
+    [Parameter] public string? Filter { get; set; }
+
     [Inject]
     public required FlowzerApi FlowzerApi { get; set; }
     
-    
-    public IQueryable<ProcessInstanceInfoDto>? Data { get; set; } = new List<ProcessInstanceInfoDto>().AsQueryable();
+    private List<ProcessInstanceInfoDto> AllInstances { get; set; } = [];
+    private bool IsLoading { get; set; } = true;
+    private string? LoadErrorMessage { get; set; }
+    private InstanceListFilter CurrentFilter { get; set; } = InstanceListFilter.All;
+
+    public IQueryable<ProcessInstanceInfoDto> Data =>
+        InstanceListFilterHelper.Apply(AllInstances, CurrentFilter).AsQueryable();
+
+    public string CurrentFilterLabel => InstanceListFilterHelper.ToDisplayLabel(CurrentFilter);
     public IEnumerable<ProcessInstanceInfoDto> SelectedItems { get; set; } = new List<ProcessInstanceInfoDto>(); 
     
     
     protected override async Task OnParametersSetAsync()
     {
+        CurrentFilter = InstanceListFilterHelper.ParseOrDefault(Filter);
         await LoadData();
     }
 
     private async Task LoadData()
     {
-        Data = (await FlowzerApi.GetAllRunningInstances()).AsQueryable();
+        IsLoading = true;
+        try
+        {
+            AllInstances = (await FlowzerApi.GetAllRunningInstances()).ToList();
+            LoadErrorMessage = null;
+        }
+        catch (Exception exception)
+        {
+            AllInstances = [];
+            LoadErrorMessage = $"Could not load instances. {exception.Message}";
+        }
+        finally
+        {
+            IsLoading = false;
+        }
     }
 }

--- a/src/FlowzerFrontend/Pages/Instances.razor.cs
+++ b/src/FlowzerFrontend/Pages/Instances.razor.cs
@@ -34,7 +34,7 @@ public partial class Instances : ComponentBase
         IsLoading = true;
         try
         {
-            AllInstances = (await FlowzerApi.GetAllRunningInstances()).ToList();
+            AllInstances = (await FlowzerApi.GetAllInstances()).ToList();
             LoadErrorMessage = null;
         }
         catch (Exception exception)

--- a/src/FlowzerFrontend/Pages/Models.razor
+++ b/src/FlowzerFrontend/Pages/Models.razor
@@ -16,6 +16,9 @@
         <MainContent>
             <FluentStack Orientation="Orientation.Vertical" Width="100%">
                 <h1>Models</h1>
+                @{
+                    var items = Data.ToList();
+                }
                 <div class="list-header">
                     <FluentStack Orientation="Orientation.Vertical" Width="100%">
                         <FluentTextField @bind-Value="SearchText" Style="min-width: 60%;" Appearance="FluentInputAppearance.Filled" Placeholder="Search">
@@ -44,14 +47,14 @@
                 {
                     <p id="models-load-error" role="alert">@LoadErrorMessage</p>
                 }
-                else if (!Data.Any())
+                else if (!items.Any())
                 {
                     <p id="models-empty-state">No models match the current filter.</p>
                 }
                 else
                 {
                     <div class="list-header">
-                        <FluentDataGrid Items="@Data" style="width: 100%;" GridTemplateColumns="80px 1fr auto" ShowHover="true"  >
+                        <FluentDataGrid Items="@items.AsQueryable()" style="width: 100%;" GridTemplateColumns="80px 1fr auto" ShowHover="true"  >
                             <SelectColumn TGridItem="ExtendedBpmnMetaDefinitionDto" SelectMode="DataGridSelectMode.Multiple" @bind-SelectedItems="@SelectedItems"  />
                             <TemplateColumn Title="Workflow">
                                 <FluentLayout Orientation="Orientation.Horizontal">

--- a/src/FlowzerFrontend/Pages/Models.razor
+++ b/src/FlowzerFrontend/Pages/Models.razor
@@ -1,6 +1,6 @@
 @page "/models"
 
-
+@using FlowzerFrontend.BusinessLogic
 @using Microsoft.FluentUI.AspNetCore.Components
 @using WebApiEngine.Shared
 <div class="main-content">
@@ -10,7 +10,7 @@
                 New Model
             </FluentButton>
             <FluentNavMenu Collapsible="false">
-                <FluentNavLink Icon="@(new Icons.Regular.Size24.Home())" Href="/NavMenu">All Models</FluentNavLink>
+                <FluentNavLink Icon="@(new Icons.Regular.Size24.Home())" Href="/models">All Models</FluentNavLink>
             </FluentNavMenu>
         </MenuContent>
         <MainContent>
@@ -18,11 +18,10 @@
                 <h1>Models</h1>
                 <div class="list-header">
                     <FluentStack Orientation="Orientation.Vertical" Width="100%">
-                        <FluentTextField Style="min-width: 60%;" Appearance="FluentInputAppearance.Filled" Placeholder="Search">
+                        <FluentTextField @bind-Value="SearchText" Style="min-width: 60%;" Appearance="FluentInputAppearance.Filled" Placeholder="Search">
                             <FluentIcon Value="@(new Icons.Regular.Size16.Search())" Slot="start" Color="Color.Neutral"/>
                         </FluentTextField>
                         <FluentStack Orientation="Orientation.Horizontal" VerticalAlignment="VerticalAlignment.Center"  Width="100%">
-                            <FluentCheckbox @bind-Value="CheckAll" Label="Check all" Style="min-width: 200px;" />
                             <FluentStack Orientation="Orientation.Horizontal" VerticalAlignment="VerticalAlignment.Center" HorizontalAlignment="HorizontalAlignment.End" Width="100%">
                                 <FluentCombobox Placeholder="Sort direction" Autofocus="true"
                                                 TOption="Option<SortDirection>"
@@ -37,45 +36,57 @@
                 </div>
 
                 <FluentDivider Style="width: 100%;" Role="DividerRole.Separator"></FluentDivider>
-                <div class="list-header">
-                    <FluentDataGrid Items="@Data" style="width: 100%;" GridTemplateColumns="80px 1fr auto" ShowHover="true"  >
-                        <SelectColumn TGridItem="ExtendedBpmnMetaDefinitionDto" SelectMode="DataGridSelectMode.Multiple" @bind-SelectedItems="@SelectedItems"  />
-                        <TemplateColumn Title="Workflow">
-                            <FluentLayout Orientation="Orientation.Horizontal">
-                                <div>
-                                    <i class="fa-solid fa-code-compare icon"></i>    
-                                </div>
-                                <FluentLayout Orientation="Orientation.Vertical">
-                                    <div class="grid-row-title"><a href="@UriHelper.GetEditDefinitionUrl(@context.DefinitionId)">@context.Name</a></div>
-                                    <div class="grid-row-subtitle">Workflow</div>
-                                    <div class="grid-row-description">@context.Description</div>
+                @if (IsLoading)
+                {
+                    <p id="models-loading-state">Loading models...</p>
+                }
+                else if (!string.IsNullOrWhiteSpace(LoadErrorMessage))
+                {
+                    <p id="models-load-error" role="alert">@LoadErrorMessage</p>
+                }
+                else if (!Data.Any())
+                {
+                    <p id="models-empty-state">No models match the current filter.</p>
+                }
+                else
+                {
+                    <div class="list-header">
+                        <FluentDataGrid Items="@Data" style="width: 100%;" GridTemplateColumns="80px 1fr auto" ShowHover="true"  >
+                            <SelectColumn TGridItem="ExtendedBpmnMetaDefinitionDto" SelectMode="DataGridSelectMode.Multiple" @bind-SelectedItems="@SelectedItems"  />
+                            <TemplateColumn Title="Workflow">
+                                <FluentLayout Orientation="Orientation.Horizontal">
+                                    <div>
+                                        <i class="fa-solid fa-code-compare icon"></i>    
+                                    </div>
+                                    <FluentLayout Orientation="Orientation.Vertical">
+                                        <div class="grid-row-title"><a href="@UriHelper.GetEditDefinitionUrl(@context.DefinitionId)">@context.Name</a></div>
+                                        <div class="grid-row-subtitle">Workflow</div>
+                                        <div class="grid-row-description">@context.Description</div>
+                                    </FluentLayout>
                                 </FluentLayout>
-                            </FluentLayout>
-                            
-
-                        </TemplateColumn>
-                        <TemplateColumn Title="Latest Version">
-                            <div class="lastchange">@(context.LatestVersion?.ToString() ?? "-")</div>
-                            @if (context.DeployedVersion == context.LatestVersion)
-                            {
-                                <a href="@UriHelper.GetEditDefinitionUrl(context.DefinitionId, context.DeployedId)">
-                                    <FluentBadge Appearance="Appearance.Neutral" BackgroundColor="green" Color="white">Deployed</FluentBadge>
-                                </a>
-                            }
-                            else if (context.DeployedVersion == null)
-                            {
-                                <FluentBadge  Appearance="Appearance.Lightweight">Not Deployed</FluentBadge>
-                            }
-                            else
-                            {
-                                <a href="@UriHelper.GetEditDefinitionUrl(context.DefinitionId, context.DeployedId)">
-                                    <FluentBadge Appearance="Appearance.Accent">@context.DeployedVersion Deployed</FluentBadge>
-                                </a>
-                            }
-                        </TemplateColumn>
-    
-                    </FluentDataGrid>
-                </div>
+                            </TemplateColumn>
+                            <TemplateColumn Title="Latest Version">
+                                <div class="lastchange">@(context.LatestVersion?.ToString() ?? "-")</div>
+                                @if (context.DeployedVersion == context.LatestVersion)
+                                {
+                                    <a href="@UriHelper.GetEditDefinitionUrl(context.DefinitionId, context.DeployedId)">
+                                        <FluentBadge Appearance="Appearance.Neutral" BackgroundColor="green" Color="white">Deployed</FluentBadge>
+                                    </a>
+                                }
+                                else if (context.DeployedVersion == null)
+                                {
+                                    <FluentBadge  Appearance="Appearance.Lightweight">Not Deployed</FluentBadge>
+                                }
+                                else
+                                {
+                                    <a href="@UriHelper.GetEditDefinitionUrl(context.DefinitionId, context.DeployedId)">
+                                        <FluentBadge Appearance="Appearance.Accent">@context.DeployedVersion Deployed</FluentBadge>
+                                    </a>
+                                }
+                            </TemplateColumn>
+                        </FluentDataGrid>
+                    </div>
+                }
             </FluentStack>
         </MainContent>
     </LayoutWithLeftMenu>

--- a/src/FlowzerFrontend/Pages/Models.razor.cs
+++ b/src/FlowzerFrontend/Pages/Models.razor.cs
@@ -1,23 +1,23 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
+using FlowzerFrontend.BusinessLogic;
 using WebApiEngine.Shared;
 
 namespace FlowzerFrontend.Pages;
 
 public partial class Models 
 {
- 
-
     [Inject]
     public required FlowzerApi FlowzerApi { get; set; }
 
     [Inject]
     public required NavigationManager NavigationManager { get; set; }
 
-    public bool Expanded { get; set; } = true;
-    public bool CheckAll { get; set; } = true;
-
     public IEnumerable<ExtendedBpmnMetaDefinitionDto> SelectedItems { get; set; } = new List<ExtendedBpmnMetaDefinitionDto>(); 
+    private List<ExtendedBpmnMetaDefinitionDto> AllModels { get; set; } = [];
+    private bool IsLoading { get; set; } = true;
+    private string? LoadErrorMessage { get; set; }
+    public string? SearchText { get; set; }
     
     public List<Option<SortDirection>> SortDirections = new()
     {
@@ -27,9 +27,16 @@ public partial class Models
     
     public Option<SortDirection>? SelectedSortDirection { get; set; }
     public string? SelectedSortDirectionString { get; set; }
-    public IQueryable<ExtendedBpmnMetaDefinitionDto>? Data { get; set; } = new List<ExtendedBpmnMetaDefinitionDto>().AsQueryable();
-    
-    
+    public IQueryable<ExtendedBpmnMetaDefinitionDto> Data =>
+        ModelListViewHelper
+            .ApplyQuery(AllModels, SearchText, SelectedSortDirection?.Value ?? SortDirection.Ascending)
+            .AsQueryable();
+
+    protected override void OnInitialized()
+    {
+        SelectedSortDirection = SortDirections.First();
+        SelectedSortDirectionString = SelectedSortDirection.Text;
+    }
     
     protected override async Task OnParametersSetAsync()
     {
@@ -45,6 +52,20 @@ public partial class Models
     
     private async Task LoadData()
     {
-        Data = (await FlowzerApi.GetAllBpmnMetaDefinitions()).AsQueryable();
+        IsLoading = true;
+        try
+        {
+            AllModels = (await FlowzerApi.GetAllBpmnMetaDefinitions()).ToList();
+            LoadErrorMessage = null;
+        }
+        catch (Exception exception)
+        {
+            AllModels = [];
+            LoadErrorMessage = $"Could not load models. {exception.Message}";
+        }
+        finally
+        {
+            IsLoading = false;
+        }
     }
 }

--- a/src/FlowzerFrontend/UriHelper.cs
+++ b/src/FlowzerFrontend/UriHelper.cs
@@ -12,6 +12,11 @@ public class UriHelper
         return $"/instance/{instanceId}";
     }
 
+    public static string GetInstancesUrl(string? filter = null)
+    {
+        return string.IsNullOrWhiteSpace(filter) ? "/instances" : $"/instances/{filter}";
+    }
+
     public static string GetShowFormUrl(Guid formId)
     {
         return $"/forms/{formId}";

--- a/src/StorageSystemShared/IInstanceStorage.cs
+++ b/src/StorageSystemShared/IInstanceStorage.cs
@@ -5,4 +5,5 @@ public interface IInstanceStorage
     public Task<ProcessInstanceInfo> GetProcessInstance(Guid processInstanceId);
     Task AddOrUpdateInstance(ProcessInstanceInfo processInstanceInfo);
     Task<IEnumerable<ProcessInstanceInfo>> GetAllActiveInstances();
+    Task<IEnumerable<ProcessInstanceInfo>> GetAllInstances();
 }

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -362,6 +362,11 @@ public class ApiHardeningIntegrationTest
         {
             return Task.FromResult(Enumerable.Empty<ProcessInstanceInfo>());
         }
+
+        public Task<IEnumerable<ProcessInstanceInfo>> GetAllInstances()
+        {
+            return Task.FromResult(Enumerable.Empty<ProcessInstanceInfo>());
+        }
     }
 
     private sealed class TestFormStorage(TestStorage storage) : IFormStorage

--- a/src/WebApiEngine.Tests/FormControllerIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/FormControllerIntegrationTest.cs
@@ -272,5 +272,6 @@ public class FormControllerIntegrationTest
         public Task<ProcessInstanceInfo> GetProcessInstance(Guid processInstanceId) => throw new NotSupportedException();
         public Task AddOrUpdateInstance(ProcessInstanceInfo processInstance) => Task.CompletedTask;
         public Task<IEnumerable<ProcessInstanceInfo>> GetAllActiveInstances() => Task.FromResult(Enumerable.Empty<ProcessInstanceInfo>());
+        public Task<IEnumerable<ProcessInstanceInfo>> GetAllInstances() => Task.FromResult(Enumerable.Empty<ProcessInstanceInfo>());
     }
 }

--- a/src/WebApiEngine.Tests/InstanceControllerIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/InstanceControllerIntegrationTest.cs
@@ -61,6 +61,30 @@ public class InstanceControllerIntegrationTest
         payload.Result.Should().OnlyContain(token => token.State == FlowNodeStateDto.Active);
     }
 
+    [Test]
+    public async Task GetAllInstances_ShouldIncludeFinishedInstances_ForDoneAndErrorFilters()
+    {
+        var activeInstanceId = Guid.NewGuid();
+        var completedInstanceId = Guid.NewGuid();
+        var failedInstanceId = Guid.NewGuid();
+        var storage = TestStorage.CreateWithInstances(activeInstanceId, completedInstanceId, failedInstanceId);
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/instance");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<List<ProcessInstanceInfoDto>>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeTrue();
+        payload.Result.Should().NotBeNull();
+        payload.Result!.Select(instance => instance.InstanceId).Should().BeEquivalentTo(
+            [activeInstanceId, completedInstanceId, failedInstanceId]);
+        payload.Result.Should().Contain(instance => instance.State == ProcessInstanceStateDto.Completed);
+        payload.Result.Should().Contain(instance => instance.State == ProcessInstanceStateDto.Failed);
+    }
+
     /// <summary>
     /// Kleine Test-Factory, die die produktiven Storage-Services durch einen in-memory Test-Store ersetzt.
     /// Damit werden die echten Controller, das Routing und die Serialisierung gegen einen realen Testserver geprüft.
@@ -169,6 +193,47 @@ public class InstanceControllerIntegrationTest
             return storage;
         }
 
+        public static TestStorage CreateWithInstances(Guid activeInstanceId, Guid completedInstanceId, Guid failedInstanceId)
+        {
+            var definitionId = Guid.NewGuid();
+            var definitionStorage = new TestDefinitionStorage(
+                new BpmnMetaDefinition
+                {
+                    DefinitionId = "invoice-process",
+                    Name = "Invoice Process"
+                });
+
+            var instanceStorage = new TestInstanceStorage(
+                CreateProcessInstance(activeInstanceId, definitionId, ProcessInstanceState.Running, false),
+                CreateProcessInstance(completedInstanceId, definitionId, ProcessInstanceState.Completed, true),
+                CreateProcessInstance(failedInstanceId, definitionId, ProcessInstanceState.Failed, true));
+
+            var subscriptionStorage = new TestMessageSubscriptionStorage();
+            return new TestStorage(definitionId, definitionStorage, subscriptionStorage, instanceStorage);
+        }
+
+        private static ProcessInstanceInfo CreateProcessInstance(
+            Guid instanceId,
+            Guid definitionId,
+            ProcessInstanceState state,
+            bool isFinished)
+        {
+            return new ProcessInstanceInfo
+            {
+                InstanceId = instanceId,
+                metaDefinitionId = "invoice-process",
+                DefinitionId = definitionId,
+                ProcessId = "Process_Invoice",
+                Tokens = [],
+                IsFinished = isFinished,
+                State = state,
+                MessageSubscriptionCount = 0,
+                SignalSubscriptionCount = 0,
+                UserTaskSubscriptionCount = 0,
+                ServiceSubscriptionCount = 0
+            };
+        }
+
         public IDefinitionStorage DefinitionStorage => DefinitionStorageSeed;
         public IMessageSubscriptionStorage SubscriptionStorage => SubscriptionStorageSeed;
         public IInstanceStorage InstanceStorage => InstanceStorageSeed;
@@ -253,11 +318,13 @@ public class InstanceControllerIntegrationTest
         public Task RemoveAllUserTaskSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
     }
 
-    private sealed class TestInstanceStorage(ProcessInstanceInfo instance) : IInstanceStorage
+    private sealed class TestInstanceStorage(params ProcessInstanceInfo[] instances) : IInstanceStorage
     {
+        private readonly Dictionary<Guid, ProcessInstanceInfo> _instances = instances.ToDictionary(instance => instance.InstanceId);
+
         public Task<ProcessInstanceInfo> GetProcessInstance(Guid processInstanceId)
         {
-            return processInstanceId == instance.InstanceId
+            return _instances.TryGetValue(processInstanceId, out var instance)
                 ? Task.FromResult(instance)
                 : throw new KeyNotFoundException($"Unknown process instance: {processInstanceId}");
         }
@@ -265,7 +332,10 @@ public class InstanceControllerIntegrationTest
         public Task AddOrUpdateInstance(ProcessInstanceInfo processInstanceInfo) => Task.CompletedTask;
 
         public Task<IEnumerable<ProcessInstanceInfo>> GetAllActiveInstances() =>
-            Task.FromResult<IEnumerable<ProcessInstanceInfo>>([instance]);
+            Task.FromResult(_instances.Values.Where(instance => !instance.IsFinished).AsEnumerable());
+
+        public Task<IEnumerable<ProcessInstanceInfo>> GetAllInstances() =>
+            Task.FromResult(_instances.Values.AsEnumerable());
     }
 
     private sealed class TestFormStorage : IFormStorage

--- a/src/WebApiEngine/Controller/InstanceController.cs
+++ b/src/WebApiEngine/Controller/InstanceController.cs
@@ -11,9 +11,9 @@ public class InstanceController(
     IStorageSystem storageSystem) : FlowzerControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<ProcessInstanceInfoDto>>> GetAllRunningInstances()
+    public async Task<ActionResult<IEnumerable<ProcessInstanceInfoDto>>> GetAllInstances()
     {
-        var instances = await storageSystem.InstanceStorage.GetAllActiveInstances();
+        var instances = await storageSystem.InstanceStorage.GetAllInstances();
         return Ok(await MapInstances(instances));
     }
 

--- a/tests/ui-smoke/tests/navigation.spec.js
+++ b/tests/ui-smoke/tests/navigation.spec.js
@@ -19,7 +19,27 @@ const smokePages = [
   {
     path: '/instances',
     heading: 'Instances',
-    readyText: 'All Instances'
+    readyText: 'Showing: All instances'
+  },
+  {
+    path: '/instances/all',
+    heading: 'Instances',
+    readyText: 'Showing: All instances'
+  },
+  {
+    path: '/instances/active',
+    heading: 'Instances',
+    readyText: 'Showing: Active instances'
+  },
+  {
+    path: '/instances/done',
+    heading: 'Instances',
+    readyText: 'Showing: Completed instances'
+  },
+  {
+    path: '/instances/error',
+    heading: 'Instances',
+    readyText: 'Showing: Failed instances'
   }
 ];
 
@@ -55,4 +75,24 @@ test('Hauptnavigation springt zwischen den Kernseiten', async ({ page }) => {
   await page.getByRole('link', { name: 'Instances' }).click();
   await expect(page).toHaveURL(/\/instances$/);
   await expect(page.getByRole('heading', { level: 1, name: 'Instances' })).toBeVisible();
+});
+
+test('Instanzfilter-Navigation bleibt innerhalb gültiger Frontend-Routen', async ({ page }) => {
+  await page.goto('/instances', { waitUntil: 'networkidle' });
+
+  await page.getByRole('link', { name: 'All Instances' }).click();
+  await expect(page).toHaveURL(/\/instances\/all$/);
+  await expect(page.getByText('Showing: All instances')).toBeVisible();
+
+  await page.getByRole('link', { name: 'Active Instances' }).click();
+  await expect(page).toHaveURL(/\/instances\/active$/);
+  await expect(page.getByText('Showing: Active instances')).toBeVisible();
+
+  await page.getByRole('link', { name: 'Done Instances' }).click();
+  await expect(page).toHaveURL(/\/instances\/done$/);
+  await expect(page.getByText('Showing: Completed instances')).toBeVisible();
+
+  await page.getByRole('link', { name: 'Failed Instances' }).click();
+  await expect(page).toHaveURL(/\/instances\/error$/);
+  await expect(page.getByText('Showing: Failed instances')).toBeVisible();
 });


### PR DESCRIPTION
## Zusammenfassung

Dieses PR härtet die Frontend-Navigation und die zentralen Kernseiten auf `next`.

Schwerpunkte sind:

- keine toten Navigationspfade mehr innerhalb der Instanzliste
- sichtbare Lade-, Fehler- und Empty-States auf den Kernseiten
- defensivere Routenbehandlung für Formularseiten
- zusätzliche Unit- und UI-Smoke-Tests für Navigation und Filterpfade

## Änderungen

- gültige Instanzfilter-Routen (`/instances/all`, `/instances/active`, `/instances/done`, `/instances/error`) eingeführt
- Instanzfilter über `InstanceListFilterHelper` zentralisiert und testbar gemacht
- Modellliste über `ModelListViewHelper` für Suche/Sortierung gekapselt
- Formularrouten über `FormRouteHelper` defensiv geparst statt direkt `Guid.Parse` zu verwenden
- Start-, Modell-, Formular- und Instanzseiten mit Inline-Lade-/Fehler-/Empty-States gehärtet
- fehlerhafte oder irreführende Links bereinigt (u. a. Modellliste, Instanzdetail-Backlink)
- mehrere `async void`-Handler in Kernpfaden auf `Task`/`EventCallback` umgestellt
- UI-Smoke-Tests und Frontend-Doku für die neuen Navigationspfade erweitert

## Tests

- `dotnet build core-engine.sln --configuration Release --no-restore`
- `dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-restore --logger 'console;verbosity=minimal'`
- `dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-restore --logger 'console;verbosity=minimal'`
- `dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-restore --logger 'console;verbosity=minimal'`
- `cd tests/ui-smoke && npm test`

## Bezug

Closes #47
