### PR TITLE
Diagramm- und Modeler-Integration im Frontend härten

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -99,6 +99,24 @@ Bei Bedarf kann das Verhalten angepasst werden:
 - `PLAYWRIGHT_SKIP_PROCESS_GUARD=1` deaktiviert den Wächter
 - `PLAYWRIGHT_PROCESS_STALE_THRESHOLD_SECONDS=<sekunden>` steuert, ab wann alte Browser-Prozesse als verwaist gelten
 
+## Diagramm- und Modeler-Prüfpfade
+
+Für die BPMN-Seiten gelten jetzt zusätzlich ein paar harte Erwartungswerte:
+
+- `/definition/{metaDefinitionId}` lädt Canvas **und** Properties Panel reproduzierbar
+- ein Speichern aus dem Modeler sendet den bisherigen Definitionsstand als `previousGuid`, damit Versionsketten im Backend nachvollziehbar bleiben
+- die Frontend-Route wechselt nach Save/Deploy auf die neu erzeugte Definition (`/definition/{metaDefinitionId}/{definitionGuid}`), damit URL und angezeigter Stand nicht auseinanderlaufen
+- ungültige Modellrouten zeigen eine sichtbare Inline-Fehlermeldung mit Retry-Button statt eines fatalen Blazor-Fehlers
+- Viewer- und Modeler-Instanzen werden beim Verlassen der Seite best-effort zerstört, damit keine veralteten Diagrammobjekte im Browser hängen bleiben
+
+### Empfohlene manuelle Checks
+
+1. `/models` öffnen und ein Modell laden
+2. prüfen, dass Diagramm **und** Properties Panel sichtbar sind
+3. einmal `Save` auslösen und kontrollieren, dass die URL auf eine konkrete Definitions-GUID springt
+4. `/instance/{guid}` für eine laufende Instanz öffnen und Diagramm plus Token-Overlay prüfen
+5. testweise eine ungültige Modellroute öffnen und die Inline-Fehlermeldung verifizieren
+
 ## Hinweise zur lokalen Datenbasis
 
 Die dateibasierte Persistenz landet standardmäßig unterhalb der Build-Ausgabe von `FilesystemStorageSystem`.

--- a/src/FlowzerFrontend.Tests/FlowzerApiOptionsTest.cs
+++ b/src/FlowzerFrontend.Tests/FlowzerApiOptionsTest.cs
@@ -171,9 +171,80 @@ public class FlowzerApiOptionsTest
         handler.LastRequestUri.Should().Be(new Uri($"http://localhost:5182/form/{formId}/{version}"));
     }
 
+    [Test]
+    public async Task UploadDefinition_ShouldIncludePreviousGuidQuery_WhenProvided()
+    {
+        var previousGuid = Guid.NewGuid();
+        var definitionDto = CreateDefinitionDto();
+        var handler = new RecordingHttpMessageHandler(System.Text.Json.JsonSerializer.Serialize(definitionDto));
+
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost:5182/")
+        };
+
+        var api = new FlowzerApi(httpClient);
+
+        var result = await api.UploadDefinition("<xml />", previousGuid);
+
+        result.Id.Should().Be(definitionDto.Id);
+        handler.LastRequestUri.Should().Be(new Uri($"http://localhost:5182/definition?previousGuid={previousGuid}"));
+    }
+
+    [Test]
+    public async Task UploadDefinition_ShouldNotIncludePreviousGuidQuery_WhenGuidIsEmpty()
+    {
+        var definitionDto = CreateDefinitionDto();
+        var handler = new RecordingHttpMessageHandler(System.Text.Json.JsonSerializer.Serialize(definitionDto));
+
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost:5182/")
+        };
+
+        var api = new FlowzerApi(httpClient);
+
+        _ = await api.UploadDefinition("<xml />", Guid.Empty);
+
+        handler.LastRequestUri.Should().Be(new Uri("http://localhost:5182/definition"));
+    }
+
+    [Test]
+    public async Task DeployDefinition_ShouldIncludePreviousGuidQuery_WhenProvided()
+    {
+        var previousGuid = Guid.NewGuid();
+        var definitionDto = CreateDefinitionDto();
+        var handler = new RecordingHttpMessageHandler(CreateApiStatusResultJson(definitionDto));
+
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost:5182/")
+        };
+
+        var api = new FlowzerApi(httpClient);
+
+        var result = await api.DeployDefinition("<xml />", previousGuid);
+
+        result.Id.Should().Be(definitionDto.Id);
+        handler.LastRequestUri.Should().Be(new Uri($"http://localhost:5182/definition/deploy?previousGuid={previousGuid}"));
+    }
+
     private static string CreateApiStatusResultJson<T>(T result)
     {
         return System.Text.Json.JsonSerializer.Serialize(new ApiStatusResult<T>(result));
+    }
+
+    private static BpmnDefinitionDto CreateDefinitionDto()
+    {
+        return new BpmnDefinitionDto
+        {
+            Id = Guid.NewGuid(),
+            DefinitionId = "definition-demo",
+            Hash = "hash-demo",
+            SavedByUser = Guid.NewGuid(),
+            SavedOn = DateTime.UtcNow,
+            Version = new VersionDto(2, 1)
+        };
     }
 
     private sealed class RecordingHttpMessageHandler : HttpMessageHandler

--- a/src/FlowzerFrontend/FlowzerApi.cs
+++ b/src/FlowzerFrontend/FlowzerApi.cs
@@ -64,19 +64,21 @@ public class FlowzerApi: ApiBase
         return await GetAsJsonAsyncSave<BpmnMetaDefinitionDto>("definition/new");
     }
 
-    public async Task<BpmnDefinitionDto> UploadDefinition(string xml)
+    public async Task<BpmnDefinitionDto> UploadDefinition(string xml, Guid? previousGuid = null)
     {
-        return await PostAsJsonAsyncSave<BpmnDefinitionDto>("definition",xml);
+        var url = AppendPreviousGuidQuery("definition", previousGuid);
+        return await PostAsJsonAsyncSave<BpmnDefinitionDto>(url, xml);
     }
