### PR TITLE
Engine- und Runtime-Restpfade härten

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -70,6 +70,8 @@ Noch offen sind unter anderem:
 - Betriebs- und Deployment-Themen wie Health, Logging-Orientierung und lokale Start-Story
 - Altlasten und Doppelstrukturen im Repository
 
+Eine aktuellere Einordnung der verbliebenen Engine-/Runtime-Lücken steht zusätzlich in [`docs/RUNTIME-GAPS.md`](./RUNTIME-GAPS.md).
+
 ### 3. Dokumentation muss nun mit der Technik mitwachsen
 
 Die Basisdokumentation ist deutlich besser als zuvor, aber für die nächste Reifestufe fehlen bzw. benötigen Updates:

--- a/docs/RUNTIME-GAPS.md
+++ b/docs/RUNTIME-GAPS.md
@@ -1,0 +1,73 @@
+# Laufzeitlücken und aktueller Restbestand
+
+**Stand:** 12. April 2026
+
+Dieses Dokument hält die aktuell noch offenen Laufzeit- und Engine-Lücken fest, damit `next` nicht nur "grün", sondern auch fachlich ehrlich bleibt.
+
+## In diesem Strang bereits geschlossen
+
+### 1. Timer-Catch-Events blockieren die Engine nicht mehr sofort
+
+- `FlowzerIntermediateTimerCatchEvent` wird jetzt wie andere wartende Catch-Events als aktiver Wartezustand behandelt.
+- Laufende Instanzen können ihre aktiven Timertermine jetzt über `ICatchHandler.ActiveTimers` offenlegen.
+- `timeDuration` wird bei der Fälligkeitsberechnung jetzt genauso berücksichtigt wie `timeCycle` und `timeDate`.
+
+### 2. User-Task-Ergebnisse haben einen stabileren Laufzeitvertrag
+
+- User-Task-Ergebnisse ohne `ProcessInstanceId` laufen nicht mehr in eine rohe `NotImplementedException`.
+- Stattdessen kommt ein valider `400 Bad Request` mit einem klaren API-Fehlervertrag zurück.
+- Zusätzlich wird jetzt geprüft, ob das übergebene `TokenId` wirklich noch aktiv ist und zum erwarteten `FlowNodeId` gehört.
+
+### 3. Instanzabbruch ist als Best-Effort-Pfad verfügbar
+
+- `InstanceEngine.Cancel()` terminiert jetzt aktive/wartende Tokens der Instanz konsistent.
+- Das ersetzt noch **keine vollständige BPMN-Kompensation**, verhindert aber, dass der API-/Runtime-Pfad an einer nackten `NotImplementedException` scheitert.
+
+## Weiterhin bewusst offen
+
+### 1. Timer-Ausführung und Persistenz
+
+Aktuell sichtbar bzw. teilweise vorbereitet:
+
+- Timer-Fälligkeiten für Start- und laufende Instanzen
+- Timer-Catch-Events als wartende Zustände
+
+Weiterhin offen:
+
+- persistierte Timer-Subscriptions in Storage/API
+- Wiederaufnahme nach Neustart nur auf Basis gespeicherter Timerzustände
+- tatsächliches `HandleTime(...)` bzw. Scheduler-Anbindung
+- Boundary-Timer-Parsing und -Abarbeitung
+
+### 2. Fehler- und Eskalationspfade
+
+Noch nicht produktionsreif umgesetzt:
+
+- Error Boundary Events
+- Escalation Catch/Throw
+- fachlich sinnvolle Fehlerpropagation auf BPMN-Ebene statt nur auf Ausnahmepfad
+
+Aktueller Status:
+
+- `GetActiveEscalations()` liefert jetzt wenigstens stabil eine leere Liste statt sofort zu scheitern
+- echte Eskalations- und Fehlersemantik bleibt ein separates Folgepaket
+
+### 3. Vollständige Kompensation bei Abbruch
+
+`Cancel()` ist aktuell eine **Best-Effort-Terminierung**:
+
+- aktive und wartende Tokens werden beendet
+- offene Interaktionen verschwinden aus dem aktiven Zustand
+
+Nicht enthalten:
+
+- Rückabwicklung bereits durchlaufener Activities
+- BPMN-Kompensationshandler
+- fachliche Undo-Semantik für Seiteneffekte
+
+## Empfohlene nächste Runtime-Schritte
+
+1. Timer-Storage + Scheduler-Pfad ergänzen
+2. Boundary-Timer parsen und persistierbar machen
+3. Error-/Escalation-Semantik gezielt modellieren und testen
+4. `Cancel()` später um echte Kompensationsstrategien erweitern

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -130,7 +130,8 @@ public class ApiHardeningIntegrationTest
         var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult>();
         payload.Should().NotBeNull();
         payload!.Successful.Should().BeFalse();
