### PR TITLE
Playwright-Kernpfade und Instanzansicht härten

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -96,7 +96,7 @@ PLAYWRIGHT_SKIP_WEBSERVERS=1 npm --prefix tests/ui-smoke run test
 
 Die dateibasierte Persistenz landet standardmäßig unterhalb der Build-Ausgabe von `FilesystemStorageSystem`.
 
-Für reproduzierbare Playwright-Läufe setzt die Testkonfiguration automatisch ein eigenes `FLOWZER_STORAGE_ROOT` und räumt dieses Verzeichnis vor dem Start der verwalteten Webserver auf. Wenn Web-API und Frontend manuell gestartet werden, kann dasselbe Verhalten lokal explizit aktiviert werden:
+Für reproduzierbare Playwright-Läufe setzt die Testkonfiguration automatisch ein eigenes `FLOWZER_STORAGE_ROOT` für die verwalteten Webserver. Der Pfad wird über `PLAYWRIGHT_MANAGED_STORAGE_ROOT` gesteuert und aus Sicherheitsgründen nur unterhalb von `tests/ui-smoke/.tmp` gelöscht bzw. neu aufgebaut. Wenn Web-API und Frontend manuell gestartet werden, kann dasselbe Verhalten lokal explizit aktiviert werden:
 
 ```bash
 FLOWZER_STORAGE_ROOT="$(pwd)/tests/ui-smoke/.tmp/manual-storage" \

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -44,7 +44,7 @@ Danach ist das Frontend unter [http://localhost:5269](http://localhost:5269) err
 
 ## Automatisierte UI-Smoke-Tests
 
-Die Smoke-Tests liegen unter `tests/ui-smoke` und prüfen aktuell die Kernrouten:
+Die Smoke- und kleinen Happy-Path-E2E-Tests liegen unter `tests/ui-smoke` und prüfen aktuell die Kernrouten:
 
 - `/`
 - `/models`
@@ -60,6 +60,7 @@ Geprüft werden insbesondere:
 - erfolgreiche Seitennavigation
 - sichtbare Kern-UI je Route
 - funktionierende Filter-Navigation innerhalb der Instanzliste
+- API-gesäte Happy Paths für Formulare, Modelle und Instanzverläufe
 - kein sichtbarer Blazor-Fatalfehler
 - keine fehlgeschlagenen Browser-Requests
 
@@ -93,4 +94,15 @@ PLAYWRIGHT_SKIP_WEBSERVERS=1 npm --prefix tests/ui-smoke run test
 
 ## Hinweise zur lokalen Datenbasis
 
-Die dateibasierte Persistenz landet unterhalb der Build-Ausgabe von `FilesystemStorageSystem`. Für saubere lokale Testläufe kann es sinnvoll sein, diese Ablage vorab zu leeren, wenn alte Modelldaten oder Formulare stören.
+Die dateibasierte Persistenz landet standardmäßig unterhalb der Build-Ausgabe von `FilesystemStorageSystem`.
+
+Für reproduzierbare Playwright-Läufe setzt die Testkonfiguration automatisch ein eigenes `FLOWZER_STORAGE_ROOT` und räumt dieses Verzeichnis vor dem Start der verwalteten Webserver auf. Wenn Web-API und Frontend manuell gestartet werden, kann dasselbe Verhalten lokal explizit aktiviert werden:
+
+```bash
+FLOWZER_STORAGE_ROOT="$(pwd)/tests/ui-smoke/.tmp/manual-storage" \
+ASPNETCORE_ENVIRONMENT=Development \
+dotnet run --project src/WebApiEngine/WebApiEngine.csproj \
+--configuration Release \
+--no-launch-profile \
+--urls http://localhost:5182
+```

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -92,6 +92,13 @@ Die Playwright-Konfiguration startet Web-API und Frontend standardmäßig selbst
 PLAYWRIGHT_SKIP_WEBSERVERS=1 npm --prefix tests/ui-smoke run test
 ```
 
+Der `npm test`-Pfad verwendet zusätzlich einen kleinen Prozesswächter. Dieser erkennt alte verwaiste `ms-playwright`-/`chrome-headless-shell`-Prozesse aus früheren Läufen und räumt nach dem Test auch neu entstandene Browser-Reste wieder weg. Damit bleiben keine CPU-intensiven Headless-Prozesse mehr unbemerkt liegen.
+
+Bei Bedarf kann das Verhalten angepasst werden:
+
+- `PLAYWRIGHT_SKIP_PROCESS_GUARD=1` deaktiviert den Wächter
+- `PLAYWRIGHT_PROCESS_STALE_THRESHOLD_SECONDS=<sekunden>` steuert, ab wann alte Browser-Prozesse als verwaist gelten
+
 ## Hinweise zur lokalen Datenbasis
 
 Die dateibasierte Persistenz landet standardmäßig unterhalb der Build-Ausgabe von `FilesystemStorageSystem`.

--- a/src/FilesystemStorageSystem/Storage.cs
+++ b/src/FilesystemStorageSystem/Storage.cs
@@ -6,9 +6,12 @@ namespace FilesystemStorageSystem;
 
 public class Storage : IStorageSystem
 {
+    public const string StorageRootEnvironmentVariableName = "FLOWZER_STORAGE_ROOT";
+    private readonly string _storageRoot;
     
     public Storage()
     {
+        _storageRoot = ResolveStorageRoot();
         SubscriptionStorage = new MessageSubscriptionStorage(this);
         DefinitionStorage = new DefinitionStorage(this);
         InstanceStorage = new InstanceStorage(this);
@@ -30,12 +33,22 @@ public class Storage : IStorageSystem
 
     public string GetBasePath(string name)
     {
-        var path = Path.Combine(Path.GetDirectoryName(this.GetType().Assembly.Location)!, name);
+        var path = Path.Combine(_storageRoot, name);
         if (!Directory.Exists(path))
             Directory.CreateDirectory(path);
         return path;
     }
-    
-    
+
+    private static string ResolveStorageRoot()
+    {
+        var configuredRoot = Environment.GetEnvironmentVariable(StorageRootEnvironmentVariableName);
+        if (!string.IsNullOrWhiteSpace(configuredRoot))
+        {
+            return Path.GetFullPath(configuredRoot);
+        }
+
+        return Path.GetDirectoryName(typeof(Storage).Assembly.Location)!
+               ?? throw new InvalidOperationException("Could not determine the default filesystem storage root.");
+    }
 
 }

--- a/src/FlowzerFrontend/Pages/EditDefinition.razor.cs
+++ b/src/FlowzerFrontend/Pages/EditDefinition.razor.cs
@@ -28,6 +28,8 @@ public partial class EditDefinition
  
     public string? ErrorString { get; set; }
     public bool IsDocumentLoading { get; set; } = true;
+    private bool IsEditorInitialized { get; set; }
+    private string? PendingXml { get; set; }
     
     
 
@@ -40,18 +42,29 @@ public partial class EditDefinition
     
     protected override async Task OnInitializedAsync()
     {
-        await JsRuntime.EvalCodeBehindJsScripts(this);
-        await InitEditor();
-    }
-
-
-    private async Task InitEditor()
-    {
-        await JsRuntime.InvokeVoidAsync("InitEdit");
         await LoadModel();
-        
     }
-    
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (firstRender)
+        {
+            await JsRuntime.EvalCodeBehindJsScripts(this);
+            await JsRuntime.InvokeVoidAsync("InitEdit");
+            IsEditorInitialized = true;
+        }
+
+        if (!IsEditorInitialized || string.IsNullOrWhiteSpace(PendingXml))
+        {
+            return;
+        }
+
+        var xml = PendingXml;
+        PendingXml = null;
+        await LoadDiagramXml(xml);
+    }
 
     private async Task LoadModel()
     {
@@ -81,7 +94,8 @@ public partial class EditDefinition
         }
         else
         {
-                await LoadDiagramXml(xml);
+            PendingXml = xml;
+            ErrorString = null;
         }
         
         IsDocumentLoading = false;

