### PR TITLE
Betriebs- und Deployment-Basis für next vorbereiten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,6 +196,8 @@ PublishScripts/
 *.nupkg
 # NuGet Symbol Packages
 *.snupkg
+# Lokale Flowzer-Storage-Daten
+.data/
 # The packages folder can be ignored because of Package Restore
 **/[Pp]ackages/*
 # except build/, which is used as an MSBuild target.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,18 @@ npm --prefix tests/ui-smoke run test
 
 Details zu API-Basisadresse, lokalen Startbefehlen und den getesteten Routen stehen in [docs/FRONTEND.md](docs/FRONTEND.md).
 
+## Lokaler Stack per Docker Compose
+
+Für einen reproduzierbaren API-/Frontend-Start gibt es jetzt zusätzlich einen kleinen lokalen Compose-Stack:
+
+```bash
+./scripts/local/start-stack.sh
+./scripts/local/check-stack.sh
+./scripts/local/stop-stack.sh
+```
+
+Weitere Betriebs- und Diagnosehinweise stehen in [docs/OPERATIONS.md](docs/OPERATIONS.md).
+
 ## Beispiel
 
 Ein kleines Nutzungsbeispiel liegt in [`/examples/SimpleEngineExample.cs`](examples/SimpleEngineExample.cs).

--- a/compose.local.yml
+++ b/compose.local.yml
@@ -19,7 +19,7 @@ services:
       interval: 10s
       timeout: 3s
       retries: 12
-      start_period: 20s
+      start_period: 90s
 
   frontend:
     image: mcr.microsoft.com/dotnet/sdk:8.0
@@ -38,3 +38,9 @@ services:
     depends_on:
       api:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5269 | grep -q FlowzerFrontend || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 18
+      start_period: 90s

--- a/compose.local.yml
+++ b/compose.local.yml
@@ -1,0 +1,40 @@
+services:
+  api:
+    image: mcr.microsoft.com/dotnet/sdk:8.0
+    working_dir: /workspace
+    command: >
+      bash -lc "
+      dotnet restore core-engine.sln &&
+      dotnet build src/WebApiEngine/WebApiEngine.csproj --configuration Release --no-restore &&
+      dotnet run --project src/WebApiEngine/WebApiEngine.csproj --configuration Release --no-build --no-launch-profile --urls http://0.0.0.0:5182"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      FLOWZER_STORAGE_ROOT: /workspace/.data/flowzer-storage
+    ports:
+      - "5182:5182"
+    volumes:
+      - .:/workspace
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5182/health/ready >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 20s
+
+  frontend:
+    image: mcr.microsoft.com/dotnet/sdk:8.0
+    working_dir: /workspace
+    command: >
+      bash -lc "
+      dotnet restore core-engine.sln &&
+      dotnet build src/FlowzerFrontend/FlowzerFrontend.csproj --configuration Release --no-restore &&
+      dotnet run --project src/FlowzerFrontend/FlowzerFrontend.csproj --configuration Release --no-build --no-launch-profile --urls http://0.0.0.0:5269"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+    ports:
+      - "5269:5269"
+    volumes:
+      - .:/workspace
+    depends_on:
+      api:
+        condition: service_healthy

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -59,10 +59,12 @@ Für einen reproduzierbaren Entwicklungsstack liegt jetzt `compose.local.yml` im
 ./scripts/local/start-stack.sh
 ```
 
+Das Start-Skript wartet, bis API und Frontend ihren Health-Status erreicht haben.
+
 Alternativ direkt:
 
 ```bash
-docker compose -f compose.local.yml up -d api frontend
+docker compose -f compose.local.yml up -d --wait api frontend
 ```
 
 ### Prüfen

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,127 @@
+# Betriebs- und Deployment-Basis
+
+**Stand:** 12. April 2026
+
+Dieses Dokument beschreibt den derzeit realistischen Betriebsrahmen für `next`: lokale Starts, Health-Signale, Compose-Setup und sinnvolle Prüfpfade.
+
+> Wichtig: Das ist **noch keine produktionsfertige Deployment-Story**. Ziel dieses Pakets ist ein reproduzierbarer, dokumentierter Start- und Prüfpfad für API und Frontend.
+
+## Enthaltene Bausteine
+
+- dokumentierte Health-Endpunkte der Web-API
+- lokaler Startpfad per `dotnet run`
+- lokaler Startpfad per Docker Compose
+- kleine Shell-Skripte zum Starten, Stoppen und Prüfen des lokalen Stacks
+- definierter Storage-Pfad für dateibasierte Persistenz
+
+## Health-Signale
+
+Die Web-API stellt aktuell folgende Endpunkte bereit:
+
+- `GET /health` – Liveness
+- `GET /health/ready` – Readiness inkl. Storage-Prüfung
+
+Typische URLs lokal:
+
+- [http://localhost:5182/health](http://localhost:5182/health)
+- [http://localhost:5182/health/ready](http://localhost:5182/health/ready)
+
+## Lokaler Start ohne Docker
+
+### Web-API
+
+```bash
+ASPNETCORE_ENVIRONMENT=Development \
+FLOWZER_STORAGE_ROOT="$(pwd)/.data/flowzer-storage" \
+dotnet run --project src/WebApiEngine/WebApiEngine.csproj \
+  --configuration Release \
+  --no-launch-profile \
+  --urls http://localhost:5182
+```
+
+### Frontend
+
+```bash
+ASPNETCORE_ENVIRONMENT=Development \
+dotnet run --project src/FlowzerFrontend/FlowzerFrontend.csproj \
+  --configuration Release \
+  --no-launch-profile \
+  --urls http://localhost:5269
+```
+
+## Lokaler Start per Docker Compose
+
+Für einen reproduzierbaren Entwicklungsstack liegt jetzt `compose.local.yml` im Repository-Root.
+
+### Starten
+
+```bash
+./scripts/local/start-stack.sh
+```
+
+Alternativ direkt:
+
+```bash
+docker compose -f compose.local.yml up -d api frontend
+```
+
+### Prüfen
+
+```bash
+./scripts/local/check-stack.sh
+```
+
+### Stoppen
+
+```bash
+./scripts/local/stop-stack.sh
+```
+
+## Storage- und Dateipfade
+
+Der Compose- und Local-Run-Pfad nutzt bewusst denselben Storage-Ort:
+
+```text
+.data/flowzer-storage
+```
+
+Dadurch bleiben Definitionen, Instanzen, Subscriptions und Formulare lokal reproduzierbar an einer bekannten Stelle liegen.
+
+## Logs und Diagnose
+
+### Container-Logs
+
+```bash
+docker compose -f compose.local.yml logs -f api
+docker compose -f compose.local.yml logs -f frontend
+```
+
+### Lokale UI-Smokes gegen laufenden Stack
+
+Wenn API und Frontend bereits laufen, können die Playwright-Smokes gezielt gegen den bestehenden Stack ausgeführt werden:
+
+```bash
+PLAYWRIGHT_SKIP_WEBSERVERS=1 \
+FLOWZER_API_URL=http://localhost:5182 \
+FLOWZER_FRONTEND_URL=http://localhost:5269 \
+npm --prefix tests/ui-smoke run test
+```
+
+Der `npm test`-Pfad enthält zusätzlich den Prozesswächter für verwaiste `ms-playwright`-/`chrome-headless-shell`-Prozesse.
+
+## Bewusst noch offen
+
+Folgende Betriebsaspekte sind mit diesem Paket **noch nicht abgeschlossen**:
+
+- strukturierte Produktions-Logformate über die Standard-Konsole hinaus
+- Metrics/Tracing
+- produktionsnahe Reverse-Proxy- oder TLS-Story
+- Image-Builds für echte Releases statt lokaler SDK-Container
+- Secret-/Configuration-Story jenseits lokaler Entwicklungswerte
+
+## Sinnvolle nächste Ausbauschritte
+
+1. dedizierte Release-Dockerfiles ergänzen
+2. Compose um persistente Volumes und optionalen Reverse Proxy erweitern
+3. Metrics/Tracing einführen
+4. Recovery-/Backup-Hinweise für dateibasierte Persistenz dokumentieren

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -70,6 +70,8 @@ Noch offen sind unter anderem:
 - Betriebs- und Deployment-Themen wie Health, Logging-Orientierung und lokale Start-Story
 - Altlasten und Doppelstrukturen im Repository
 
+Für die inzwischen vorhandene lokale Start- und Diagnosebasis siehe zusätzlich [`docs/OPERATIONS.md`](./OPERATIONS.md).
+
 ### 3. Dokumentation muss nun mit der Technik mitwachsen
 
 Die Basisdokumentation ist deutlich besser als zuvor, aber für die nächste Reifestufe fehlen bzw. benötigen Updates:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -86,6 +86,7 @@ Referenz: [#55](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/55
 Referenz: [#54](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/54)
 
 - lokale Startpfade für API und Frontend vereinheitlichen
+- kleine Compose- und Skriptbasis für reproduzierbare lokale Starts schaffen
 - Logging-/Betriebsanforderungen dokumentieren
 - Compose-/Deployment-Basis für eine produktionsnahe Nutzung vorbereiten
 

--- a/scripts/local/check-stack.sh
+++ b/scripts/local/check-stack.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+api_url="${FLOWZER_API_URL:-http://localhost:5182}"
+frontend_url="${FLOWZER_FRONTEND_URL:-http://localhost:5269}"
+
+echo "Checking API liveness: ${api_url}/health"
+curl --fail --silent --show-error "${api_url}/health" >/tmp/flowzer-health.json
+cat /tmp/flowzer-health.json
+echo
+
+echo "Checking API readiness: ${api_url}/health/ready"
+curl --fail --silent --show-error "${api_url}/health/ready" >/tmp/flowzer-ready.json
+cat /tmp/flowzer-ready.json
+echo
+
+echo "Checking frontend root: ${frontend_url}"
+curl --fail --silent --show-error "${frontend_url}" >/tmp/flowzer-frontend.html
+grep -q "FlowzerFrontend" /tmp/flowzer-frontend.html
+echo "Frontend responded successfully."

--- a/scripts/local/check-stack.sh
+++ b/scripts/local/check-stack.sh
@@ -3,18 +3,34 @@ set -euo pipefail
 
 api_url="${FLOWZER_API_URL:-http://localhost:5182}"
 frontend_url="${FLOWZER_FRONTEND_URL:-http://localhost:5269}"
+health_file="$(mktemp /tmp/flowzer-health.XXXXXX.json)"
+ready_file="$(mktemp /tmp/flowzer-ready.XXXXXX.json)"
+frontend_file="$(mktemp /tmp/flowzer-frontend.XXXXXX.html)"
+curl_opts=(
+  --fail
+  --silent
+  --show-error
+  --connect-timeout 5
+  --max-time 15
+  --retry 10
+  --retry-delay 1
+  --retry-all-errors
+  --retry-connrefused
+)
+
+trap 'rm -f "$health_file" "$ready_file" "$frontend_file"' EXIT
 
 echo "Checking API liveness: ${api_url}/health"
-curl --fail --silent --show-error "${api_url}/health" >/tmp/flowzer-health.json
-cat /tmp/flowzer-health.json
+curl "${curl_opts[@]}" "${api_url}/health" >"$health_file"
+cat "$health_file"
 echo
 
 echo "Checking API readiness: ${api_url}/health/ready"
-curl --fail --silent --show-error "${api_url}/health/ready" >/tmp/flowzer-ready.json
-cat /tmp/flowzer-ready.json
+curl "${curl_opts[@]}" "${api_url}/health/ready" >"$ready_file"
+cat "$ready_file"
 echo
 
 echo "Checking frontend root: ${frontend_url}"
-curl --fail --silent --show-error "${frontend_url}" >/tmp/flowzer-frontend.html
-grep -q "FlowzerFrontend" /tmp/flowzer-frontend.html
+curl "${curl_opts[@]}" "${frontend_url}" >"$frontend_file"
+grep -q "FlowzerFrontend" "$frontend_file"
 echo "Frontend responded successfully."

--- a/scripts/local/start-stack.sh
+++ b/scripts/local/start-stack.sh
@@ -8,9 +8,9 @@ mkdir -p "${repo_root}/.data/flowzer-storage"
 
 docker compose \
   -f "${repo_root}/compose.local.yml" \
-  up -d api frontend
+  up -d --wait api frontend
 
-echo "Flowzer local stack started."
+echo "Flowzer local stack started and is healthy."
 echo "- API:      http://localhost:5182/swagger/index.html"
 echo "- Health:   http://localhost:5182/health"
 echo "- Readiness:http://localhost:5182/health/ready"

--- a/scripts/local/start-stack.sh
+++ b/scripts/local/start-stack.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+
+mkdir -p "${repo_root}/.data/flowzer-storage"
+
+docker compose \
+  -f "${repo_root}/compose.local.yml" \
+  up -d api frontend
+
+echo "Flowzer local stack started."
+echo "- API:      http://localhost:5182/swagger/index.html"
+echo "- Health:   http://localhost:5182/health"
+echo "- Readiness:http://localhost:5182/health/ready"
+echo "- Frontend: http://localhost:5269"

--- a/scripts/local/stop-stack.sh
+++ b/scripts/local/stop-stack.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+
+docker compose \
+  -f "${repo_root}/compose.local.yml" \
+  down
+
+echo "Flowzer local stack stopped."


### PR DESCRIPTION
## Ziel

Dieser Strang schafft eine kleine, reproduzierbare Betriebs- und Deployment-Basis für `next`, ohne schon eine vollständige Produktionsplattform zu behaupten.

## Bezug

- closes #54

## Was umgesetzt wurde

### Lokale Start- und Diagnosebasis

- neues `compose.local.yml` für einen reproduzierbaren lokalen API-/Frontend-Stack
- neue Skripte unter `scripts/local/` zum Starten, Prüfen und Stoppen des Stacks
- definierter Storage-Pfad unter `.data/flowzer-storage`
- `.gitignore` schützt lokale Persistenzdaten vor versehentlichem Commit

### Dokumentation

- neues Betriebsdokument `/docs/OPERATIONS.md`
- README ergänzt um den lokalen Compose-Startpfad
- Status- und Roadmap-Dokumente verweisen auf die neue Betriebsbasis

### Health und Validierung

- Compose-Setup wartet auf die API-Readiness via `/health/ready`
- `check-stack.sh` prüft Liveness, Readiness und Frontend-Erreichbarkeit
- UI-Smokes können gezielt gegen den bereits laufenden Stack gefahren werden

## Validierung

```bash
bash -n scripts/local/start-stack.sh scripts/local/stop-stack.sh scripts/local/check-stack.sh
docker compose -f compose.local.yml config
./scripts/local/start-stack.sh
./scripts/local/check-stack.sh
PLAYWRIGHT_SKIP_WEBSERVERS=1 FLOWZER_API_URL=http://localhost:5182 FLOWZER_FRONTEND_URL=http://localhost:5269 npm --prefix tests/ui-smoke run test
./scripts/local/stop-stack.sh
```

## Bewusst noch offen

- echte Release-Dockerfiles statt SDK-Container
- Reverse-Proxy/TLS-Story
- Metrics/Tracing
- Secret-/Produktionskonfiguration