-        payload.ErrorMessage.Should().Be("User task results require a ProcessInstanceId. (Parameter 'ProcessInstanceId')");
+        payload.ErrorMessage.Should().Contain("User task results require a ProcessInstanceId.");
+        payload.ErrorMessage.Should().Contain("ProcessInstanceId");
     }
 
     [Test]

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -111,6 +111,29 @@ public class ApiHardeningIntegrationTest
     }
 
     [Test]
+    public async Task UserTaskEndpoint_ShouldReturnBadRequest_WhenProcessInstanceIdIsMissing()
+    {
+        var storage = new TestStorage();
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/usertask", new UserTaskResultDto
+        {
+            FlowNodeId = "UserTask_1",
+            TokenId = Guid.NewGuid(),
+            ProcessInstanceId = null,
+            Data = null
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeFalse();
+        payload.ErrorMessage.Should().Be("User task results require a ProcessInstanceId. (Parameter 'ProcessInstanceId')");
+    }
+
+    [Test]
     public async Task MissingFormMetadata_ShouldReturnJsonApiContract_WhenControllerThrowsFileNotFound()
     {
         var storage = new TestStorage

--- a/src/WebApiEngine/BusinessLogic/BpmnBusinessLogic.cs
+++ b/src/WebApiEngine/BusinessLogic/BpmnBusinessLogic.cs
@@ -171,31 +171,34 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider)
     {
         using var storageSystem = storageProvider.GetTransactionalStorage();
 
-        InstanceEngine instance;
-        if (userTaskResult.ProcessInstanceId != null) //the message is for a specific instance, so load the instance
+        if (userTaskResult.ProcessInstanceId == null)
         {
-            var processInstance = await storageSystem.InstanceStorage.GetProcessInstance(userTaskResult.ProcessInstanceId.Value);
-            
-            instance = new InstanceEngine(processInstance.Tokens);
-            instance.InstanceId = userTaskResult.ProcessInstanceId.Value;
-            instance.HandleTaskResult(userTaskResult.TokenId, userTaskResult.Data, userId);
-            await SaveInstance(storageSystem, instance, processInstance.metaDefinitionId, processInstance.DefinitionId, processInstance.ProcessId);
-        }
-        else //the message is for a new instance, so create a new one
-        {
-            throw new NotImplementedException("Not implemented yet");
-            // var xmlData = await storageSystem.DefinitionStorage.GetBinary(userTaskResult.DefinitionId);
-            // var model =  ModelParser.ParseModel(xmlData);
-            //
-            // var process = model.GetProcesses().FirstOrDefault(x => x.Id == messageSubscription.ProcessId);
-            // if (process == null)
-            //     throw new Exception($"No process with the id \"{messageSubscription.ProcessId}\" was found in the definition with the id \"{messageSubscription.DefinitionId}\".");
-            //
-            // instance = StartProcessByMessage(messageSubscription.DefinitionId, messageSubscription.RelatedDefinitionId, process, message);
-            //await SaveInstance(storageSystem, instance, metaDefinitionId, definitionId, messageSubscription.ProcessId);
+            throw new ArgumentException("User task results require a ProcessInstanceId.", nameof(userTaskResult.ProcessInstanceId));
         }
 
-        
+        var processInstance = await storageSystem.InstanceStorage.GetProcessInstance(userTaskResult.ProcessInstanceId.Value);
+        var instance = new InstanceEngine(processInstance.Tokens);
+        instance.InstanceId = userTaskResult.ProcessInstanceId.Value;
+
+        var activeUserTaskToken = instance.GetActiveUserTasks()
+            .SingleOrDefault(token => token.Id == userTaskResult.TokenId);
+
+        if (activeUserTaskToken == null)
+        {
+            throw new ArgumentException(
+                $"The user task token \"{userTaskResult.TokenId}\" is not active for process instance \"{userTaskResult.ProcessInstanceId}\".",
+                nameof(userTaskResult.TokenId));
+        }
+
+        if (!string.Equals(activeUserTaskToken.CurrentFlowNode?.Id, userTaskResult.FlowNodeId, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"The user task token \"{userTaskResult.TokenId}\" does not belong to flow node \"{userTaskResult.FlowNodeId}\".",
+                nameof(userTaskResult.FlowNodeId));
+        }
+
+        instance.HandleTaskResult(userTaskResult.TokenId, userTaskResult.Data, userId);
+        await SaveInstance(storageSystem, instance, processInstance.metaDefinitionId, processInstance.DefinitionId, processInstance.ProcessId);
         storageSystem.CommitChanges();
 
         return instance;

--- a/src/core-engine-tests/EngineTest.cs
+++ b/src/core-engine-tests/EngineTest.cs
@@ -388,11 +388,12 @@ public class EngineTest
                                                """);
 
         var activeTimers = ((ICatchHandler)instanceEngine).ActiveTimers;
+        var timerToken = instanceEngine.ActiveTokens.Single(token => token.CurrentFlowNode?.Id == "TimerCatch_1");
 
         using (new AssertionScope())
         {
             activeTimers.Should().ContainSingle();
-            activeTimers.Single().Should().BeCloseTo(DateTime.UtcNow.AddSeconds(5), TimeSpan.FromSeconds(1));
+            activeTimers.Single().Should().BeCloseTo(timerToken.LastStateChangeTime.AddSeconds(5), TimeSpan.FromMilliseconds(250));
             instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Waiting);
             instanceEngine.ActiveTokens
                 .Count(token => token.CurrentFlowNode != null && token.CurrentFlowNode.Id == "TimerCatch_1")

--- a/src/core-engine-tests/EngineTest.cs
+++ b/src/core-engine-tests/EngineTest.cs
@@ -6,8 +6,6 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using Model;
 using Task = System.Threading.Tasks.Task;
-using FluentAssertions;
-using FluentAssertions.Execution;
 
 namespace core_engine_tests;
 
@@ -359,6 +357,95 @@ public class EngineTest
         // activeTimers.Should().HaveCount(0);
         //
     }
+
+    [Test]
+    public void IntermediateTimerCatchEvent_ShouldStayActiveAndExposeDueDate()
+    {
+        var instanceEngine = StartProcessFromXml("""
+                                               <?xml version="1.0" encoding="UTF-8"?>
+                                               <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                                                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                                 id="Definitions_TimerCatch"
+                                                                 targetNamespace="http://bpmn.io/schema/bpmn">
+                                                 <bpmn:process id="Process_TimerCatch" isExecutable="true">
+                                                   <bpmn:startEvent id="StartEvent_1">
+                                                     <bpmn:outgoing>Flow_1</bpmn:outgoing>
+                                                   </bpmn:startEvent>
+                                                   <bpmn:intermediateCatchEvent id="TimerCatch_1">
+                                                     <bpmn:incoming>Flow_1</bpmn:incoming>
+                                                     <bpmn:outgoing>Flow_2</bpmn:outgoing>
+                                                     <bpmn:timerEventDefinition id="TimerDefinition_1">
+                                                       <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT5S</bpmn:timeDuration>
+                                                     </bpmn:timerEventDefinition>
+                                                   </bpmn:intermediateCatchEvent>
+                                                   <bpmn:endEvent id="EndEvent_1">
+                                                     <bpmn:incoming>Flow_2</bpmn:incoming>
+                                                   </bpmn:endEvent>
+                                                   <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="TimerCatch_1" />
+                                                   <bpmn:sequenceFlow id="Flow_2" sourceRef="TimerCatch_1" targetRef="EndEvent_1" />
+                                                 </bpmn:process>
+                                               </bpmn:definitions>
+                                               """);
+
+        var activeTimers = ((ICatchHandler)instanceEngine).ActiveTimers;
+
+        using (new AssertionScope())
+        {
+            activeTimers.Should().ContainSingle();
+            activeTimers.Single().Should().BeCloseTo(DateTime.UtcNow.AddSeconds(5), TimeSpan.FromSeconds(1));
+            instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Waiting);
+            instanceEngine.ActiveTokens
+                .Count(token => token.CurrentFlowNode != null && token.CurrentFlowNode.Id == "TimerCatch_1")
+                .Should()
+                .Be(1);
+        }
+    }
+
+    [Test]
+    public void Cancel_ShouldTerminateWaitingInstanceAndClearActiveTasks()
+    {
+        var instanceEngine = StartProcessFromXml("""
+                                               <?xml version="1.0" encoding="UTF-8"?>
+                                               <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                                                 xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                                                                 id="Definitions_UserTask"
+                                                                 targetNamespace="http://bpmn.io/schema/bpmn">
+                                                 <bpmn:process id="Process_UserTask" isExecutable="true">
+                                                   <bpmn:startEvent id="StartEvent_1">
+                                                     <bpmn:outgoing>Flow_1</bpmn:outgoing>
+                                                   </bpmn:startEvent>
+                                                   <bpmn:userTask id="UserTask_1" name="Review">
+                                                     <bpmn:extensionElements>
+                                                       <zeebe:formDefinition formId="cancel-form" />
+                                                     </bpmn:extensionElements>
+                                                     <bpmn:incoming>Flow_1</bpmn:incoming>
+                                                     <bpmn:outgoing>Flow_2</bpmn:outgoing>
+                                                   </bpmn:userTask>
+                                                   <bpmn:endEvent id="EndEvent_1">
+                                                     <bpmn:incoming>Flow_2</bpmn:incoming>
+                                                   </bpmn:endEvent>
+                                                   <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="UserTask_1" />
+                                                   <bpmn:sequenceFlow id="Flow_2" sourceRef="UserTask_1" targetRef="EndEvent_1" />
+                                                 </bpmn:process>
+                                               </bpmn:definitions>
+                                               """);
+
+        instanceEngine.Cancel();
+
+        using (new AssertionScope())
+        {
+            instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Terminated);
+            instanceEngine.GetActiveUserTasks().Should().BeEmpty();
+            instanceEngine.ActiveTokens.Should().BeEmpty();
+            instanceEngine.Tokens.Any(token =>
+                    token.CurrentFlowNode != null &&
+                    token.CurrentFlowNode.Id == "UserTask_1" &&
+                    token.State == FlowNodeState.Terminated)
+                .Should()
+                .BeTrue();
+            instanceEngine.MasterToken.State.Should().Be(FlowNodeState.Terminated);
+        }
+    }
     
     [Test]
     public async Task SubProcessTest()
@@ -377,5 +464,11 @@ public class EngineTest
         instanceEngine.HandleServiceTaskResult("sub2_step1");
         instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Waiting);
         instanceEngine.Tokens.Should().HaveCount(12);
+    }
+
+    private static InstanceEngine StartProcessFromXml(string xml)
+    {
+        var process = ModelParser.ParseModel(xml).GetProcesses().Single();
+        return Helper.CreateProcessEngine(process).StartProcess();
     }
 }

--- a/src/core-engine/Extensions/RecordExtension.cs
+++ b/src/core-engine/Extensions/RecordExtension.cs
@@ -17,6 +17,10 @@ public static class RecordExtensions
 
         foreach (var propertyInfo in properties)
         {
+            if (!propertyInfo.CanWrite || propertyInfo.SetMethod == null)
+            {
+                continue;
+            }
             
             var propertyValue = propertyInfo.GetValue(record);
             if (propertyInfo.GetCustomAttribute<DoNotTranslateAttribute>() != null)

--- a/src/core-engine/InstanceEngine/Base.cs
+++ b/src/core-engine/InstanceEngine/Base.cs
@@ -62,9 +62,9 @@ public partial class InstanceEngine: ICatchHandler
         _ => throw new FlowzerRuntimeException("ProcessInstanceState nicht ermittelbar")
     };
     
-    public Task<IEnumerable<Escalation>> GetActiveEscalations()
+    public System.Threading.Tasks.Task<IEnumerable<Escalation>> GetActiveEscalations()
     {
-        throw new NotImplementedException();
+        return System.Threading.Tasks.Task.FromResult<IEnumerable<Escalation>>([]);
     }
 
     public IEnumerable<Token> GetActiveUserTasks() => Tokens
@@ -128,7 +128,19 @@ public partial class InstanceEngine: ICatchHandler
     /// </summary>
     public void Cancel()
     {
-        throw new NotImplementedException();
+        var tokensToTerminate = Tokens
+            .Where(CanBeTerminatedByCancellation)
+            .ToArray();
+
+        foreach (var token in tokensToTerminate)
+        {
+            token.State = FlowNodeState.Terminating;
+        }
+
+        foreach (var token in Tokens.Where(token => token.State == FlowNodeState.Terminating))
+        {
+            token.State = FlowNodeState.Terminated;
+        }
     }
 
     // public Task<ProcessInstance> HandleTime(DateTime time)
@@ -152,7 +164,34 @@ public partial class InstanceEngine: ICatchHandler
         return processToken;
     }
     
-    List<DateTime> ICatchHandler.ActiveTimers => throw new NotImplementedException();
+    List<DateTime> ICatchHandler.ActiveTimers => Tokens
+        .Where(token => token.State == FlowNodeState.Active)
+        .SelectMany(GetActiveTimerDates)
+        .Distinct()
+        .ToList();
+
+    private static IEnumerable<DateTime> GetActiveTimerDates(Token token)
+    {
+        if (token.CurrentFlowNode is FlowzerIntermediateTimerCatchEvent timerCatchEvent)
+        {
+            yield return TimerDueDateCalculator.GetDueDate(
+                token.LastStateChangeTime,
+                timerCatchEvent.TimerDefinition,
+                timerCatchEvent);
+        }
+    }
+
+    private static bool CanBeTerminatedByCancellation(Token token)
+    {
+        return token.State is
+            FlowNodeState.Ready or
+            FlowNodeState.Active or
+            FlowNodeState.Completing or
+            FlowNodeState.WaitingForLoopEnd or
+            FlowNodeState.Failing or
+            FlowNodeState.Terminating;
+    }
+
     public List<Token> ActiveUserTasks()
     {
         return GetActiveUserTasks().ToList();

--- a/src/core-engine/InstanceEngine/Base.cs
+++ b/src/core-engine/InstanceEngine/Base.cs
@@ -123,8 +123,8 @@ public partial class InstanceEngine: ICatchHandler
     }
 
     /// <summary>
-    /// Abbruch der Instanz. Dabei werden alle Tokens terminiert und die bereits durchlaufenen Activities kompensiert.
-    /// Subprozesse werden ebenfalls abgebrochen.
+    /// Bricht die Instanz best-effort ab, indem aktive bzw. wartende Tokens terminiert werden.
+    /// Eine BPMN-Kompensation bereits ausgeführter Activities ist damit bewusst noch nicht verbunden.
     /// </summary>
     public void Cancel()
     {

--- a/src/core-engine/InstanceEngine/InstanceEngine.cs
+++ b/src/core-engine/InstanceEngine/InstanceEngine.cs
@@ -254,6 +254,7 @@ public partial class InstanceEngine
         { typeof(ReceiveTask), new DoNothingFlowNodeHandler() },
         { typeof(FlowzerIntermediateMessageCatchEvent), new DoNothingFlowNodeHandler() },
         { typeof(FlowzerIntermediateSignalCatchEvent), new DoNothingFlowNodeHandler() },
+        { typeof(FlowzerIntermediateTimerCatchEvent), new DoNothingFlowNodeHandler() },
         { typeof(Process), new DoNothingFlowNodeHandler() },
         { typeof(SubProcess), new ProcessFlowNodeHandler() },
         // {typeof(EventBasedGateway), new EventBasedGatewayHandler()},

--- a/src/core-engine/ProcessEngine.cs
+++ b/src/core-engine/ProcessEngine.cs
@@ -25,23 +25,6 @@ public class ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null)
         return instance;
     }
 
-   
-    private DateTime GetDateFromTimerDefinition(DateTime referenceTime, TimerEventDefinition timerDefinition, FlowNode flowNode)
-    {
-        if (timerDefinition.TimeCycle != null)
-        {
-            var timeSpan = ISO8601Date.DateExtensions.ParseIso8601Duration(timerDefinition.TimeCycle.Body);
-            return referenceTime.Add(timeSpan);
-        }
-        else if (timerDefinition.TimeDate != null)
-        {
-            return DateTime.Parse(timerDefinition.TimeDate.Body);
-        }
-
-        throw new ModelValidationException("Timer definition is invalid. for node " + flowNode.Name);
-    }
-
-
     // public async Task<InstanceEngine> HandleTime(DateTime time)
     // {
     //     var processInstance = new ProcessInstance
@@ -99,7 +82,7 @@ public class ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null)
         {
             return Process.FlowElements
                 .OfType<FlowzerTimerStartEvent>()
-                .Select(e => GetDateFromTimerDefinition(DateTime.Now, e.TimerDefinition, e))
+                .Select(e => TimerDueDateCalculator.GetDueDate(DateTime.Now, e.TimerDefinition, e))
                 .ToList();
         }
     }

--- a/src/core-engine/TimerDueDateCalculator.cs
+++ b/src/core-engine/TimerDueDateCalculator.cs
@@ -1,0 +1,35 @@
+using core_engine.Exceptions;
+
+namespace core_engine;
+
+/// <summary>
+/// Kapselt die Berechnung von Fälligkeitszeitpunkten für Timerdefinitionen,
+/// damit Start- und Laufzeitpfade dieselbe Logik verwenden.
+/// </summary>
+internal static class TimerDueDateCalculator
+{
+    public static DateTime GetDueDate(DateTime referenceTime, TimerEventDefinition timerDefinition, FlowNode flowNode)
+    {
+        ArgumentNullException.ThrowIfNull(timerDefinition);
+        ArgumentNullException.ThrowIfNull(flowNode);
+
+        if (timerDefinition.TimeCycle != null)
+        {
+            var timeSpan = ISO8601Date.DateExtensions.ParseIso8601Duration(timerDefinition.TimeCycle.Body);
+            return referenceTime.Add(timeSpan);
+        }
+
+        if (timerDefinition.TimeDuration != null)
+        {
+            var timeSpan = ISO8601Date.DateExtensions.ParseIso8601Duration(timerDefinition.TimeDuration.Body);
+            return referenceTime.Add(timeSpan);
+        }
+
+        if (timerDefinition.TimeDate != null)
+        {
+            return DateTime.Parse(timerDefinition.TimeDate.Body);
+        }
+
+        throw new ModelValidationException("Timer definition is invalid. for node " + flowNode.Name);
+    }
+}

--- a/src/core-engine/TimerDueDateCalculator.cs
+++ b/src/core-engine/TimerDueDateCalculator.cs
@@ -30,6 +30,10 @@ internal static class TimerDueDateCalculator
             return DateTime.Parse(timerDefinition.TimeDate.Body);
         }
 
-        throw new ModelValidationException("Timer definition is invalid. for node " + flowNode.Name);
+        var nodeIdentifier = string.IsNullOrWhiteSpace(flowNode.Name)
+            ? flowNode.Id
+            : $"{flowNode.Id} ({flowNode.Name})";
+
+        throw new ModelValidationException($"Timer definition is invalid for node {nodeIdentifier}.");
     }
 }


### PR DESCRIPTION
## Ziel

Dieser Strang baut verbleibende Engine- und Runtime-Lücken auf `next` gezielt ab, ohne neue Produktpfade zu behaupten, die technisch noch nicht getragen sind.

## Bezug

- closes #53

## Was umgesetzt wurde

### Timer- und Catch-Event-Härtung

- laufende Instanzen können aktive Timer jetzt über `ICatchHandler.ActiveTimers` stabil melden
- `FlowzerIntermediateTimerCatchEvent` wird als echter Wartezustand behandelt statt zur Laufzeit hart zu scheitern
- die Timer-Fälligkeitsberechnung ist in eine gemeinsame Hilfsklasse gezogen worden
- `timeDuration` wird dabei jetzt zusätzlich zu `timeCycle` und `timeDate` unterstützt

### Runtime-Verträge stabilisiert

- `GetActiveEscalations()` liefert jetzt wenigstens stabil eine leere Liste statt sofort in eine `NotImplementedException` zu laufen
- `InstanceEngine.Cancel()` terminiert aktive/wartende Tokens jetzt konsistent als Best-Effort-Abbruchpfad
- User-Task-Ergebnisse ohne `ProcessInstanceId` liefern jetzt einen klaren `400 Bad Request` statt in eine rohe `NotImplementedException` zu laufen
- beim Abschließen eines User Tasks wird zusätzlich geprüft, ob `TokenId` und `FlowNodeId` wirklich zum aktiven Task der Instanz passen

### Reflection-/Record-Härtung

- `ApplyResolveExpression(...)` überspringt jetzt getter-only Eigenschaften, damit Records mit abgeleiteten Read-Only-Properties (z. B. Timer-Typen) nicht mehr an Reflection-Setzversuchen scheitern

### Dokumentation

- neues Dokument `/docs/RUNTIME-GAPS.md` beschreibt den jetzt geschlossenen Teil und den weiterhin bewusst offenen Restbestand
- `/docs/PROJECT-STATUS.md` verweist auf die detailliertere Runtime-Einordnung

## Testabdeckung

- neuer Engine-Test für aktive Intermediate-Timer-Catch-Events inklusive Fälligkeitszeit
- neuer Engine-Test für den Best-Effort-Abbruch wartender Instanzen
- neuer API-Integrationstest für User-Task-Ergebnisse ohne `ProcessInstanceId`

## Validierung

```bash
dotnet build core-engine.sln --configuration Release --no-restore
dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-restore --logger 'console;verbosity=minimal'
dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-restore --logger 'console;verbosity=minimal'
dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-restore --logger 'console;verbosity=minimal'
npm --prefix bpmn.io ci
npm --prefix bpmn.io run build
npm --prefix tests/ui-smoke ci
npm --prefix tests/ui-smoke run test
```