-    public async Task<BpmnDefinitionDto> DeployDefinition(string xml)
+
+    public async Task<BpmnDefinitionDto> DeployDefinition(string xml, Guid? previousGuid = null)
     {
-        var apiStatusResult = await PostAsJsonAsyncSave<ApiStatusResult<BpmnDefinitionDto>>("definition/deploy",xml, true, false);
+        var url = AppendPreviousGuidQuery("definition/deploy", previousGuid);
+        var apiStatusResult = await PostAsJsonAsyncSave<ApiStatusResult<BpmnDefinitionDto>>(url, xml, true, false);
         if (apiStatusResult.Successful)
             return apiStatusResult.Result!;
         
         throw new ApiException(apiStatusResult.ErrorMessage);
     }
-
 
     public async Task<List<ProcessInstanceInfoDto>> GetAllInstances()
     {
@@ -87,8 +89,6 @@ public class FlowzerApi: ApiBase
     {
         return await GetAsJsonAndThrowOnErrorAsync<ProcessInstanceInfoDto>("instance/" + instanceGuid);
     }
-
-
 
     public async Task<MessageSubscriptionDto[]> GetMessageSubscriptions(Guid instanceGuid)
     {
@@ -155,6 +155,17 @@ public class FlowzerApi: ApiBase
     public async Task CompleteUserTask(UserTaskResultDto userTaskResult)
     {
         await PostAsJsonAndOnErrorAsync<dynamic>("form/result", userTaskResult);
+    }
+
+    private static string AppendPreviousGuidQuery(string url, Guid? previousGuid)
+    {
+        if (!previousGuid.HasValue || previousGuid.Value == Guid.Empty)
+        {
+            return url;
+        }
+
+        var separator = url.Contains('?') ? '&' : '?';
+        return $"{url}{separator}previousGuid={Uri.EscapeDataString(previousGuid.Value.ToString())}";
     }
 }
 

--- a/src/FlowzerFrontend/Pages/EditDefinition.razor
+++ b/src/FlowzerFrontend/Pages/EditDefinition.razor
@@ -3,44 +3,50 @@
 @using Microsoft.FluentUI.AspNetCore.Components
 @using FlowzerFrontend.Components
 
-
-
-
-
 <div class="main-content">
 
     <HeaderElement BackLink="/models">
         <LeftSide>
-            
-            <LabelWithEdit @bind-Label=@CurrentMetaDefinition.Name AfterChanged="AfterChanged"/>
-            <span id="current-file-version">Version: @CurrentDefinition.Version.ToString() </span>
-        
+            @if (CanEditMetadata)
+            {
+                <LabelWithEdit @bind-Label="CurrentMetaDefinition.Name" AfterChanged="AfterChanged" />
+            }
+            else
+            {
+                <span id="current-file-name">@CurrentMetaDefinition.Name</span>
+            }
+            <span id="current-file-version">Version: @(CurrentDefinition.Id == Guid.Empty ? "-" : CurrentDefinition.Version.ToString()) </span>
         </LeftSide>
         <RigthSide>
             <FluentStack Class="action-button-group">
                 @* <FluentCombobox AriaLabel="Pre-selected option" Items="@AvailableVersions" @bind-Value="@CurrentDefinition" Height="200px" /> *@
 
-                <FluentButton IconStart="@(new Icons.Regular.Size16.ArrowUpload())" Appearance="Appearance.Accent" @onclick="OnDeployClick">
+                <FluentButton IconStart="@(new Icons.Regular.Size16.ArrowUpload())"
+                              Appearance="Appearance.Accent"
+                              Disabled="@(!CanPersistDefinition)"
+                              @onclick="OnDeployClick">
                     Deploy
                 </FluentButton>
-                <FluentButton IconEnd="@(new Icons.Regular.Size16.Save())" @onclick="OnSaveClick">
+                <FluentButton IconEnd="@(new Icons.Regular.Size16.Save())"
+                              Disabled="@(!CanPersistDefinition)"
+                              @onclick="OnSaveClick">
                     Save
                 </FluentButton>
-                <FluentButton IconEnd="@(new Icons.Regular.Size16.Bug())">
+                <FluentButton IconEnd="@(new Icons.Regular.Size16.Bug())" Disabled="true">
                     Debug
                 </FluentButton>
 
-                <FluentMenuButton Text="Options" IconStart="new Icons.Regular.Size20.Options()" OnMenuChanged="OnSaveMenuChoosen" ButtonAppearance="Appearance.Neutral" >
+                <FluentMenuButton Text="Options"
+                                  IconStart="new Icons.Regular.Size20.Options()"
+                                  OnMenuChanged="OnSaveMenuChoosen"
+                                  ButtonAppearance="Appearance.Neutral"
+                                  Disabled="@(!CanPersistDefinition)">
                     <FluentMenuItem Id="SaveAs">Save Copy...</FluentMenuItem>
                 </FluentMenuButton>
             </FluentStack>
         </RigthSide>
-  
     </HeaderElement>
-  
- 
-    
-    
+
     <div class="content with-diagram" id="designer-container">
         <div class="canvas" id="js-canvas"></div>
         <div class="properties-panel-parent" id="js-properties-panel"></div>
@@ -48,15 +54,19 @@
 
     @if (IsDocumentLoading)
     {
-        <div>Loading...</div>
+        <p id="definition-loading-state">Loading model...</p>
     }
-    else if (ErrorString != null)
+    else if (!string.IsNullOrWhiteSpace(ErrorString))
     {
-        <div>
-            <span>Error :-(</span><br/>
+        <div id="definition-load-error" class="diagram-inline-message" role="alert">
+            <span>Error :-(</span><br />
             @ErrorString
+            <div class="diagram-inline-actions">
+                <FluentButton Id="definition-retry-button" Appearance="Appearance.Accent" @onclick="OnRetryClick">
+                    Retry
+                </FluentButton>
+            </div>
         </div>
     }
 
 </div>
-

--- a/src/FlowzerFrontend/Pages/EditDefinition.razor.cs
+++ b/src/FlowzerFrontend/Pages/EditDefinition.razor.cs
@@ -6,15 +6,16 @@ using WebApiEngine.Shared;
 
 namespace FlowzerFrontend.Pages;
 
-public partial class EditDefinition
+public partial class EditDefinition : IAsyncDisposable
 {
+    private const string EditorInteropPath = "window.FlowzerDefinitionEditor";
+
     [Parameter]
     public string? MetaDefinitionId { get; set; }
         
     [Parameter]
     public Guid? DefinitionId { get; set; }
 
-    
     [Inject]
     public required IJSRuntime JsRuntime { get; set; }
 
@@ -23,6 +24,9 @@ public partial class EditDefinition
 
     [Inject]
     public required IDialogService DialogService { get; set; }
+
+    [Inject]
+    public required NavigationManager NavigationManager { get; set; }
     
     private FluentMenuButton _menubutton = new();
  
@@ -31,18 +35,31 @@ public partial class EditDefinition
     private bool IsEditorInitialized { get; set; }
     private string? PendingXml { get; set; }
     private string? LastFailedXmlImport { get; set; }
-    
-    
+    private bool IsPersistingDefinition { get; set; }
+    private bool NeedsEditorInitialization { get; set; } = true;
 
-    private BpmnMetaDefinitionDto CurrentMetaDefinition { get; set; } = new BpmnMetaDefinitionDto()
+    private BpmnMetaDefinitionDto CurrentMetaDefinition { get; set; } = CreateLoadingMetaDefinition();
+
+    private BpmnDefinitionDto CurrentDefinition { get; set; } = CreateEmptyDefinition();
+
+    public List<BpmnMetaDefinitionDto> AvailableVersions { get; set; } = new();
+
+    private bool CanEditMetadata => !IsDocumentLoading && string.IsNullOrWhiteSpace(ErrorString);
+    private bool CanPersistDefinition =>
+        !IsDocumentLoading &&
+        !IsPersistingDefinition &&
+        IsEditorInitialized &&
+        string.IsNullOrWhiteSpace(ErrorString);
+
+    protected override async Task OnParametersSetAsync()
     {
-        Description = "",
-        Name = "Loading...",
-        DefinitionId = "Loading..."
-    };
-    
-    protected override async Task OnInitializedAsync()
-    {
+        if (IsEditorInitialized)
+        {
+            await DisposeEditorAsync();
+            IsEditorInitialized = false;
+        }
+
+        NeedsEditorInitialization = true;
         await LoadModel();
     }
 
@@ -50,21 +67,10 @@ public partial class EditDefinition
     {
         await base.OnAfterRenderAsync(firstRender);
 
-        if (firstRender)
+        if (NeedsEditorInitialization)
         {
-            try
-            {
-                await JsRuntime.EvalCodeBehindJsScripts(this);
-                await JsRuntime.InvokeVoidAsync("InitEdit");
-                IsEditorInitialized = true;
-                ErrorString = null;
-            }
-            catch (Exception exception)
-            {
-                ErrorString = $"Failed to initialize the BPMN editor: {exception.Message}";
-                await InvokeAsync(StateHasChanged);
-                return;
-            }
+            NeedsEditorInitialization = false;
+            await TryInitializeEditorAsync();
         }
 
         if (!IsEditorInitialized || string.IsNullOrWhiteSpace(PendingXml))
@@ -91,109 +97,230 @@ public partial class EditDefinition
             LastFailedXmlImport = xml;
             PendingXml = xml;
             ErrorString = $"Failed to load BPMN XML into the editor: {exception.Message}";
-            await InvokeAsync(StateHasChanged);
+            await SafeStateHasChangedAsync();
+        }
+    }
+
+    private async Task TryInitializeEditorAsync()
+    {
+        try
+        {
+            await JsRuntime.EvalCodeBehindJsScripts(this);
+            await JsRuntime.InvokeVoidAsyncNoneCached($"{EditorInteropPath}.initialize");
+            IsEditorInitialized = true;
+            ErrorString = null;
+            await SafeStateHasChangedAsync();
+        }
+        catch (Exception exception)
+        {
+            IsEditorInitialized = false;
+            ErrorString = $"Failed to initialize the BPMN editor: {exception.Message}";
+            await SafeStateHasChangedAsync();
         }
     }
 
     private async Task LoadModel()
     {
+        IsDocumentLoading = true;
+        ErrorString = null;
+        PendingXml = null;
+        LastFailedXmlImport = null;
+        CurrentMetaDefinition = CreateLoadingMetaDefinition(MetaDefinitionId);
+        CurrentDefinition = CreateEmptyDefinition();
 
-        if (string.IsNullOrEmpty(MetaDefinitionId))
+        try
         {
-            return;
-        }
-        
-        var metaModel = await FlowzerApi.GetMetaDefinitionById(MetaDefinitionId);
-        CurrentMetaDefinition = metaModel;
+            if (string.IsNullOrWhiteSpace(MetaDefinitionId))
+            {
+                ErrorString = "No model identifier was provided.";
+                CurrentMetaDefinition = CreateUnavailableMetaDefinition();
+                return;
+            }
 
-        if (DefinitionId.HasValue)
-        {
-            CurrentDefinition = await FlowzerApi.GetDefinition(DefinitionId!);
-        }
-        else //if not definition id is given, load the latest definition
-        {
-            CurrentDefinition = await FlowzerApi.GetLatestDefinition(MetaDefinitionId);
-        }
-      
-        var xml = await FlowzerApi.GetXmlDefinition(CurrentDefinition.Id);
+            CurrentMetaDefinition = await FlowzerApi.GetMetaDefinitionById(MetaDefinitionId);
+            CurrentDefinition = DefinitionId.HasValue
+                ? await FlowzerApi.GetDefinition(DefinitionId.Value)
+                : await FlowzerApi.GetLatestDefinition(MetaDefinitionId);
 
-        if (string.IsNullOrEmpty(xml))
-        {
-            ErrorString = "No XML found for this model.";
-        }
-        else
-        {
+            var xml = await FlowzerApi.GetXmlDefinition(CurrentDefinition.Id);
+            if (string.IsNullOrWhiteSpace(xml))
+            {
+                ErrorString = "No XML found for this model.";
+                return;
+            }
+
             PendingXml = xml;
-            LastFailedXmlImport = null;
-            ErrorString = null;
         }
-        
-        IsDocumentLoading = false;
-        await InvokeAsync(StateHasChanged);
-    }
-
-    private BpmnDefinitionDto CurrentDefinition { get; set; } = new BpmnDefinitionDto()
-    {
-        DefinitionId = "Loading...",
-        Hash = "Loading...",
-        Id = Guid.Empty,
-        PreviousGuid = Guid.Empty,
-        SavedByUser = Guid.Empty,
-        SavedOn = DateTime.Now,
-        Version = new VersionDto()
+        catch (Exception exception)
         {
-            Major = 0,
-            Minor = 0
+            CurrentMetaDefinition = CreateUnavailableMetaDefinition(MetaDefinitionId);
+            CurrentDefinition = CreateEmptyDefinition();
+            ErrorString = $"Could not load model. {exception.Message}";
         }
-    };
-
-    public List<BpmnMetaDefinitionDto> AvailableVersions { get; set; } = new();
+        finally
+        {
+            IsDocumentLoading = false;
+            await SafeStateHasChangedAsync();
+        }
+    }
 
     private async Task LoadDiagramXml(string xml)
     {
-        await JsRuntime.InvokeVoidAsyncNoneCached("window.bpmnModeler.importXML", xml);
+        await JsRuntime.InvokeVoidAsyncNoneCached($"{EditorInteropPath}.importXml", xml);
         ErrorString = null;
     }
 
     private async Task OnSaveClick()
     {
-        var xmlData = await GetXmlData();
-        var definition = await FlowzerApi.UploadDefinition(xmlData);
-        CurrentDefinition = definition;
-        await InvokeAsync(StateHasChanged);
+        await PersistDefinitionAsync((xml, previousGuid) => FlowzerApi.UploadDefinition(xml, previousGuid));
     }
 
     private async Task OnDeployClick()
     {
-        var xmlData = await GetXmlData();
+        await PersistDefinitionAsync((xml, previousGuid) => FlowzerApi.DeployDefinition(xml, previousGuid));
+    }
+
+    private async Task PersistDefinitionAsync(Func<string, Guid?, Task<BpmnDefinitionDto>> persistDefinition)
+    {
+        if (!CanPersistDefinition)
+        {
+            var dialog = await DialogService.ShowErrorAsync("The BPMN editor is not ready yet.", "Error");
+            await dialog.Result;
+            return;
+        }
+
+        IsPersistingDefinition = true;
+        await SafeStateHasChangedAsync();
+
         try
         {
-            var definition = await FlowzerApi.DeployDefinition(xmlData);
-            CurrentDefinition = definition;
+            var xmlData = await GetXmlData();
+            var persistedDefinition = await persistDefinition(xmlData, GetPreviousDefinitionGuid());
+
+            CurrentDefinition = persistedDefinition;
+            DefinitionId = persistedDefinition.Id;
+            PendingXml = xmlData;
+            LastFailedXmlImport = null;
+            ErrorString = null;
+
+            var targetUrl = UriHelper.GetEditDefinitionUrl(CurrentMetaDefinition.DefinitionId, persistedDefinition.Id);
+            NavigationManager.NavigateTo(targetUrl, replace: true);
         }
-        catch (Exception e)
+        catch (ApiException exception)
         {
-            var dialog = await DialogService.ShowErrorAsync(e.Message, "Error");
+            var dialog = await DialogService.ShowErrorAsync(exception.Message, "Error");
             await dialog.Result;
         }
- 
-        await InvokeAsync(StateHasChanged);
+        catch (Exception exception)
+        {
+            var dialog = await DialogService.ShowErrorAsync(exception.Message, "Error");
+            await dialog.Result;
+        }
+        finally
+        {
+            IsPersistingDefinition = false;
+            await SafeStateHasChangedAsync();
+        }
     }
 
     private async Task<string> GetXmlData()
     {
-        var saveXmlResult = await JsRuntime.InvokeAsyncNoneCached<JsonObject>("window.bpmnModeler.saveXML");
-        var xmlData = saveXmlResult["xml"]!.GetValue<string>();
-        return xmlData;
+        var saveXmlResult = await JsRuntime.InvokeAsyncNoneCached<JsonObject>($"{EditorInteropPath}.saveXml");
+        if (saveXmlResult["xml"] is not JsonNode xmlNode)
+        {
+            throw new Exception("The BPMN editor returned no XML payload.");
+        }
+
+        return xmlNode.GetValue<string>();
     }
 
-    private async Task AfterChanged(string obj)
+    private Guid? GetPreviousDefinitionGuid()
     {
+        return CurrentDefinition.Id == Guid.Empty ? null : CurrentDefinition.Id;
+    }
+
+    private async Task OnRetryClick()
+    {
+        ErrorString = null;
+
+        if (!IsEditorInitialized)
+        {
+            NeedsEditorInitialization = true;
+            await LoadModel();
+            return;
+        }
+
+        await LoadModel();
+    }
+
+    private async Task AfterChanged(string _)
+    {
+        if (!CanEditMetadata)
+        {
+            return;
+        }
+
         await FlowzerApi.UpdateMetaDefinition(CurrentMetaDefinition);
     }
 
     private void OnSaveMenuChoosen(MenuChangeEventArgs obj)
     {
         JsRuntime.InvokeVoidAsync("console.writeline", obj?.Id ?? "null");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await DisposeEditorAsync();
+    }
+
+    private async Task DisposeEditorAsync()
+    {
+        try
+        {
+            await JsRuntime.InvokeVoidAsyncNoneCached($"{EditorInteropPath}.dispose");
+        }
+        catch
+        {
+            // Best effort only: the page may already be gone while the browser tears down the component.
+        }
+    }
+
+    private async Task SafeStateHasChangedAsync()
+    {
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private static BpmnMetaDefinitionDto CreateLoadingMetaDefinition(string? definitionId = null)
+    {
+        return new BpmnMetaDefinitionDto
+        {
+            Description = string.Empty,
+            Name = "Loading...",
+            DefinitionId = string.IsNullOrWhiteSpace(definitionId) ? "Loading..." : definitionId
+        };
+    }
+
+    private static BpmnMetaDefinitionDto CreateUnavailableMetaDefinition(string? definitionId = null)
+    {
+        return new BpmnMetaDefinitionDto
+        {
+            Description = string.Empty,
+            Name = "Unavailable model",
+            DefinitionId = string.IsNullOrWhiteSpace(definitionId) ? "Unavailable model" : definitionId
+        };
+    }
+
+    private static BpmnDefinitionDto CreateEmptyDefinition()
+    {
+        return new BpmnDefinitionDto
+        {
+            DefinitionId = "Loading...",
+            Hash = "Loading...",
+            Id = Guid.Empty,
+            PreviousGuid = Guid.Empty,
+            SavedByUser = Guid.Empty,
+            SavedOn = DateTime.UtcNow,
+            Version = new VersionDto(0, 0)
+        };
     }
 }

--- a/src/FlowzerFrontend/Pages/EditDefinition.razor.cs
+++ b/src/FlowzerFrontend/Pages/EditDefinition.razor.cs
@@ -263,9 +263,9 @@ public partial class EditDefinition : IAsyncDisposable
         await FlowzerApi.UpdateMetaDefinition(CurrentMetaDefinition);
     }
 
-    private void OnSaveMenuChoosen(MenuChangeEventArgs obj)
+    private static void OnSaveMenuChoosen(MenuChangeEventArgs _)
     {
-        JsRuntime.InvokeVoidAsync("console.writeline", obj?.Id ?? "null");
+        // Platzhalter für spätere Optionsmenü-Aktionen.
     }
 
     public async ValueTask DisposeAsync()

--- a/src/FlowzerFrontend/Pages/EditDefinition.razor.css
+++ b/src/FlowzerFrontend/Pages/EditDefinition.razor.css
@@ -1,6 +1,3 @@
-
-
-
 #current-file-name{
     font-size: var(--header-tile-size);
 }