--- a/src/FlowzerFrontend/Pages/EditDefinition.razor.cs
+++ b/src/FlowzerFrontend/Pages/EditDefinition.razor.cs
@@ -30,6 +30,7 @@ public partial class EditDefinition
     public bool IsDocumentLoading { get; set; } = true;
     private bool IsEditorInitialized { get; set; }
     private string? PendingXml { get; set; }
+    private string? LastFailedXmlImport { get; set; }
     
     
 
@@ -51,9 +52,19 @@ public partial class EditDefinition
 
         if (firstRender)
         {
-            await JsRuntime.EvalCodeBehindJsScripts(this);
-            await JsRuntime.InvokeVoidAsync("InitEdit");
-            IsEditorInitialized = true;
+            try
+            {
+                await JsRuntime.EvalCodeBehindJsScripts(this);
+                await JsRuntime.InvokeVoidAsync("InitEdit");
+                IsEditorInitialized = true;
+                ErrorString = null;
+            }
+            catch (Exception exception)
+            {
+                ErrorString = $"Failed to initialize the BPMN editor: {exception.Message}";
+                await InvokeAsync(StateHasChanged);
+                return;
+            }
         }
 
         if (!IsEditorInitialized || string.IsNullOrWhiteSpace(PendingXml))
@@ -62,8 +73,26 @@ public partial class EditDefinition
         }
 
         var xml = PendingXml;
-        PendingXml = null;
-        await LoadDiagramXml(xml);
+
+        if (string.Equals(LastFailedXmlImport, xml, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        try
+        {
+            await LoadDiagramXml(xml);
+            PendingXml = null;
+            LastFailedXmlImport = null;
+            ErrorString = null;
+        }
+        catch (Exception exception)
+        {
+            LastFailedXmlImport = xml;
+            PendingXml = xml;
+            ErrorString = $"Failed to load BPMN XML into the editor: {exception.Message}";
+            await InvokeAsync(StateHasChanged);
+        }
     }
 
     private async Task LoadModel()
@@ -95,6 +124,7 @@ public partial class EditDefinition
         else
         {
             PendingXml = xml;
+            LastFailedXmlImport = null;
             ErrorString = null;
         }
         

--- a/src/FlowzerFrontend/Pages/EditForm.razor.cs
+++ b/src/FlowzerFrontend/Pages/EditForm.razor.cs
@@ -21,6 +21,8 @@ public partial class EditForm : FlowzerComponentBase
     public bool IsLoading { get; set; } = true;
 
     public bool IsNew { get; set; }
+    private string? PendingFormData { get; set; }
+    private bool IsFormDataLoadedIntoIframe { get; set; }
 
     public FormMetaDataDto CurrentFormMeta { get; set; } 
     public FormDto FormData { get; set; } = new()
@@ -70,8 +72,7 @@ public partial class EditForm : FlowzerComponentBase
                 var existingFormId = routeState.FormId!.Value;
                 CurrentFormMeta = await FlowzerApi.GetFormMetaData(existingFormId);    
                 FormData = await FlowzerApi.GetLatestForm(existingFormId);
-                if (!string.IsNullOrEmpty(FormData.FormData))
-                    await LoadFormData(FormData.FormData);
+                PendingFormData = FormData.FormData;
             }
 
             ErrorString = null;
@@ -83,6 +84,27 @@ public partial class EditForm : FlowzerComponentBase
         finally
         {
             IsLoading = false;
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (IsLoading || IsFormDataLoadedIntoIframe || string.IsNullOrWhiteSpace(PendingFormData) || !string.IsNullOrWhiteSpace(ErrorString))
+        {
+            return;
+        }
+
+        try
+        {
+            await LoadFormData(PendingFormData);
+            IsFormDataLoadedIntoIframe = true;
+        }
+        catch (Exception exception)
+        {
+            ErrorString = $"Could not initialize the form editor. {exception.Message}";
+            await InvokeAsync(StateHasChanged);
         }
     }
 

--- a/src/FlowzerFrontend/Pages/Instance.razor.cs
+++ b/src/FlowzerFrontend/Pages/Instance.razor.cs
@@ -15,6 +15,8 @@ public partial class Instance
     private const string UserTaskTreeItemKey = "user";
 
     private ProcessInstanceInfoDto? _instance;
+    private bool IsViewerInitialized { get; set; }
+    private string? PendingXml { get; set; }
 
     [Parameter] public Guid InstanceGuid { get; set; }
 
@@ -65,18 +67,39 @@ public partial class Instance
 
     protected override async Task OnInitializedAsync()
     {
-        await JsRuntime.EvalCodeBehindJsScripts(this);
         await Reload();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        try
+        {
+            if (firstRender)
+            {
+                await JsRuntime.EvalCodeBehindJsScripts(this);
+                await InitViewer();
+                IsViewerInitialized = true;
+            }
+
+            await TryRenderInstanceVisualizationAsync();
+        }
+        catch (Exception exception)
+        {
+            ErrorString = $"Could not render instance diagram. {exception.Message}";
+            await InvokeAsync(StateHasChanged);
+        }
     }
 
     private async Task LoadData()
     {
         _instance = await FlowzerApi.GetProcessInstance(InstanceGuid);
         var data = await FlowzerApi.GetXmlDefinition(_instance.DefinitionId);
-        await LoadDiagramXml(data);
-        await ShowTokens(_instance.Tokens);
+        PendingXml = data;
         await ShowVariables(_instance.Tokens);
         LoadMeesageSubscriptionOverview();
+        await InvokeAsync(StateHasChanged);
     }
 
     private async Task ShowVariables(List<TokenDto> instanceTokens)