@@ -22,9 +19,17 @@
     border-top: lightgray 1px solid;
 }
 
+.diagram-inline-message {
+    margin: 16px;
+    padding: 16px;
+    border-radius: 8px;
+    border: 1px solid #d1d5db;
+    background: #f8fafc;
+}
 
-
-
+.diagram-inline-actions {
+    margin-top: 12px;
+}
 
 /*============== BPMN Designer zeug ==============*/
 

--- a/src/FlowzerFrontend/Pages/EditDefinition.razor.js
+++ b/src/FlowzerFrontend/Pages/EditDefinition.razor.js
@@ -1,0 +1,80 @@
+(function () {
+    async function waitForElement(selector) {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+            const element = document.querySelector(selector);
+            if (element) {
+                return element;
+            }
+
+            await new Promise(resolve => requestAnimationFrame(resolve));
+        }
+
+        throw new Error(`Required BPMN container '${selector}' was not rendered.`);
+    }
+
+    function resetContainer(selector) {
+        const element = document.querySelector(selector);
+        if (element) {
+            element.innerHTML = '';
+        }
+    }
+
+    async function disposeEditor() {
+        const existingEditor = window.bpmnModeler;
+        if (existingEditor && typeof existingEditor.destroy === 'function') {
+            existingEditor.destroy();
+        }
+
+        window.bpmnModeler = undefined;
+        resetContainer('#js-canvas');
+        resetContainer('#js-properties-panel');
+    }
+
+    function getEditor() {
+        if (!window.bpmnModeler || typeof window.bpmnModeler.importXML !== 'function') {
+            throw new Error('BPMN editor is not initialized.');
+        }
+
+        return window.bpmnModeler;
+    }
+
+    async function initializeEditor() {
+        await waitForElement('#js-canvas');
+        await waitForElement('#js-properties-panel');
+        await new Promise(resolve => requestAnimationFrame(resolve));
+
+        await disposeEditor();
+        await window.InitEdit();
+
+        if (!window.bpmnModeler) {
+            throw new Error('BPMN editor could not be created.');
+        }
+    }
+
+    async function importXml(xml) {
+        if (!xml || !xml.trim()) {
+            throw new Error('No BPMN XML was provided.');
+        }
+
+        const editor = getEditor();
+        const importResult = await editor.importXML(xml);
+        const canvas = editor.get('canvas');
+        if (canvas && typeof canvas.zoom === 'function') {
+            canvas.zoom('fit-viewport');
+        }
+
+        return Array.isArray(importResult?.warnings) ? importResult.warnings : [];
+    }
+
+    async function saveXml() {
+        const editor = getEditor();
+        return await editor.saveXML({ format: true });
+    }
+
+    window.FlowzerDefinitionEditor = {
+        dispose: disposeEditor,
+        importXml,
+        initialize: initializeEditor,
+        saveXml
+    };
+})();

--- a/src/FlowzerFrontend/Pages/Instance.razor
+++ b/src/FlowzerFrontend/Pages/Instance.razor
@@ -18,7 +18,12 @@
 
     @if (!string.IsNullOrWhiteSpace(ErrorString))
     {
-        <p id="instance-load-error" role="alert">@ErrorString</p>
+        <div id="instance-load-error" role="alert">
+            <p>@ErrorString</p>
+            <FluentButton Id="instance-retry-button" Appearance="Appearance.Accent" @onclick="OnRetryClick">
+                Retry
+            </FluentButton>
+        </div>
     }
     else if (_instance == null)
     {

--- a/src/FlowzerFrontend/Pages/Instance.razor.cs
+++ b/src/FlowzerFrontend/Pages/Instance.razor.cs
@@ -7,8 +7,9 @@ using Microsoft.JSInterop;
 using WebApiEngine.Shared;
 namespace FlowzerFrontend.Pages;
 
-public partial class Instance
+public partial class Instance : IAsyncDisposable
 {
+    private const string ViewerInteropPath = "window.FlowzerInstanceViewer";
     private const string MessagesTreeItemKey = "messages";
     private const string ServiceTreeItemKey = "service";
     private const string SignalTreeItemKey = "singal";
@@ -16,6 +17,7 @@ public partial class Instance
 
     private ProcessInstanceInfoDto? _instance;
     private bool IsViewerInitialized { get; set; }
+    private bool NeedsViewerInitialization { get; set; } = true;
     private string? PendingXml { get; set; }
 
     [Parameter] public Guid InstanceGuid { get; set; }
@@ -24,7 +26,6 @@ public partial class Instance
 
     [Inject] public required FlowzerApi FlowzerApi { get; set; }
 
-    
     public IEnumerable<ITreeViewItem> VariableItems = [];
     
     public string? VariableContent;
@@ -33,7 +34,6 @@ public partial class Instance
     
     public string ErrorString { get; set; } = string.Empty;
 
-    
     private ITreeViewItem? _currentSelectedToken;
     public ITreeViewItem? CurrentSelectedToken
     {
@@ -58,15 +58,19 @@ public partial class Instance
 
     }
 
-
     private bool _trapFocus = true;
     private bool _modal = true;
     private readonly Dictionary<string, object> _treeItemMappings = new();
-    
 
-
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnParametersSetAsync()
     {
+        if (IsViewerInitialized)
+        {
+            await DisposeViewerAsync();
+            IsViewerInitialized = false;
+        }
+
+        NeedsViewerInitialization = true;
         await Reload();
     }
 
@@ -76,11 +80,10 @@ public partial class Instance
 
         try
         {
-            if (firstRender)
+            if (NeedsViewerInitialization)
             {
-                await JsRuntime.EvalCodeBehindJsScripts(this);
-                await InitViewer();
-                IsViewerInitialized = true;
+                NeedsViewerInitialization = false;
+                await TryInitializeViewerAsync();
             }
 
             await TryRenderInstanceVisualizationAsync();
@@ -90,6 +93,13 @@ public partial class Instance
             ErrorString = $"Could not render instance diagram. {exception.Message}";
             await InvokeAsync(StateHasChanged);
         }
+    }
+
+    private async Task TryInitializeViewerAsync()
+    {
+        await JsRuntime.EvalCodeBehindJsScripts(this);
+        await InitViewer();
+        IsViewerInitialized = true;
     }
 
     private async Task LoadData()
@@ -283,36 +293,37 @@ public partial class Instance
 
     private async Task AddToken(string? instanceTokenKey, int instanceTokensCount)
     {
-        if (string.IsNullOrEmpty(instanceTokenKey))
+        if (string.IsNullOrEmpty(instanceTokenKey) || !IsViewerInitialized)
             return;
         
         try
         {
-            await JsRuntime.InvokeVoidAsync("addToken", instanceTokenKey, instanceTokensCount);
+            _ = await JsRuntime.InvokeAsyncNoneCached<bool>($"{ViewerInteropPath}.addToken", instanceTokenKey, instanceTokensCount);
         }
         catch (Exception e)
         {
             throw new Exception($"Error adding token '{instanceTokenKey}', Message:" + e.Message, e);
         }
     }
+
     private async Task ClearTokens()
     {
-        await JsRuntime.InvokeVoidAsync("clearTokens");
+        if (!IsViewerInitialized)
+            return;
+
+        await JsRuntime.InvokeVoidAsyncNoneCached($"{ViewerInteropPath}.clearTokens");
     }
 
     private async Task InitViewer()
     {
-        await JsRuntime.InvokeVoidAsync("InitViewer");
-
+        await JsRuntime.InvokeVoidAsyncNoneCached($"{ViewerInteropPath}.initialize");
     }
 
     private async Task LoadDiagramXml(string xml)
     {
-        await JsRuntime.InvokeVoidAsync("window.bpmnViewer.importXML", xml);
+        await JsRuntime.InvokeVoidAsyncNoneCached($"{ViewerInteropPath}.importXml", xml);
         ErrorString = string.Empty;
     }
-
-
 
     private async Task OpenSendRestRequestAsync(RestExampleRequest restData)
     {
@@ -336,7 +347,6 @@ public partial class Instance
 
     }
 
-
     private bool GetTreeRelatedItem<T>(string id, out T o)
     {
         if (_treeItemMappings.TryGetValue(id, out var obj))
@@ -350,7 +360,6 @@ public partial class Instance
         o = default!;
         return false;
     }
-
 
     private async Task Reload()
     {
@@ -392,5 +401,36 @@ public partial class Instance
         await ShowTokens(_instance.Tokens);
         ErrorString = string.Empty;
         await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task OnRetryClick()
+    {
+        ErrorString = string.Empty;
+
+        if (!IsViewerInitialized)
+        {
+            NeedsViewerInitialization = true;
+            await Reload();
+            return;
+        }
+
+        await Reload();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await DisposeViewerAsync();
+    }
+
+    private async Task DisposeViewerAsync()
+    {
+        try
+        {
+            await JsRuntime.InvokeVoidAsyncNoneCached($"{ViewerInteropPath}.dispose");
+        }
+        catch
+        {
+            // Best effort only: during page teardown the runtime may already be unavailable.
+        }
     }
 }

--- a/src/FlowzerFrontend/Pages/Instance.razor.js
+++ b/src/FlowzerFrontend/Pages/Instance.razor.js
@@ -1,16 +1,102 @@
+(function () {
+    async function waitForElement(selector) {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+            const element = document.querySelector(selector);
+            if (element) {
+                return element;
+            }
 
+            await new Promise(resolve => requestAnimationFrame(resolve));
+        }
 
+        throw new Error(`Required BPMN container '${selector}' was not rendered.`);
+    }
 
-function clearTokens(){
-    bpmnViewer.get('overlays').clear();
-}
+    function resetCanvas() {
+        const canvas = document.querySelector('#js-canvas');
+        if (canvas) {
+            canvas.innerHTML = '';
+        }
+    }
 
-function addToken(id, count){
-    bpmnViewer.get('overlays').add(id, 'note', {
-        position: {
-            top: -10,
-            left: -10
-        },
-        html: '<div class="diagram-note" style="background: green; border-radius: 100%; width: 20px; height: 20px; overflow: hidden; font-weigth: bold; text-align: center; color: white;">' + count + '</div>'
-    });
-}
+    function getViewer() {
+        if (!window.bpmnViewer || typeof window.bpmnViewer.importXML !== 'function') {
+            throw new Error('BPMN viewer is not initialized.');
+        }
+
+        return window.bpmnViewer;
+    }
+
+    async function disposeViewer() {
+        const existingViewer = window.bpmnViewer;
+        if (existingViewer && typeof existingViewer.destroy === 'function') {
+            existingViewer.destroy();
+        }
+
+        window.bpmnViewer = undefined;
+        resetCanvas();
+    }
+
+    async function initializeViewer() {
+        await waitForElement('#js-canvas');
+        await new Promise(resolve => requestAnimationFrame(resolve));
+
+        await disposeViewer();
+        await window.InitViewer();
+
+        if (!window.bpmnViewer) {
+            throw new Error('BPMN viewer could not be created.');
+        }
+    }
+
+    async function importXml(xml) {
+        if (!xml || !xml.trim()) {
+            throw new Error('No BPMN XML was provided.');
+        }
+
+        const viewer = getViewer();
+        const importResult = await viewer.importXML(xml);
+        const canvas = viewer.get('canvas');
+        if (canvas && typeof canvas.zoom === 'function') {
+            canvas.zoom('fit-viewport');
+        }
+
+        return Array.isArray(importResult?.warnings) ? importResult.warnings : [];
+    }
+
+    function clearTokens() {
+        const viewer = getViewer();
+        viewer.get('overlays').clear();
+    }
+
+    function addToken(id, count) {
+        if (!id) {
+            return false;
+        }
+
+        const viewer = getViewer();
+        const elementRegistry = viewer.get('elementRegistry');
+        if (!elementRegistry || !elementRegistry.get(id)) {
+            console.warn(`Could not find BPMN element '${id}' for token overlay.`);
+            return false;
+        }
+
+        viewer.get('overlays').add(id, 'note', {
+            position: {
+                top: -10,
+                left: -10
+            },
+            html: `<div class="diagram-note" style="background: green; border-radius: 100%; width: 20px; height: 20px; overflow: hidden; font-weight: bold; text-align: center; color: white;">${count}</div>`
+        });
+
+        return true;
+    }
+
+    window.FlowzerInstanceViewer = {
+        addToken,
+        clearTokens,
+        dispose: disposeViewer,
+        importXml,
+        initialize: initializeViewer
+    };
+})();