@@ -333,16 +356,41 @@ public partial class Instance
     {
         try
         {
-            await InitViewer();
             await LoadData();
         }
         catch (Exception exception)
         {
             _instance = null;
+            PendingXml = null;
             Items = [];
             VariableItems = [];
             VariableContent = null;
             ErrorString = $"Could not load instance details. {exception.Message}";
         }
+
+        try
+        {
+            await TryRenderInstanceVisualizationAsync();
+        }
+        catch (Exception exception)
+        {
+            ErrorString = $"Could not render instance diagram. {exception.Message}";
+        }
+    }
+
+    private async Task TryRenderInstanceVisualizationAsync()
+    {
+        if (!IsViewerInitialized || _instance == null || string.IsNullOrWhiteSpace(PendingXml))
+        {
+            return;
+        }
+
+        var xml = PendingXml;
+        PendingXml = null;
+
+        await LoadDiagramXml(xml);
+        await ShowTokens(_instance.Tokens);
+        ErrorString = string.Empty;
+        await InvokeAsync(StateHasChanged);
     }
 }

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -153,6 +153,7 @@ public class ApiHardeningIntegrationTest
     {
         var storage = new TestStorage();
         var definitionId = Guid.NewGuid();
+        const string correlationKey = "INV-1000";
         storage.StoredDefinitions.Add(new BpmnDefinition
         {
             Id = definitionId,
@@ -184,7 +185,8 @@ public class ApiHardeningIntegrationTest
         storage.MessageSubscriptions.Add(new MessageSubscription(
             new MessageDefinition
             {
-                Name = "InvoiceReceived"
+                Name = "InvoiceReceived",
+                FlowzerCorrelationKey = correlationKey
             },
             "Process_Invoice",
             "invoice-process",
@@ -195,7 +197,8 @@ public class ApiHardeningIntegrationTest
 
         var response = await client.PostAsJsonAsync("/message", new MessageDto
         {
-            Name = "InvoiceReceived"
+            Name = "InvoiceReceived",
+            CorrelationKey = correlationKey
         });
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -203,6 +206,7 @@ public class ApiHardeningIntegrationTest
         payload.Should().NotBeNull();
         payload!.Successful.Should().BeTrue();
         payload.Result.Should().Contain("InvoiceReceived");
+        payload.Result.Should().Contain(correlationKey);
         payload.ErrorMessage.Should().BeNull();
     }
 

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -5,12 +5,15 @@ using System.Text;
 using BPMN.Common;
 using FluentAssertions;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Model;
 using StorageSystem;
 using WebApiEngine.Auth;
+using WebApiEngine.BusinessLogic;
+using WebApiEngine.Controller;
 using WebApiEngine.Shared;
 
 namespace WebApiEngine.Tests;
@@ -192,19 +195,19 @@ public class ApiHardeningIntegrationTest
             "invoice-process",
             definitionId));
 
-        await using var factory = new TestWebApplicationFactory(storage);
-        using var client = factory.CreateClient();
+        var controller = new MessageController(storage, new BpmnBusinessLogic(new TestTransactionalStorageProvider(storage)));
 
-        var response = await client.PostAsJsonAsync("/message", new MessageDto
+        var response = await controller.HandleMessage(new MessageDto
         {
             Name = "InvoiceReceived",
             CorrelationKey = correlationKey
         });
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<string>>();
+        var okResult = response.Result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
+        var payload = okResult.Value.Should().BeOfType<ApiStatusResult<string>>().Subject;
         payload.Should().NotBeNull();
-        payload!.Successful.Should().BeTrue();
+        payload.Successful.Should().BeTrue();
         payload.Result.Should().Contain("InvoiceReceived");
         payload.Result.Should().Contain(correlationKey);
         payload.ErrorMessage.Should().BeNull();

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -15,6 +15,7 @@ using WebApiEngine.Shared;
 
 namespace WebApiEngine.Tests;
 
+[NonParallelizable]
 public class ApiHardeningIntegrationTest
 {
     [Test]

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -154,9 +154,43 @@ public class ApiHardeningIntegrationTest
     [Test]
     public async Task MessageEndpoint_ShouldReturnSuccessfulResultPayload_WhenMessageWasHandled()
     {
+        const string correlationKey = "INV-1000";
+        var storage = CreateMessageStartStorage(correlationKey);
+
+        var controller = new MessageController(storage, new BpmnBusinessLogic(new TestTransactionalStorageProvider(storage)));
+
+        var response = await controller.HandleMessage(new MessageDto
+        {
+            Name = "InvoiceReceived",
+            CorrelationKey = correlationKey
+        });
+
+        if (response.Result is BadRequestObjectResult badRequestResult)
+        {
+            var businessLogicError = await TryHandleMessageDirectly(correlationKey);
+            var controllerError = ExtractErrorMessage(badRequestResult.Value);
+
+            Assert.Fail(
+                $"Expected a successful message response, but the controller returned BadRequest. " +
+                $"Controller error: {controllerError ?? "<empty>"}. " +
+                $"Direct business logic result: {businessLogicError ?? "<success>"}.");
+        }
+
+        var okResult = response.Result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
+        var payload = okResult.Value.Should().BeOfType<ApiStatusResult<string>>().Subject;
+        payload.Should().NotBeNull();
+        payload.Successful.Should().BeTrue();
+        payload.Result.Should().Contain("InvoiceReceived");
+        payload.Result.Should().Contain(correlationKey);
+        payload.ErrorMessage.Should().BeNull();
+    }
+
+    private static TestStorage CreateMessageStartStorage(string correlationKey)
+    {
         var storage = new TestStorage();
         var definitionId = Guid.NewGuid();
-        const string correlationKey = "INV-1000";
+
         storage.StoredDefinitions.Add(new BpmnDefinition
         {
             Id = definitionId,
@@ -195,22 +229,37 @@ public class ApiHardeningIntegrationTest
             "invoice-process",
             definitionId));
 
-        var controller = new MessageController(storage, new BpmnBusinessLogic(new TestTransactionalStorageProvider(storage)));
+        return storage;
+    }
 
-        var response = await controller.HandleMessage(new MessageDto
+    private static async Task<string?> TryHandleMessageDirectly(string correlationKey)
+    {
+        var storage = CreateMessageStartStorage(correlationKey);
+        var businessLogic = new BpmnBusinessLogic(new TestTransactionalStorageProvider(storage));
+
+        try
         {
-            Name = "InvoiceReceived",
-            CorrelationKey = correlationKey
-        });
+            await businessLogic.HandleMessage(new Message
+            {
+                Name = "InvoiceReceived",
+                CorrelationKey = correlationKey
+            });
 
-        var okResult = response.Result.Should().BeOfType<OkObjectResult>().Subject;
-        okResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
-        var payload = okResult.Value.Should().BeOfType<ApiStatusResult<string>>().Subject;
-        payload.Should().NotBeNull();
-        payload.Successful.Should().BeTrue();
-        payload.Result.Should().Contain("InvoiceReceived");
-        payload.Result.Should().Contain(correlationKey);
-        payload.ErrorMessage.Should().BeNull();
+            return null;
+        }
+        catch (Exception exception)
+        {
+            return exception.ToString();
+        }
+    }
+
+    private static string? ExtractErrorMessage(object? responseValue)
+    {
+        return responseValue switch
+        {
+            ApiStatusResult<string> apiStatusResult => apiStatusResult.ErrorMessage,
+            _ => responseValue?.ToString()
+        };
     }
 
     private sealed class TestWebApplicationFactory(TestStorage storage) : WebApplicationFactory<Program>

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text;
+using BPMN.Common;
 using FluentAssertions;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -146,6 +147,64 @@ public class ApiHardeningIntegrationTest
         payload.ErrorMessage.Should().Contain("No process instance is waiting for a message");
     }
 
+    [Test]
+    public async Task MessageEndpoint_ShouldReturnSuccessfulResultPayload_WhenMessageWasHandled()
+    {
+        var storage = new TestStorage();
+        var definitionId = Guid.NewGuid();
+        storage.StoredDefinitions.Add(new BpmnDefinition
+        {
+            Id = definitionId,
+            DefinitionId = "invoice-process",
+            Hash = "hash",
+            SavedByUser = Guid.NewGuid(),
+            SavedOn = DateTime.UtcNow,
+            Version = new Model.Version(1, 0),
+            IsActive = true
+        });
+        storage.StoredBinaries[definitionId] = """
+                                              <?xml version="1.0" encoding="UTF-8"?>
+                                              <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                                                id="Definitions_1"
+                                                                targetNamespace="http://bpmn.io/schema/bpmn">
+                                                <bpmn:message id="Message_InvoiceReceived" name="InvoiceReceived" />
+                                                <bpmn:process id="Process_Invoice" isExecutable="true">
+                                                  <bpmn:startEvent id="StartEvent_1">
+                                                    <bpmn:outgoing>Flow_1</bpmn:outgoing>
+                                                    <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_InvoiceReceived" />
+                                                  </bpmn:startEvent>
+                                                  <bpmn:endEvent id="EndEvent_1">
+                                                    <bpmn:incoming>Flow_1</bpmn:incoming>
+                                                  </bpmn:endEvent>
+                                                  <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
+                                                </bpmn:process>
+                                              </bpmn:definitions>
+                                              """;
+        storage.MessageSubscriptions.Add(new MessageSubscription(
+            new MessageDefinition
+            {
+                Name = "InvoiceReceived"
+            },
+            "Process_Invoice",
+            "invoice-process",
+            definitionId));
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/message", new MessageDto
+        {
+            Name = "InvoiceReceived"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<string>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeTrue();
+        payload.Result.Should().Contain("InvoiceReceived");
+        payload.ErrorMessage.Should().BeNull();
+    }
+
     private sealed class TestWebApplicationFactory(TestStorage storage) : WebApplicationFactory<Program>
     {
         protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
@@ -177,6 +236,7 @@ public class ApiHardeningIntegrationTest
         public Guid? LastRequestedExtendedUserTaskUserId { get; set; }
         public List<BpmnDefinition> StoredDefinitions { get; } = [];
         public Dictionary<Guid, string> StoredBinaries { get; } = [];
+        public List<MessageSubscription> MessageSubscriptions { get; } = [];
 
         public IDefinitionStorage DefinitionStorage => new TestDefinitionStorage(this);
         public IMessageSubscriptionStorage SubscriptionStorage => new TestSubscriptionStorage(this);
@@ -299,19 +359,36 @@ public class ApiHardeningIntegrationTest
     private sealed class TestSubscriptionStorage(TestStorage storage) : IMessageSubscriptionStorage
     {
         public Task<IEnumerable<MessageSubscription>> GetAllMessageSubscriptions() =>
-            Task.FromResult(Enumerable.Empty<MessageSubscription>());
+            Task.FromResult(storage.MessageSubscriptions.AsEnumerable());
 
         public Task<IEnumerable<MessageSubscription>> GetMessageSubscription(string messageName, string? correlationKey, Guid? messageInstanceId) =>
-            Task.FromResult(Enumerable.Empty<MessageSubscription>());
+            Task.FromResult(storage.MessageSubscriptions
+                .Where(subscription =>
+                    subscription.Message.Name == messageName &&
+                    subscription.Message.FlowzerCorrelationKey == correlationKey &&
+                    subscription.ProcessInstanceId == messageInstanceId));
 
         public Task<IEnumerable<MessageSubscription>> GetMessageSubscription(Guid instanceId) =>
-            Task.FromResult(Enumerable.Empty<MessageSubscription>());
+            Task.FromResult(storage.MessageSubscriptions.Where(subscription => subscription.ProcessInstanceId == instanceId));
 
-        public Task AddMessageSubscription(MessageSubscription messageSubscription) => Task.CompletedTask;
+        public Task AddMessageSubscription(MessageSubscription messageSubscription)
+        {
+            storage.MessageSubscriptions.Add(messageSubscription);
+            return Task.CompletedTask;
+        }
 
-        public Task RemoveProcessMessageSubscriptionsByProcessInstanceId(Guid instanceId) => Task.CompletedTask;
+        public Task RemoveProcessMessageSubscriptionsByProcessInstanceId(Guid instanceId)
+        {
+            storage.MessageSubscriptions.RemoveAll(subscription => subscription.ProcessInstanceId == instanceId);
+            return Task.CompletedTask;
+        }
 
-        public Task RemoveAllProcessMessageSubscriptionsWithNoInstancedId(string metaDefinitionId) => Task.CompletedTask;
+        public Task RemoveAllProcessMessageSubscriptionsWithNoInstancedId(string metaDefinitionId)
+        {
+            storage.MessageSubscriptions.RemoveAll(subscription =>
+                subscription.RelatedDefinitionId == metaDefinitionId && subscription.ProcessInstanceId == null);
+            return Task.CompletedTask;
+        }
 
         public Task RemoveAllProcessSignalSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
 

--- a/src/WebApiEngine.Tests/AssemblyTestSettings.cs
+++ b/src/WebApiEngine.Tests/AssemblyTestSettings.cs
@@ -1,0 +1,6 @@
+using NUnit.Framework;
+
+// Die Web-API-Integrationstests booten mehrfach komplette ASP.NET-Hosts mit
+// test-spezifischen DI-Overrides. Serielle Ausführung verhindert flakey
+// Überschneidungen zwischen parallelen Host-Initialisierungen im CI-Lauf.
+[assembly: LevelOfParallelism(1)]

--- a/src/WebApiEngine.Tests/StoragePathTest.cs
+++ b/src/WebApiEngine.Tests/StoragePathTest.cs
@@ -1,0 +1,34 @@
+using FilesystemStorageSystem;
+using FluentAssertions;
+
+namespace WebApiEngine.Tests;
+
+[NonParallelizable]
+public class StoragePathTest
+{
+    [Test]
+    public void GetBasePath_ShouldUseConfiguredStorageRoot_WhenEnvironmentVariableIsSet()
+    {
+        var originalValue = Environment.GetEnvironmentVariable(Storage.StorageRootEnvironmentVariableName);
+        var tempRoot = Path.Combine(Path.GetTempPath(), "flowzer-storage-root-test", Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            Environment.SetEnvironmentVariable(Storage.StorageRootEnvironmentVariableName, tempRoot);
+
+            var storage = new Storage();
+            var resolvedPath = storage.GetBasePath("FileStorage/Forms");
+
+            resolvedPath.Should().StartWith(Path.GetFullPath(tempRoot));
+            Directory.Exists(resolvedPath).Should().BeTrue();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(Storage.StorageRootEnvironmentVariableName, originalValue);
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+}

--- a/src/WebApiEngine/Controller/MessageController.cs
+++ b/src/WebApiEngine/Controller/MessageController.cs
@@ -32,6 +32,10 @@ public class MessageController(IStorageSystem storageSystem,
         var response =
             $"Message '{messageDto.Name}'{correlationText} was sent to the process instance.";
 
-        return Ok(new ApiStatusResult<string>(response));
+        return Ok(new ApiStatusResult<string>
+        {
+            Successful = true,
+            Result = response
+        });
     }
 }

--- a/src/core-engine-tests/SimpleExpressionHandlerTest.cs
+++ b/src/core-engine-tests/SimpleExpressionHandlerTest.cs
@@ -92,4 +92,22 @@ public class SimpleExpressionHandlerTest
             CultureInfo.CurrentUICulture = originalUiCulture;
         }
     }
+
+    [Test]
+    public void CreateDefault_ShouldFallbackToSimpleExpressionHandler_WhenClearScriptIsUnavailable()
+    {
+        var config = FlowzerConfig.CreateDefault(() => throw new DllNotFoundException("ClearScriptV8.linux-x64.so"));
+
+        config.ExpressionHandler.Should().BeOfType<SimpleExpressionHandler>();
+    }
+
+    [Test]
+    public void CreateDefault_ShouldKeepCustomExpressionHandler_WhenFactorySucceeds()
+    {
+        var expressionHandler = new SimpleExpressionHandler();
+
+        var config = FlowzerConfig.CreateDefault(() => expressionHandler);
+
+        config.ExpressionHandler.Should().BeSameAs(expressionHandler);
+    }
 }

--- a/src/core-engine/FlowzerConfig.cs
+++ b/src/core-engine/FlowzerConfig.cs
@@ -6,12 +6,34 @@ namespace core_engine;
 
 public class FlowzerConfig
 {
+    private static readonly Lazy<FlowzerConfig> DefaultConfig = new(() => CreateDefault());
+
     public required IExpressionHandler ExpressionHandler { get; init; }
 
-    public static FlowzerConfig Default => new()
+    public static FlowzerConfig Default => DefaultConfig.Value;
+
+    /// <summary>
+    /// Erstellt die Standardkonfiguration. Wenn die native V8-/ClearScript-Abhängigkeit
+    /// in der aktuellen Umgebung nicht verfügbar ist, fällt die Engine kontrolliert auf
+    /// den einfachen Ausdrucks-Handler zurück. Dadurch bleiben CI und Nicht-V8-Umgebungen
+    /// funktionsfähig, ohne produktive V8-Setups zu blockieren.
+    /// </summary>
+    internal static FlowzerConfig CreateDefault(Func<IExpressionHandler>? expressionHandlerFactory = null)
     {
-        ExpressionHandler = new FeelinExpressionHandler()
-    };
+        var handlerFactory = expressionHandlerFactory ?? (() => new FeelinExpressionHandler());
+
+        try
+        {
+            return new FlowzerConfig
+            {
+                ExpressionHandler = handlerFactory()
+            };
+        }
+        catch (Exception exception) when (ShouldFallbackToSimpleExpressionHandler(exception))
+        {
+            return CreateForTests();
+        }
+    }
 
     /// <summary>
     /// Liefert eine testfreundliche Konfiguration ohne native V8-Abhängigkeit.
@@ -21,6 +43,35 @@ public class FlowzerConfig
         return new FlowzerConfig
         {
             ExpressionHandler = new SimpleExpressionHandler()
+        };
+    }
+
+    private static bool ShouldFallbackToSimpleExpressionHandler(Exception exception)
+    {
+        return EnumerateExceptionChain(exception).Any(IsMissingClearScriptDependency);
+    }
+
+    private static IEnumerable<Exception> EnumerateExceptionChain(Exception exception)
+    {
+        for (var current = exception; current != null; current = current.InnerException!)
+        {
+            yield return current;
+
+            if (current.InnerException == null)
+            {
+                yield break;
+            }
+        }
+    }
+
+    private static bool IsMissingClearScriptDependency(Exception exception)
+    {
+        return exception switch
+        {
+            DllNotFoundException => true,
+            FileNotFoundException => true,
+            PlatformNotSupportedException => true,
+            _ => exception.Message.Contains("ClearScript", StringComparison.OrdinalIgnoreCase)
         };
     }
 }

--- a/src/core-engine/Properties/AssemblyInfo.cs
+++ b/src/core-engine/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("core-engine-tests")]

--- a/tests/ui-smoke/package.json
+++ b/tests/ui-smoke/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "scripts": {
     "install:browsers": "playwright install --with-deps chromium",
-    "test": "playwright test",
-    "test:headed": "playwright test --headed"
+    "test": "node ./scripts/run-playwright.js",
+    "test:headed": "node ./scripts/run-playwright.js --headed"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.1"

--- a/tests/ui-smoke/playwright.config.js
+++ b/tests/ui-smoke/playwright.config.js
@@ -6,11 +6,27 @@ const frontendUrl = process.env.FLOWZER_FRONTEND_URL || 'http://localhost:5269';
 const apiUrl = process.env.FLOWZER_API_URL || 'http://localhost:5182';
 const frontendServerOrigin = new URL(frontendUrl).origin;
 const apiServerOrigin = new URL(apiUrl).origin;
-const managedStorageRoot = process.env.FLOWZER_STORAGE_ROOT || path.join(__dirname, '.tmp', 'storage');
+const playwrightTempRoot = path.resolve(__dirname, '.tmp');
+const managedStorageRoot = path.resolve(
+  process.env.PLAYWRIGHT_MANAGED_STORAGE_ROOT || path.join(playwrightTempRoot, 'storage')
+);
 const reuseExistingServer = !process.env.CI && process.env.PLAYWRIGHT_REUSE_EXISTING_SERVER === '1';
+
+function isPathWithin(parentPath, childPath)
+{
+  const relativePath = path.relative(parentPath, childPath);
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+}
 
 if (!process.env.PLAYWRIGHT_SKIP_WEBSERVERS)
 {
+  if (!isPathWithin(playwrightTempRoot, managedStorageRoot))
+  {
+    throw new Error(
+      `PLAYWRIGHT_MANAGED_STORAGE_ROOT must be located under ${playwrightTempRoot}. Received: ${managedStorageRoot}`
+    );
+  }
+
   fs.rmSync(managedStorageRoot, { recursive: true, force: true });
   fs.mkdirSync(managedStorageRoot, { recursive: true });
 }

--- a/tests/ui-smoke/playwright.config.js
+++ b/tests/ui-smoke/playwright.config.js
@@ -1,18 +1,30 @@
+const fs = require('fs');
+const path = require('path');
 const { defineConfig } = require('@playwright/test');
 
 const frontendUrl = process.env.FLOWZER_FRONTEND_URL || 'http://localhost:5269';
 const apiUrl = process.env.FLOWZER_API_URL || 'http://localhost:5182';
 const frontendServerOrigin = new URL(frontendUrl).origin;
 const apiServerOrigin = new URL(apiUrl).origin;
-const reuseExistingServer = !process.env.CI;
+const managedStorageRoot = process.env.FLOWZER_STORAGE_ROOT || path.join(__dirname, '.tmp', 'storage');
+const reuseExistingServer = !process.env.CI && process.env.PLAYWRIGHT_REUSE_EXISTING_SERVER === '1';
+
+if (!process.env.PLAYWRIGHT_SKIP_WEBSERVERS)
+{
+  fs.rmSync(managedStorageRoot, { recursive: true, force: true });
+  fs.mkdirSync(managedStorageRoot, { recursive: true });
+}
+
 const webServerEnvironment = {
   ...process.env,
-  ASPNETCORE_ENVIRONMENT: process.env.ASPNETCORE_ENVIRONMENT || 'Development'
+  ASPNETCORE_ENVIRONMENT: process.env.ASPNETCORE_ENVIRONMENT || 'Development',
+  FLOWZER_STORAGE_ROOT: managedStorageRoot
 };
 
 module.exports = defineConfig({
   testDir: './tests',
   fullyParallel: false,
+  workers: 1,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   timeout: 60_000,

--- a/tests/ui-smoke/scripts/playwright-process-guard.js
+++ b/tests/ui-smoke/scripts/playwright-process-guard.js
@@ -1,0 +1,184 @@
+const { spawnSync } = require('child_process');
+
+/**
+ * Prozesswächter für lokale/CI-Playwright-Läufe.
+ *
+ * Ziel:
+ * - offensichtlich liegengebliebene Browser-Prozesse aus älteren Läufen vor dem Start erkennen
+ * - nach dem Lauf neu entstandene Playwright-Browser zuverlässig wegräumen
+ *
+ * Die Filter sind bewusst auf bekannte Playwright-/ms-playwright-Kommandos begrenzt, damit
+ * normale Chrome-/Chromium-Instanzen der Benutzerumgebung nicht berührt werden.
+ */
+
+const DEFAULT_STALE_THRESHOLD_SECONDS = 10 * 60;
+const MATCHERS = [
+  'playwright_chromiumdev_profile-',
+  'ms-playwright/chromium_headless_shell',
+  'ms-playwright/chromium-',
+  'chrome-headless-shell',
+  'chrome-linux/chrome'
+];
+
+function listCandidateProcesses()
+{
+  const result = spawnSync('ps', ['-eo', 'pid=,etime=,command='], {
+    encoding: 'utf8'
+  });
+
+  if (result.status !== 0)
+  {
+    throw new Error(result.stderr || 'Unable to inspect running processes.');
+  }
+
+  return result.stdout
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(parseProcessLine)
+    .filter(Boolean)
+    .filter(processInfo => matchesPlaywrightProcess(processInfo.command));
+}
+
+function parseProcessLine(line)
+{
+  const match = line.match(/^(\d+)\s+([0-9:-]+)\s+(.+)$/);
+  if (!match)
+  {
+    return null;
+  }
+
+  return {
+    pid: Number(match[1]),
+    elapsed: match[2],
+    elapsedSeconds: parseElapsedSeconds(match[2]),
+    command: match[3]
+  };
+}
+
+function parseElapsedSeconds(value)
+{
+  const dayAndTime = value.split('-');
+  const dayPart = dayAndTime.length === 2 ? Number(dayAndTime[0]) : 0;
+  const timePart = dayAndTime.length === 2 ? dayAndTime[1] : dayAndTime[0];
+  const timeSegments = timePart.split(':').map(segment => Number(segment));
+
+  if (timeSegments.some(Number.isNaN) || Number.isNaN(dayPart))
+  {
+    return 0;
+  }
+
+  if (timeSegments.length === 3)
+  {
+    return dayPart * 86_400 + timeSegments[0] * 3_600 + timeSegments[1] * 60 + timeSegments[2];
+  }
+
+  if (timeSegments.length === 2)
+  {
+    return dayPart * 86_400 + timeSegments[0] * 60 + timeSegments[1];
+  }
+
+  if (timeSegments.length === 1)
+  {
+    return dayPart * 86_400 + timeSegments[0];
+  }
+
+  return 0;
+}
+
+function matchesPlaywrightProcess(command)
+{
+  return MATCHERS.some(matcher => command.includes(matcher));
+}
+
+function killProcesses(processes, signal)
+{
+  for (const processInfo of processes)
+  {
+    try
+    {
+      process.kill(processInfo.pid, signal);
+    }
+    catch (error)
+    {
+      if (error && error.code !== 'ESRCH')
+      {
+        throw error;
+      }
+    }
+  }
+}
+
+function sleep(milliseconds)
+{
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+async function cleanupProcesses({
+  mode,
+  knownPids = new Set(),
+  staleThresholdSeconds = DEFAULT_STALE_THRESHOLD_SECONDS,
+  verbose = true
+} = {})
+{
+  const candidates = listCandidateProcesses();
+  const selected = candidates.filter(processInfo =>
+  {
+    if (mode === 'stale')
+    {
+      return processInfo.elapsedSeconds >= staleThresholdSeconds;
+    }
+
+    if (mode === 'new')
+    {
+      return !knownPids.has(processInfo.pid);
+    }
+
+    return true;
+  });
+
+  if (selected.length === 0)
+  {
+    if (verbose)
+    {
+      console.log(`[ui-smoke] No Playwright browser processes matched cleanup mode "${mode}".`);
+    }
+
+    return [];
+  }
+
+  if (verbose)
+  {
+    console.log(
+      `[ui-smoke] Cleaning up ${selected.length} Playwright browser process(es) for mode "${mode}":`,
+      selected.map(processInfo => `${processInfo.pid}:${processInfo.elapsed}`).join(', ')
+    );
+  }
+
+  killProcesses(selected, 'SIGTERM');
+  await sleep(1_500);
+
+  const stillRunning = listCandidateProcesses()
+    .filter(processInfo => selected.some(candidate => candidate.pid === processInfo.pid));
+
+  if (stillRunning.length > 0)
+  {
+    if (verbose)
+    {
+      console.warn(
+        `[ui-smoke] Escalating cleanup for ${stillRunning.length} stubborn Playwright browser process(es):`,
+        stillRunning.map(processInfo => processInfo.pid).join(', ')
+      );
+    }
+
+    killProcesses(stillRunning, 'SIGKILL');
+  }
+
+  return selected;
+}
+
+module.exports = {
+  cleanupProcesses,
+  listCandidateProcesses,
+  DEFAULT_STALE_THRESHOLD_SECONDS
+};

--- a/tests/ui-smoke/scripts/run-playwright.js
+++ b/tests/ui-smoke/scripts/run-playwright.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+const { spawn } = require('child_process');
+const { cleanupProcesses, listCandidateProcesses, DEFAULT_STALE_THRESHOLD_SECONDS } = require('./playwright-process-guard');
+
+const args = process.argv.slice(2);
+const knownPids = new Set(listCandidateProcesses().map(processInfo => processInfo.pid));
+const staleThresholdSeconds = Number.parseInt(
+  process.env.PLAYWRIGHT_PROCESS_STALE_THRESHOLD_SECONDS || '',
+  10
+) || DEFAULT_STALE_THRESHOLD_SECONDS;
+const shouldSkipGuard = process.env.PLAYWRIGHT_SKIP_PROCESS_GUARD === '1';
+
+let cleanupStarted = false;
+
+async function performCleanup(mode)
+{
+  if (cleanupStarted)
+  {
+    return;
+  }
+
+  cleanupStarted = true;
+
+  if (shouldSkipGuard)
+  {
+    return;
+  }
+
+  try
+  {
+    await cleanupProcesses({ mode, knownPids, staleThresholdSeconds });
+  }
+  catch (error)
+  {
+    console.warn(`[ui-smoke] Browser cleanup failed during "${mode}": ${error instanceof Error ? error.message : error}`);
+  }
+}
+
+async function main()
+{
+  if (!shouldSkipGuard)
+  {
+    await cleanupProcesses({ mode: 'stale', staleThresholdSeconds });
+  }
+
+  const child = spawn(
+    process.platform === 'win32' ? 'npx.cmd' : 'npx',
+    ['playwright', 'test', ...args],
+    {
+      cwd: __dirname + '/..',
+      stdio: 'inherit',
+      env: process.env
+    }
+  );
+
+  const terminateChild = signal =>
+  {
+    if (!child.killed)
+    {
+      child.kill(signal);
+    }
+  };
+
+  process.on('SIGINT', () =>
+  {
+    terminateChild('SIGINT');
+  });
+
+  process.on('SIGTERM', () =>
+  {
+    terminateChild('SIGTERM');
+  });
+
+  child.on('exit', async (code, signal) =>
+  {
+    await performCleanup('new');
+
+    if (signal)
+    {
+      process.kill(process.pid, signal);
+      return;
+    }
+
+    process.exit(code ?? 1);
+  });
+
+  child.on('error', async error =>
+  {
+    console.error(`[ui-smoke] Failed to start Playwright: ${error instanceof Error ? error.message : error}`);
+    await performCleanup('new');
+    process.exit(1);
+  });
+}
+
+main().catch(async error =>
+{
+  console.error(error);
+  await performCleanup('all');
+  process.exit(1);
+});

--- a/tests/ui-smoke/support/flowzer-api.js
+++ b/tests/ui-smoke/support/flowzer-api.js
@@ -48,36 +48,65 @@ function buildMessageStartUserTaskXml({
   formKey,
   userTaskName = 'Review order'
 }) {
-  const processId = `Process_${toSafeId(definitionId)}`;
+  const safeDefinitionId = toSafeId(definitionId);
+  const processId = `Process_${safeDefinitionId}`;
   const messageId = `Message_${toSafeId(definitionId)}`;
-  const messageStartEventId = `StartEvent_${toSafeId(definitionId)}`;
-  const userTaskId = `Activity_${toSafeId(definitionId)}_Review`;
-  const endEventId = `EndEvent_${toSafeId(definitionId)}`;
+  const messageStartEventId = `StartEvent_${safeDefinitionId}`;
+  const userTaskId = `Activity_${safeDefinitionId}_Review`;
+  const endEventId = `EndEvent_${safeDefinitionId}`;
+  const firstFlowId = `Flow_${safeDefinitionId}_1`;
+  const secondFlowId = `Flow_${safeDefinitionId}_2`;
+  const diagramId = `BPMNDiagram_${safeDefinitionId}`;
+  const planeId = `BPMNPlane_${safeDefinitionId}`;
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
                   xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
                   id="${definitionId}"
                   targetNamespace="http://bpmn.io/schema/bpmn">
   <bpmn:message id="${messageId}" name="${messageName}" />
-  <bpmn:process id="${definitionId}" isExecutable="true">
+  <bpmn:process id="${processId}" isExecutable="true">
     <bpmn:startEvent id="${messageStartEventId}" name="Message Start">
-      <bpmn:outgoing>Flow_${processId}_1</bpmn:outgoing>
+      <bpmn:outgoing>${firstFlowId}</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_${processId}" messageRef="${messageId}" />
     </bpmn:startEvent>
     <bpmn:userTask id="${userTaskId}" name="${userTaskName}">
       <bpmn:extensionElements>
         <zeebe:formDefinition formKey="${formKey}" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_${processId}_1</bpmn:incoming>
-      <bpmn:outgoing>Flow_${processId}_2</bpmn:outgoing>
+      <bpmn:incoming>${firstFlowId}</bpmn:incoming>
+      <bpmn:outgoing>${secondFlowId}</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:endEvent id="${endEventId}" name="Done">
-      <bpmn:incoming>Flow_${processId}_2</bpmn:incoming>
+      <bpmn:incoming>${secondFlowId}</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_${toSafeId(definitionId)}_1" sourceRef="${messageStartEventId}" targetRef="${userTaskId}" />
-    <bpmn:sequenceFlow id="Flow_${toSafeId(definitionId)}_2" sourceRef="${userTaskId}" targetRef="${endEventId}" />
+    <bpmn:sequenceFlow id="${firstFlowId}" sourceRef="${messageStartEventId}" targetRef="${userTaskId}" />
+    <bpmn:sequenceFlow id="${secondFlowId}" sourceRef="${userTaskId}" targetRef="${endEventId}" />
   </bpmn:process>
+  <bpmndi:BPMNDiagram id="${diagramId}">
+    <bpmndi:BPMNPlane id="${planeId}" bpmnElement="${processId}">
+      <bpmndi:BPMNShape id="${messageStartEventId}_di" bpmnElement="${messageStartEventId}">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="${userTaskId}_di" bpmnElement="${userTaskId}">
+        <dc:Bounds x="280" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="${endEventId}_di" bpmnElement="${endEventId}">
+        <dc:Bounds x="460" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="${firstFlowId}_di" bpmnElement="${firstFlowId}">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="280" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="${secondFlowId}_di" bpmnElement="${secondFlowId}">
+        <di:waypoint x="380" y="120" />
+        <di:waypoint x="460" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
 </bpmn:definitions>`;
 }
 

--- a/tests/ui-smoke/support/flowzer-api.js
+++ b/tests/ui-smoke/support/flowzer-api.js
@@ -1,0 +1,186 @@
+const { randomUUID } = require('crypto');
+
+const apiUrl = process.env.FLOWZER_API_URL || 'http://localhost:5182';
+
+function buildApiUrl(pathname) {
+  return new URL(pathname, apiUrl).toString();
+}
+
+async function readJson(response, description) {
+  const bodyText = await response.text();
+  if (!response.ok()) {
+    throw new Error(`${description} failed with HTTP ${response.status()}: ${bodyText}`);
+  }
+
+  return bodyText ? JSON.parse(bodyText) : null;
+}
+
+function ensureApiSuccess(payload, description) {
+  const isSuccessful = payload?.Successful ?? payload?.successful;
+  if (!payload || isSuccessful === false) {
+    const errorMessage = payload?.ErrorMessage || payload?.errorMessage || 'Unknown API error.';
+    throw new Error(`${description} failed: ${errorMessage}`);
+  }
+
+  return payload?.Result ?? payload?.result;
+}
+
+function createFormSchema(label) {
+  return JSON.stringify({
+    components: [
+      {
+        label,
+        key: 'value',
+        type: 'textfield',
+        input: true
+      }
+    ]
+  });
+}
+
+function toSafeId(value) {
+  return value.replace(/[^A-Za-z0-9_]/g, '_');
+}
+
+function buildMessageStartUserTaskXml({
+  definitionId,
+  messageName,
+  formKey,
+  userTaskName = 'Review order'
+}) {
+  const processId = `Process_${toSafeId(definitionId)}`;
+  const messageId = `Message_${toSafeId(definitionId)}`;
+  const messageStartEventId = `StartEvent_${toSafeId(definitionId)}`;
+  const userTaskId = `Activity_${toSafeId(definitionId)}_Review`;
+  const endEventId = `EndEvent_${toSafeId(definitionId)}`;
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="${definitionId}"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:message id="${messageId}" name="${messageName}" />
+  <bpmn:process id="${definitionId}" isExecutable="true">
+    <bpmn:startEvent id="${messageStartEventId}" name="Message Start">
+      <bpmn:outgoing>Flow_${processId}_1</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_${processId}" messageRef="${messageId}" />
+    </bpmn:startEvent>
+    <bpmn:userTask id="${userTaskId}" name="${userTaskName}">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="${formKey}" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_${processId}_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_${processId}_2</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="${endEventId}" name="Done">
+      <bpmn:incoming>Flow_${processId}_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_${toSafeId(definitionId)}_1" sourceRef="${messageStartEventId}" targetRef="${userTaskId}" />
+    <bpmn:sequenceFlow id="Flow_${toSafeId(definitionId)}_2" sourceRef="${userTaskId}" targetRef="${endEventId}" />
+  </bpmn:process>
+</bpmn:definitions>`;
+}
+
+async function saveForm(request, { formId = randomUUID(), name, schema }) {
+  const metadataResponse = await request.post(buildApiUrl(`/form/meta/${formId}`), {
+    data: {
+      formId,
+      name
+    }
+  });
+  ensureApiSuccess(await readJson(metadataResponse, 'Saving form metadata'), 'Saving form metadata');
+
+  const formResponse = await request.post(buildApiUrl('/form'), {
+    data: {
+      formId,
+      version: { major: 0, minor: 0 },
+      formData: schema
+    }
+  });
+
+  const formResult = ensureApiSuccess(await readJson(formResponse, 'Saving form content'), 'Saving form content');
+  return {
+    formId,
+    savedFormId: formResult?.id || formResult?.Id,
+    version: formResult?.version || formResult?.Version
+  };
+}
+
+async function createDefinitionMeta(request, { name, description = '' }) {
+  const createResponse = await request.get(buildApiUrl('/definition/new'));
+  const createdDefinition = await readJson(createResponse, 'Creating definition metadata');
+  const definitionId = createdDefinition?.definitionId || createdDefinition?.DefinitionId;
+
+  const updateResponse = await request.put(buildApiUrl('/definition/meta'), {
+    data: {
+      definitionId,
+      name,
+      description
+    }
+  });
+  await readJson(updateResponse, 'Updating definition metadata');
+
+  return definitionId;
+}
+
+async function deployDefinition(request, { xml }) {
+
+  const definitionResponse = await request.post(buildApiUrl('/definition/deploy'), {
+    headers: {
+      'content-type': 'text/plain'
+    },
+    data: xml
+  });
+
+  const deployedDefinition = ensureApiSuccess(
+    await readJson(definitionResponse, 'Deploying definition'),
+    'Deploying definition');
+
+  return {
+    definitionId: deployedDefinition?.definitionId || deployedDefinition?.DefinitionId,
+    definitionGuid: deployedDefinition.id || deployedDefinition.Id
+  };
+}
+
+async function sendMessage(request, { name, correlationKey = null, variables = {}, instanceId = null }) {
+  const response = await request.post(buildApiUrl('/message'), {
+    data: {
+      name,
+      correlationKey,
+      variables,
+      instanceId
+    }
+  });
+
+  ensureApiSuccess(await readJson(response, 'Sending message'), 'Sending message');
+}
+
+async function getUserTasks(request) {
+  const response = await request.get(buildApiUrl('/usertask'));
+  return ensureApiSuccess(await readJson(response, 'Loading user tasks'), 'Loading user tasks');
+}
+
+async function completeUserTask(request, userTask, data = {}) {
+  const response = await request.post(buildApiUrl('/form/result'), {
+    data: {
+      flowNodeId: userTask.token.currentFlowNodeId,
+      tokenId: userTask.token.id,
+      processInstanceId: userTask.processInstanceId,
+      data
+    }
+  });
+
+  ensureApiSuccess(await readJson(response, 'Completing user task'), 'Completing user task');
+}
+
+module.exports = {
+  buildMessageStartUserTaskXml,
+  createDefinitionMeta,
+  createFormSchema,
+  deployDefinition,
+  getUserTasks,
+  saveForm,
+  sendMessage,
+  completeUserTask,
+  randomUUID
+};

--- a/tests/ui-smoke/tests/core-paths.spec.js
+++ b/tests/ui-smoke/tests/core-paths.spec.js
@@ -1,0 +1,128 @@
+const { test, expect } = require('@playwright/test');
+const {
+  buildMessageStartUserTaskXml,
+  createDefinitionMeta,
+  createFormSchema,
+  deployDefinition,
+  getUserTasks,
+  saveForm,
+  sendMessage,
+  completeUserTask
+} = require('../support/flowzer-api');
+
+function createSuffix(prefix) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+let runtimeScenarioPromise;
+
+async function ensureRuntimeScenario(request) {
+  if (runtimeScenarioPromise) {
+    return runtimeScenarioPromise;
+  }
+
+  runtimeScenarioPromise = (async () => {
+    const formKey = createSuffix('ui-smoke-task-form');
+    const modelName = createSuffix('UI Smoke Runtime');
+    const messageName = createSuffix('UiSmokeStart');
+    const definitionId = await createDefinitionMeta(request, {
+      name: modelName,
+      description: 'Playwright runtime happy-path.'
+    });
+
+    await saveForm(request, {
+      name: formKey,
+      schema: createFormSchema('Approval')
+    });
+
+    await deployDefinition(request, {
+      xml: buildMessageStartUserTaskXml({
+        definitionId,
+        messageName,
+        formKey,
+        userTaskName: 'Review order'
+      })
+    });
+
+    return {
+      definitionId,
+      formKey,
+      modelName,
+      messageName
+    };
+  })();
+
+  return runtimeScenarioPromise;
+}
+
+test('Formulare aus der API erscheinen in Liste und Detailansicht', async ({ page, request }) => {
+  const formName = createSuffix('ui-smoke-form');
+  const { formId } = await saveForm(request, {
+    name: formName,
+    schema: createFormSchema('Customer')
+  });
+
+  await page.goto('/forms', { waitUntil: 'networkidle' });
+
+  const formLink = page.getByRole('link', { name: formName });
+  await expect(formLink).toBeVisible();
+  await formLink.click();
+
+  await expect(page).toHaveURL(new RegExp(`/forms/${formId}$`));
+  await expect(page.locator('#edit-form-loading-state')).toHaveCount(0, { timeout: 20_000 });
+  await expect(page.locator('#current-file-name')).toHaveText(formName, { timeout: 20_000 });
+  await expect(page.locator('iframe[src="/formio"]')).toBeVisible();
+  await expect(page.locator('#blazor-error-ui')).toBeHidden();
+});
+
+test('Bereitgestellte Modelle erscheinen im Frontend und öffnen den Diagrammzugriff', async ({ page, request }) => {
+  const runtimeScenario = await ensureRuntimeScenario(request);
+  const { definitionId, modelName } = runtimeScenario;
+
+  await page.goto('/models', { waitUntil: 'networkidle' });
+
+  const definitionLink = page.getByRole('link', { name: modelName });
+  await expect(definitionLink).toBeVisible();
+  await definitionLink.click();
+
+  await expect(page).toHaveURL(new RegExp(`/definition/${definitionId}$`));
+  await expect(page.locator('#current-file-name')).toHaveText(modelName);
+  await expect(page.locator('#current-file-version')).toContainText('2.0');
+  await expect(page.locator('#designer-container')).toBeVisible();
+  await expect(page.getByText('Error :-(')).toHaveCount(0);
+});
+
+test('Message-Start-Prozess wandert von offenem Task zu Done Instances', async ({ page, request }) => {
+  const runtimeScenario = await ensureRuntimeScenario(request);
+  const { modelName, messageName } = runtimeScenario;
+
+  await sendMessage(request, {
+    name: messageName,
+    variables: {
+      customer: 'Ada'
+    }
+  });
+
+  const userTasks = await getUserTasks(request);
+  const userTask = userTasks.find(task => task.definitionMetaName === modelName);
+  expect(userTask).toBeTruthy();
+
+  await page.goto('/', { waitUntil: 'networkidle' });
+  await expect(page.locator('.user-task-card').filter({ hasText: modelName })).toBeVisible();
+
+  await page.goto('/instances/active', { waitUntil: 'networkidle' });
+  const activeInstanceLink = page.getByRole('link', { name: modelName });
+  await expect(activeInstanceLink).toBeVisible();
+  await activeInstanceLink.click();
+
+  await expect(page).toHaveURL(/\/instance\/[0-9a-f-]+$/);
+  await expect(page.locator('#instance-name')).toContainText(modelName);
+  await expect(page.locator('#blazor-error-ui')).toBeHidden();
+
+  await completeUserTask(request, userTask, {
+    approved: true
+  });
+
+  await page.goto('/instances/done', { waitUntil: 'networkidle' });
+  await expect(page.getByRole('link', { name: modelName })).toBeVisible();
+});


### PR DESCRIPTION
## Ziel

Dieser Strang baut die Playwright-Smoke-/E2E-Abdeckung für die wichtigsten Kernpfade aus und härtet die dabei gefundenen Produktprobleme direkt mit ab.

## Bezug

- refs #50

## Was umgesetzt wurde

### Reproduzierbare Testumgebung
- dateibasierte Persistenz kann jetzt über `FLOWZER_STORAGE_ROOT` gezielt gesetzt werden
- Playwright nutzt für verwaltete Läufe ein eigenes Storage-Verzeichnis und räumt dieses vor dem Start sauber auf
- bestehende Server werden nur noch explizit per `PLAYWRIGHT_REUSE_EXISTING_SERVER=1` wiederverwendet

### Neue Kernpfad-Tests
- Formular aus der API erscheint in Liste und Detailansicht
- bereitgestelltes Modell erscheint im Frontend und öffnet den Diagrammzugriff
- Message-Start-Prozess läuft von offenem User Task bis in die `done`-Instanzen durch

### Behobene Produktprobleme
- `MessageController` liefert bei erfolgreichen String-Antworten jetzt einen tatsächlich erfolgreichen API-Vertrag
- Formular- und Definitionseditor laden iframe/Modeler erst nach dem ersten Rendern
- Instanzdetailansicht initialisiert Viewer und Diagramm ebenfalls render-sicher und ohne fatalen Blazor-Fehler

### Zusätzliche Regressionstests
- API-Integrationstest für erfolgreiche Message-Antworten
- Test für konfigurierbaren Storage-Root
- Frontend-/UI-Dokumentation für reproduzierbare lokale Läufe ergänzt

## Validierung

```bash
dotnet build core-engine.sln --configuration Release --no-restore
dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'
dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'
dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'
cd tests/ui-smoke && npm test
```