--- a/tests/ui-smoke/tests/core-paths.spec.js
+++ b/tests/ui-smoke/tests/core-paths.spec.js
@@ -15,6 +15,7 @@ function createSuffix(prefix) {
 }
 
 let runtimeScenarioPromise;
+let modelerScenarioPromise;
 
 async function ensureRuntimeScenario(request) {
   if (runtimeScenarioPromise) {
@@ -35,7 +36,7 @@ async function ensureRuntimeScenario(request) {
       schema: createFormSchema('Approval')
     });
 
-    await deployDefinition(request, {
+    const deployedDefinition = await deployDefinition(request, {
       xml: buildMessageStartUserTaskXml({
         definitionId,
         messageName,
@@ -46,6 +47,7 @@ async function ensureRuntimeScenario(request) {
 
     return {
       definitionId,
+      definitionGuid: deployedDefinition.definitionGuid,
       formKey,
       modelName,
       messageName
@@ -53,6 +55,39 @@ async function ensureRuntimeScenario(request) {
   })();
 
   return runtimeScenarioPromise;
+}
+
+async function ensureModelerScenario(request) {
+  if (modelerScenarioPromise) {
+    return modelerScenarioPromise;
+  }
+
+  modelerScenarioPromise = (async () => {
+    const formKey = createSuffix('ui-smoke-modeler-form');
+    const modelName = createSuffix('UI Smoke Modeler');
+    const messageName = createSuffix('UiSmokeModelerStart');
+    const definitionId = await createDefinitionMeta(request, {
+      name: modelName,
+      description: 'Playwright modeler hardening path.'
+    });
+
+    const deployedDefinition = await deployDefinition(request, {
+      xml: buildMessageStartUserTaskXml({
+        definitionId,
+        messageName,
+        formKey,
+        userTaskName: 'Review model'
+      })
+    });
+
+    return {
+      definitionId,
+      definitionGuid: deployedDefinition.definitionGuid,
+      modelName
+    };
+  })();
+
+  return modelerScenarioPromise;
 }
 
 test('Formulare aus der API erscheinen in Liste und Detailansicht', async ({ page, request }) => {
@@ -76,8 +111,8 @@ test('Formulare aus der API erscheinen in Liste und Detailansicht', async ({ pag
 });
 
 test('Bereitgestellte Modelle erscheinen im Frontend und öffnen den Diagrammzugriff', async ({ page, request }) => {
-  const runtimeScenario = await ensureRuntimeScenario(request);
-  const { definitionId, modelName } = runtimeScenario;
+  const modelerScenario = await ensureModelerScenario(request);
+  const { definitionId, modelName } = modelerScenario;
 
   await page.goto('/models', { waitUntil: 'networkidle' });
 
@@ -87,9 +122,46 @@ test('Bereitgestellte Modelle erscheinen im Frontend und öffnen den Diagrammzug
 
   await expect(page).toHaveURL(new RegExp(`/definition/${definitionId}$`));
   await expect(page.locator('#current-file-name')).toHaveText(modelName);
-  await expect(page.locator('#current-file-version')).toContainText('2.0');
+  await expect(page.locator('#current-file-version')).toContainText(/\d+\.\d+/);
   await expect(page.locator('#designer-container')).toBeVisible();
+  await expect(page.locator('#js-canvas .djs-container')).toBeVisible();
+  await expect(page.locator('#js-properties-panel .bio-properties-panel, #js-properties-panel .djs-properties-panel')).toBeVisible();
   await expect(page.getByText('Error :-(')).toHaveCount(0);
+  await expect(page.locator('#definition-load-error')).toHaveCount(0);
+});
+
+test('Der Modeler speichert mit Versionsbezug und aktualisiert die Definitionsroute', async ({ page, request }) => {
+  const modelerScenario = await ensureModelerScenario(request);
+  const { definitionId, definitionGuid } = modelerScenario;
+
+  await page.goto(`/definition/${definitionId}/${definitionGuid}`, { waitUntil: 'networkidle' });
+  await expect(page.locator('#definition-loading-state')).toHaveCount(0, { timeout: 20_000 });
+  await expect(page.locator('#js-canvas .djs-container')).toBeVisible();
+
+  const requestPromise = page.waitForRequest(currentRequest => {
+    return currentRequest.method() === 'POST' && currentRequest.url().includes('/definition?previousGuid=');
+  });
+
+  const responsePromise = page.waitForResponse(currentResponse => {
+    return currentResponse.request().method() === 'POST' && currentResponse.url().includes('/definition?previousGuid=');
+  });
+
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  const saveRequest = await requestPromise;
+  expect(saveRequest.url()).toContain(`previousGuid=${definitionGuid}`);
+
+  const saveResponse = await responsePromise;
+  expect(saveResponse.ok()).toBeTruthy();
+
+  const savedDefinition = await saveResponse.json();
+  const savedDefinitionGuid = savedDefinition.id || savedDefinition.Id;
+  expect(savedDefinitionGuid).toBeTruthy();
+  expect(savedDefinitionGuid).not.toBe(definitionGuid);
+
+  await expect(page).toHaveURL(new RegExp(`/definition/${definitionId}/${savedDefinitionGuid}$`));
+  await expect(page.locator('#blazor-error-ui')).toBeHidden();
+  await expect(page.locator('#definition-load-error')).toHaveCount(0);
 });
 
 test('Message-Start-Prozess wandert von offenem Task zu Done Instances', async ({ page, request }) => {
@@ -117,6 +189,8 @@ test('Message-Start-Prozess wandert von offenem Task zu Done Instances', async (
 
   await expect(page).toHaveURL(/\/instance\/[0-9a-f-]+$/);
   await expect(page.locator('#instance-name')).toContainText(modelName);
+  await expect(page.locator('#js-canvas .djs-container')).toBeVisible();
+  await expect(page.locator('.diagram-note')).toBeVisible();
   await expect(page.locator('#blazor-error-ui')).toBeHidden();
 
   await completeUserTask(request, userTask, {

--- a/tests/ui-smoke/tests/navigation.spec.js
+++ b/tests/ui-smoke/tests/navigation.spec.js
@@ -96,3 +96,17 @@ test('Instanzfilter-Navigation bleibt innerhalb gültiger Frontend-Routen', asyn
   await expect(page).toHaveURL(/\/instances\/error$/);
   await expect(page.getByText('Showing: Failed instances')).toBeVisible();
 });
+
+
+test('Ungültige Modellrouten zeigen einen Inline-Fehler statt eines fatalen Blazor-Absturzes', async ({ page }) => {
+  const pageErrors = [];
+
+  page.on('pageerror', error => pageErrors.push(error.message));
+
+  await page.goto('/definition/definition-does-not-exist', { waitUntil: 'networkidle' });
+
+  await expect(page.locator('#definition-load-error')).toContainText('Could not load model.', { timeout: 20_000 });
+  await expect(page.locator('#definition-retry-button')).toBeVisible();
+  await expect(page.locator('#blazor-error-ui')).toBeHidden();
+  expect(pageErrors, 'Unerwartete PageErrors auf einer ungültigen Modellroute').toEqual([]);
+});


### PR DESCRIPTION
## Ziel

Dieser Strang härtet die Diagramm- und Modeler-Integration im Frontend, damit Laden, Anzeigen, Speichern und Fehlerszenarien stabiler funktionieren.

## Bezug

- closes #49

## Was umgesetzt wurde

### Render- und Interop-Härtung
- Modeler- und Viewer-Initialisierung laufen jetzt über explizite JS-Wrapper mit DOM-Checks, Cleanup und `fit-viewport`
- beim Verlassen der Seiten werden Viewer/Modeler best-effort zerstört, damit keine veralteten Diagrammobjekte hängen bleiben
- Retry-Pfade für Modell- und Instanzseite ergänzen die bisher rein fatalen Fehlerzustände

### Frontend-Verhalten verbessert
- `/definition/{metaDefinitionId}` zeigt jetzt klare Loading- und Inline-Fehlerzustände mit Retry-Button
- Save/Deploy sind nur aktiv, wenn der Editor wirklich bereit ist
- Save/Deploy navigieren nach erfolgreichem Persistieren auf die konkrete neue Definitionsroute
- beim Speichern und Deployen wird der bisherige Stand als `previousGuid` an die API übergeben

### Testabdeckung erweitert
- neue Frontend-Unit-Tests für die API-URL-Bildung mit `previousGuid`
- zusätzliche Playwright-Smokes für
  - sichtbaren Diagramm- und Properties-Panel-Pfad
  - Speichern mit Versionsbezug und aktualisierter Route
  - ungültige Modellrouten mit sauberem Inline-Fehler
  - Viewer-Pfad in der Instanzansicht

### Dokumentation
- `/docs/FRONTEND.md` beschreibt jetzt die Diagramm-/Modeler-Prüfpfade und die empfohlenen manuellen Checks genauer

## Validierung

```bash
dotnet restore core-engine.sln
dotnet build core-engine.sln --configuration Release --no-restore
dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-restore --logger 'console;verbosity=minimal'
dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-restore --logger 'console;verbosity=minimal'
dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-restore --logger 'console;verbosity=minimal'
npm --prefix bpmn.io ci
npm --prefix bpmn.io run build
npm --prefix tests/ui-smoke ci
npm --prefix tests/ui-smoke run test
```
