### PR TITLE
Release-Dockerfiles und runtime-nahe Compose-Variante ergänzen

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.idea
+.vs
+.vscode
+.worktrees
+.data
+**/bin
+**/obj
+**/TestResults
+tests/ui-smoke/node_modules
+tests/ui-smoke/playwright-report
+tests/ui-smoke/test-results
+bpmn.io/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,7 @@ PublishScripts/
 *.snupkg
 # Lokale Flowzer-Storage-Daten
 .data/
+.data/runtime-storage
 # The packages folder can be ignored because of Package Restore
 **/[Pp]ackages/*
 # except build/, which is used as an MSBuild target.

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,37 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+# Nur die für die Web-API relevanten Projekte vorziehen, damit Restore-Layer stabil bleiben.
+COPY Model/Model.csproj Model/
+COPY src/FlowzerBPMN/FlowzerBPMN.csproj src/FlowzerBPMN/
+COPY src/Flowzer.Shared/Flowzer.Shared.csproj src/Flowzer.Shared/
+COPY src/StorageSystemShared/StorageSystemShared.csproj src/StorageSystemShared/
+COPY src/FilesystemStorageSystem/FilesystemStorageSystem.csproj src/FilesystemStorageSystem/
+COPY src/core-engine/core-engine.csproj src/core-engine/
+COPY src/WebApiEngine.Shared/WebApiEngine.Shared.csproj src/WebApiEngine.Shared/
+COPY src/WebApiEngine/WebApiEngine.csproj src/WebApiEngine/
+
+RUN dotnet restore src/WebApiEngine/WebApiEngine.csproj
+
+COPY . .
+RUN dotnet publish src/WebApiEngine/WebApiEngine.csproj \
+    --configuration Release \
+    --no-restore \
+    --output /app/publish \
+    /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends wget ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV ASPNETCORE_URLS=http://0.0.0.0:8080
+ENV FLOWZER_STORAGE_ROOT=/data/flowzer-storage
+
+COPY --from=build /app/publish ./
+
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "WebApiEngine.dll"]

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,6 +1,8 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 
+COPY global.json ./
+
 # Nur die für die Web-API relevanten Projekte vorziehen, damit Restore-Layer stabil bleiben.
 COPY Model/Model.csproj Model/
 COPY src/FlowzerBPMN/FlowzerBPMN.csproj src/FlowzerBPMN/

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,24 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+# Restore auf das Frontend + seine Referenzen begrenzen.
+COPY Model/Model.csproj Model/
+COPY src/Flowzer.Shared/Flowzer.Shared.csproj src/Flowzer.Shared/
+COPY src/WebApiEngine.Shared/WebApiEngine.Shared.csproj src/WebApiEngine.Shared/
+COPY src/FlowzerFrontend/FlowzerFrontend.csproj src/FlowzerFrontend/
+
+RUN dotnet restore src/FlowzerFrontend/FlowzerFrontend.csproj
+
+COPY . .
+RUN dotnet publish src/FlowzerFrontend/FlowzerFrontend.csproj \
+    --configuration Release \
+    --no-restore \
+    --output /app/publish \
+    /p:UseAppHost=false
+
+FROM nginx:1.27-alpine AS runtime
+
+COPY deploy/nginx/frontend.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/publish/wwwroot /usr/share/nginx/html
+
+EXPOSE 8080

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,6 +1,8 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 
+COPY global.json ./
+
 # Restore auf das Frontend + seine Referenzen begrenzen.
 COPY Model/Model.csproj Model/
 COPY src/Flowzer.Shared/Flowzer.Shared.csproj src/Flowzer.Shared/

--- a/README.md
+++ b/README.md
@@ -168,6 +168,18 @@ Für einen reproduzierbaren API-/Frontend-Start gibt es jetzt zusätzlich einen 
 
 Weitere Betriebs- und Diagnosehinweise stehen in [docs/OPERATIONS.md](docs/OPERATIONS.md).
 
+## Runtime-Container für lokale Release-Checks
+
+Zusätzlich zur Dev-Compose-Variante gibt es jetzt auch eine runtime-nahe Containerbasis:
+
+```bash
+./scripts/runtime/start-runtime-stack.sh
+./scripts/runtime/check-runtime-stack.sh
+./scripts/runtime/stop-runtime-stack.sh
+```
+
+Der Runtime-Gateway-Stack ist anschließend standardmäßig unter [http://localhost:5288](http://localhost:5288) erreichbar.
+
 ## Beispiel
 
 Ein kleines Nutzungsbeispiel liegt in [`/examples/SimpleEngineExample.cs`](examples/SimpleEngineExample.cs).

--- a/compose.runtime.yml
+++ b/compose.runtime.yml
@@ -1,0 +1,50 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      FLOWZER_STORAGE_ROOT: /data/flowzer-storage
+    volumes:
+      - ./.data/runtime-storage:/data/flowzer-storage
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/health/ready >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 18
+      start_period: 30s
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/ | grep -q FlowzerFrontend || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 18
+      start_period: 30s
+
+  gateway:
+    image: nginx:1.27-alpine
+    depends_on:
+      api:
+        condition: service_healthy
+      frontend:
+        condition: service_healthy
+    ports:
+      - "${FLOWZER_RUNTIME_PORT:-5288}:8080"
+    volumes:
+      - ./deploy/nginx/runtime.conf:/etc/nginx/nginx.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/health/ready >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s

--- a/compose.runtime.yml
+++ b/compose.runtime.yml
@@ -19,8 +19,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.frontend
-    environment:
-      ASPNETCORE_ENVIRONMENT: Production
     depends_on:
       api:
         condition: service_healthy

--- a/deploy/nginx/frontend.conf
+++ b/deploy/nginx/frontend.conf
@@ -1,0 +1,11 @@
+server {
+  listen 8080;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/deploy/nginx/runtime.conf
+++ b/deploy/nginx/runtime.conf
@@ -32,8 +32,12 @@ http {
       proxy_pass http://flowzer_api/health/ready;
     }
 
-    location ~ ^/(definition|message|instance|usertask|form)(/|$) {
+    location ~ ^/(definition|instance)(/|$) {
       proxy_pass $flowzer_route_target;
+    }
+
+    location ~ ^/(message|usertask|form)(/|$) {
+      proxy_pass http://flowzer_api;
     }
 
     location / {

--- a/deploy/nginx/runtime.conf
+++ b/deploy/nginx/runtime.conf
@@ -1,0 +1,43 @@
+events {}
+
+http {
+  upstream flowzer_api {
+    server api:8080;
+  }
+
+  upstream flowzer_frontend {
+    server frontend:8080;
+  }
+
+  map $http_accept $flowzer_route_target {
+    default http://flowzer_api;
+    "~*text/html" http://flowzer_frontend;
+  }
+
+  server {
+    listen 8080;
+    server_name _;
+
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    location = /health {
+      proxy_pass http://flowzer_api/health;
+    }
+
+    location = /health/ready {
+      proxy_pass http://flowzer_api/health/ready;
+    }
+
+    location ~ ^/(definition|message|instance|usertask|form)(/|$) {
+      proxy_pass $flowzer_route_target;
+    }
+
+    location / {
+      proxy_pass http://flowzer_frontend;
+    }
+  }
+}

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -11,6 +11,7 @@ Dieses Dokument beschreibt den derzeit realistischen Betriebsrahmen für `next`:
 - dokumentierte Health-Endpunkte der Web-API
 - lokaler Startpfad per `dotnet run`
 - lokaler Startpfad per Docker Compose
+- runtime-nahe Release-Container für API + Frontend + Gateway
 - kleine Shell-Skripte zum Starten, Stoppen und Prüfen des lokalen Stacks
 - definierter Storage-Pfad für dateibasierte Persistenz
 
@@ -79,6 +80,38 @@ docker compose -f compose.local.yml up -d --wait api frontend
 ./scripts/local/stop-stack.sh
 ```
 
+## Runtime-nahe Containerbasis
+
+Für lokale Release-Checks liegt zusätzlich `compose.runtime.yml` mit echten Runtime-Images und vorgeschaltetem Gateway im Repository-Root.
+
+### Starten
+
+```bash
+./scripts/runtime/start-runtime-stack.sh
+```
+
+Das Skript baut API- und Frontend-Images, startet anschließend den Gateway-Stack und wartet auf grüne Healthchecks.
+
+### Prüfen
+
+```bash
+./scripts/runtime/check-runtime-stack.sh
+```
+
+Typische URLs:
+
+- [http://localhost:5288](http://localhost:5288)
+- [http://localhost:5288/health](http://localhost:5288/health)
+- [http://localhost:5288/health/ready](http://localhost:5288/health/ready)
+
+Bei Portkonflikten kann der Host-Port über `FLOWZER_RUNTIME_PORT` überschrieben werden.
+
+### Stoppen
+
+```bash
+./scripts/runtime/stop-runtime-stack.sh
+```
+
 ## Storage- und Dateipfade
 
 Der Compose- und Local-Run-Pfad nutzt bewusst denselben Storage-Ort:
@@ -89,6 +122,14 @@ Der Compose- und Local-Run-Pfad nutzt bewusst denselben Storage-Ort:
 
 Dadurch bleiben Definitionen, Instanzen, Subscriptions und Formulare lokal reproduzierbar an einer bekannten Stelle liegen.
 
+Der runtime-nahe Stack nutzt bewusst einen separaten Pfad:
+
+```text
+.data/runtime-storage
+```
+
+Damit bleiben lokale Dev-Daten und runtime-nahe Containerdaten getrennt.
+
 ## Logs und Diagnose
 
 ### Container-Logs
@@ -96,6 +137,10 @@ Dadurch bleiben Definitionen, Instanzen, Subscriptions und Formulare lokal repro
 ```bash
 docker compose -f compose.local.yml logs -f api
 docker compose -f compose.local.yml logs -f frontend
+
+docker compose -f compose.runtime.yml logs -f api
+docker compose -f compose.runtime.yml logs -f frontend
+docker compose -f compose.runtime.yml logs -f gateway
 ```
 
 ### Lokale UI-Smokes gegen laufenden Stack
@@ -111,6 +156,15 @@ npm --prefix tests/ui-smoke run test
 
 Der `npm test`-Pfad enthält zusätzlich den Prozesswächter für verwaiste `ms-playwright`-/`chrome-headless-shell`-Prozesse.
 
+Dasselbe funktioniert auch gegen den runtime-nahen Gateway-Stack:
+
+```bash
+PLAYWRIGHT_SKIP_WEBSERVERS=1 \
+FLOWZER_API_URL=http://localhost:5288 \
+FLOWZER_FRONTEND_URL=http://localhost:5288 \
+npm --prefix tests/ui-smoke run test
+```
+
 ## Bewusst noch offen
 
 Folgende Betriebsaspekte sind mit diesem Paket **noch nicht abgeschlossen**:
@@ -118,12 +172,11 @@ Folgende Betriebsaspekte sind mit diesem Paket **noch nicht abgeschlossen**:
 - strukturierte Produktions-Logformate über die Standard-Konsole hinaus
 - Metrics/Tracing
 - produktionsnahe Reverse-Proxy- oder TLS-Story
-- Image-Builds für echte Releases statt lokaler SDK-Container
 - Secret-/Configuration-Story jenseits lokaler Entwicklungswerte
 
 ## Sinnvolle nächste Ausbauschritte
 
-1. dedizierte Release-Dockerfiles ergänzen
-2. Compose um persistente Volumes und optionalen Reverse Proxy erweitern
-3. Metrics/Tracing einführen
-4. Recovery-/Backup-Hinweise für dateibasierte Persistenz dokumentieren
+1. Reverse-Proxy-/Gateway-Konfiguration für echte Zielumgebungen weiter härten
+2. Metrics/Tracing einführen
+3. Recovery-/Backup-Hinweise für dateibasierte Persistenz dokumentieren
+4. Secret-/Konfigurationsstory für Nicht-Entwicklungsumgebungen schärfen

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -1,6 +1,6 @@
 # Projektstatus: Flowzer BPMN Core Engine
 
-**Stand:** 11. April 2026
+**Stand:** 12. April 2026
 
 ## Kurzfazit
 
@@ -49,6 +49,7 @@ Unter anderem bereits umgesetzt:
 - DTO-/Warnungsbereinigung und API-Härtung in mehreren Teilbereichen
 - Signal- und Service-Task-Subscriptions im Web-API-Pfad
 - Nullability- und Guard-Härtung in zentralen Frontend-Seiten
+- lokale Runtime-Containerbasis für API, Frontend und Gateway
 
 ## Was weiterhin bremst
 
@@ -56,10 +57,9 @@ Unter anderem bereits umgesetzt:
 
 Besonders relevant sind noch:
 
-- Formularpfad von Storage über API bis Frontend
-- Diagramm-/Modeler-Integration
 - weiter ausgebautes Playwright-/E2E-Smoke-Set
-- einheitlichere Fehlerverträge in der Web-API
+- Restlücken bei Auth-/Identity- und Fehlerpfaden
+- Release-/Telemetry-/Secret-Story über die lokale Basis hinaus
 
 ### 2. Es gibt noch Restlücken im Codebestand
 
@@ -67,7 +67,7 @@ Noch offen sind unter anderem:
 
 - einzelne `NotImplementedException`-Stellen in Runtime-/Storage-Pfaden
 - provisorische Auth-/Identity-Platzhalter
-- Betriebs- und Deployment-Themen wie Health, Logging-Orientierung und lokale Start-Story
+- Betriebs- und Deployment-Themen wie Reverse Proxy, TLS, Logging-/Telemetry und Recovery
 - Altlasten und Doppelstrukturen im Repository
 
 Für die inzwischen vorhandene lokale Start- und Diagnosebasis siehe zusätzlich [`docs/OPERATIONS.md`](./OPERATIONS.md).
@@ -85,23 +85,11 @@ Die Basisdokumentation ist deutlich besser als zuvor, aber für die nächste Rei
 
 ## Offene GitHub-Issues auf dem aktuellen Stand
 
-### Frontend-Epic
+Die erste große Stabilisierungsrunde ist inzwischen weitgehend geschlossen. Der aktuelle nächste Ausbaupunkt ist:
 
-- [#7 Frontend bauen](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/7)
+- [#63 Release-Dockerfiles und runtime-nahe Compose-Variante ergänzen](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/63)
 
-### Daraus abgeleitete Teilpakete
-
-- [#47 Frontend-Navigation und Kernseiten weiter härten](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/47)
-- [#48 Formularpfad von Storage bis Frontend stabilisieren](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/48)
-- [#49 Diagramm- und Modeler-Integration im Frontend härten](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/49)
-- [#50 Playwright-Smoke- und E2E-Abdeckung für Kernpfade ausbauen](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/50)
-
-### Weitere nächste Produktivitäts- und Reife-Pakete
-
-- [#52 Web-API für Fehlerverträge, Health und Auth-Vorbereitung härten](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/52)
-- [#53 Verbliebene Engine- und Runtime-Lücken systematisch abbauen](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/53)
-- [#54 Betriebs- und Deployment-Basis für produktionsnahe Nutzung vorbereiten](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/54)
-- [#55 Repository-Struktur und Status-Dokumentation weiter aufräumen](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/55)
+Die frühere Frontend-Aufteilung über [#47](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/47) bis [#50](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/50) sowie die Härtungen [#52](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/52) bis [#55](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/55) sind bereits abgeschlossen.
 
 ## Aktuelle Gesamtempfehlung
 
@@ -109,12 +97,10 @@ Das Projekt sollte jetzt **nicht mehr primär gerettet**, sondern gezielt **zur 
 
 Die sinnvolle Reihenfolge ist aus heutiger Sicht:
 
-1. Formularpfad sauber schließen
-2. Frontend-Kernseiten und Diagramm-/Modeler-Pfade weiter härten
-3. Playwright-/E2E-Abdeckung ausbauen
-4. API-Fehlerverträge, Health und Auth-Vorbereitung schärfen
-5. Restliche Runtime-Lücken und Repository-Altlasten abbauen
-6. Betriebs- und Deployment-Basis vorbereiten
+1. runtime-nahe Release-Containerbasis sauber abschließen
+2. Reverse-Proxy-/Secret-/Telemetry-Story weiter schärfen
+3. verbleibende Runtime- und Auth-Lücken abbauen
+4. E2E- und Recovery-/Operations-Dokumentation weiter vertiefen
 
 ## Gesamturteil
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,58 +14,45 @@ Die erste große Stabilisierungsrunde ist bereits erfolgt:
 - Demo-Console-App ergänzt
 - wesentliche Engine-/Subscription-/Frontend-Härtungen umgesetzt
 - lokale und CI-nahe Testpfade wieder grün gemacht
+- lokale Runtime-Containerbasis für Release-nahe Prüfpfade ergänzt
+- das ursprüngliche Frontend-Epic (#7) und seine Teilpakete #47–#50 sind abgeschlossen
 
 Die Roadmap startet also **nicht mehr bei Null**, sondern baut auf einer funktionierenden Basis auf.
 
-## Priorität 1: Kernpfade vollständig stabilisieren
+## Priorität 1: Release-nahe Betriebsbasis abschließen
 
-### 1.1 Formularpfad durchhärten
+### 1.1 Runtime-Container und Release-Compose ergänzen
 
-Referenz: [#48](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/48)
+Referenz: [#63](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/63)
 
-- Formularspeicherung, Metadaten und Versionspfad robust machen
-- API-Verträge für Formulare sauber absichern
-- Formularpfad bis zur Frontend-Anbindung testen
+- dedizierte Runtime-Container für API und Frontend bereitstellen
+- Gateway-/Reverse-Proxy-Basis für Same-Origin-Betrieb ergänzen
+- lokalen Build-/Start-/Check-Pfad für echte Runtime-Images dokumentieren
 
-### 1.2 Frontend-Kernseiten weiter härten
+### 1.2 Weitere Betriebsaspekte nachziehen
 
-Referenz: [#47](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/47)
+- Metrics/Tracing
+- Secret-/Konfigurationsstory
+- Recovery-/Backup-Hinweise
+- Reverse-Proxy-/TLS-Härtung für echte Zielumgebungen
 
-- Navigation und Kernseiten systematisch prüfen
-- Lade-, Nullability- und Zustandsprobleme weiter abbauen
-- manuelle und kleine automatisierte Checks zusammenführen
+## Priorität 2: Restliche Produktpfade vertiefen
 
-### 1.3 Diagramm-/Modeler-Integration absichern
+### 2.1 Weitere E2E-/Smoke-Pfade ausbauen
 
-Referenz: [#49](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/49)
-
-- Diagrammladen und Modeler-Interaktionen prüfen
-- Fehlerzustände besser abfangen
-- zentrale Diagramm-/Modeler-Pfade dokumentieren
-
-## Priorität 2: Test- und Produktpfade vertiefen
-
-### 2.1 Playwright-Smoke- und E2E-Suite ausbauen
-
-Referenz: [#50](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/50)
-
-- Kernpfade für Start, Formulare, Instanzen und Diagrammzugriffe automatisieren
+- Kernpfade für Direktaufrufe, Refreshes und Betriebsfehler weiter ausbauen
 - Testdaten und Hilfslogik für reproduzierbare Läufe schaffen
 - die Suite klein und CI-tauglich halten
 
-### 2.2 API-Fehlerverträge und Betriebs-Signale verbessern
+### 2.2 API-Fehlerverträge und Auth-/Betriebssignale weiter verbessern
 
-Referenz: [#52](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/52)
-
-- Fehlerantworten vereinheitlichen
-- Health-/Readiness-Endpunkte ergänzen
+- Fehlerantworten weiter vereinheitlichen
+- Betriebsmetriken ergänzen
 - Auth-Platzhalter technisch sauberer kapseln
 
 ## Priorität 3: Restlücken abbauen
 
 ### 3.1 Engine- und Runtime-Restbestand bereinigen
-
-Referenz: [#53](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/53)
 
 - `NotImplementedException`-Stellen inventarisieren
 - produktionskritische Pfade priorisiert schließen
@@ -79,47 +66,21 @@ Referenz: [#55](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/55
 - Status- und Roadmap-Dokumente laufend aktualisieren
 - technische Realität und Doku synchron halten
 
-## Priorität 4: Produktnahe Betriebsbasis schaffen
-
-### 4.1 Lokale Betriebs- und Deployment-Story vorbereiten
-
-Referenz: [#54](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/54)
-
-- lokale Startpfade für API und Frontend vereinheitlichen
-- kleine Compose- und Skriptbasis für reproduzierbare lokale Starts schaffen
-- Logging-/Betriebsanforderungen dokumentieren
-- Compose-/Deployment-Basis für eine produktionsnahe Nutzung vorbereiten
-
-### 4.2 Weitere Betriebsaspekte nachziehen
-
-Sinnvolle Folgearbeiten danach:
-
-- Metrics/Tracing
-- Release-/Versionierungsstory
-- Packaging/Container-Story
-- Betriebsdokumentation für Fehleranalyse und Recovery
-
 ## Empfohlene Reihenfolge der nächsten Sprints
 
-### Sprint A – Formular- und Frontend-Kernpfade
+### Sprint A – Runtime-Container abschließen
 
-- #48 Formularpfad stabilisieren
-- #47 Kernseiten und Navigation weiter härten
+- #63 Release-Dockerfiles und runtime-nahe Compose-Variante ergänzen
 
-### Sprint B – Diagramm- und E2E-Pfade
+### Sprint B – Betriebs- und E2E-Reife
 
-- #49 Diagramm-/Modeler-Integration härten
-- #50 Playwright-/E2E-Abdeckung ausbauen
+- Gateway-/Reverse-Proxy-Pfade weiter härten
+- zusätzliche direkte Refresh-/Fehlerpfade in Playwright abdecken
 
-### Sprint C – API- und Runtime-Reife
+### Sprint C – Runtime- und Auth-Restlücken
 
-- #52 API-Härtung für Fehlerverträge, Health und Auth-Vorbereitung
-- #53 Engine-/Runtime-Restlücken abbauen
-
-### Sprint D – Betriebs- und Repo-Reife
-
-- #54 Betriebs- und Deployment-Basis vorbereiten
-- #55 Repo- und Status-Dokumentation weiter aufräumen
+- verbleibende Runtime-/Storage-/Auth-Lücken abbauen
+- Recovery- und Operations-Dokumentation vertiefen
 
 ## Leitprinzip für die weitere Arbeit
 

--- a/scripts/runtime/check-runtime-stack.sh
+++ b/scripts/runtime/check-runtime-stack.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runtime_port="${FLOWZER_RUNTIME_PORT:-5288}"
+gateway_url="${FLOWZER_GATEWAY_URL:-http://localhost:${runtime_port}}"
+health_file="$(mktemp /tmp/flowzer-runtime-health.XXXXXX.json)"
+ready_file="$(mktemp /tmp/flowzer-runtime-ready.XXXXXX.json)"
+frontend_file="$(mktemp /tmp/flowzer-runtime-frontend.XXXXXX.html)"
+curl_opts=(
+  --fail
+  --silent
+  --show-error
+  --connect-timeout 5
+  --max-time 15
+  --retry 10
+  --retry-delay 1
+  --retry-all-errors
+  --retry-connrefused
+)
+
+trap 'rm -f "$health_file" "$ready_file" "$frontend_file"' EXIT
+
+echo "Checking runtime gateway liveness: ${gateway_url}/health"
+curl "${curl_opts[@]}" "${gateway_url}/health" >"$health_file"
+cat "$health_file"
+echo
+
+echo "Checking runtime gateway readiness: ${gateway_url}/health/ready"
+curl "${curl_opts[@]}" "${gateway_url}/health/ready" >"$ready_file"
+cat "$ready_file"
+echo
+
+echo "Checking runtime frontend root: ${gateway_url}"
+curl "${curl_opts[@]}" "${gateway_url}" >"$frontend_file"
+grep -q "FlowzerFrontend" "$frontend_file"
+echo "Runtime frontend responded successfully."

--- a/scripts/runtime/start-runtime-stack.sh
+++ b/scripts/runtime/start-runtime-stack.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+runtime_port="${FLOWZER_RUNTIME_PORT:-5288}"
+
+mkdir -p "${repo_root}/.data/runtime-storage"
+
+docker compose \
+  -f "${repo_root}/compose.runtime.yml" \
+  up -d --build --wait api frontend gateway
+
+echo "Flowzer runtime stack started and is healthy."
+echo "- Gateway:  http://localhost:${runtime_port}"
+echo "- Health:   http://localhost:${runtime_port}/health"
+echo "- Readiness:http://localhost:${runtime_port}/health/ready"

--- a/scripts/runtime/stop-runtime-stack.sh
+++ b/scripts/runtime/stop-runtime-stack.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+
+docker compose \
+  -f "${repo_root}/compose.runtime.yml" \
+  down
+
+echo "Flowzer runtime stack stopped."


### PR DESCRIPTION
## Zusammenfassung

Diese PR setzt Issue #63 um und ergänzt eine runtime-nahe Containerbasis zusätzlich zur bestehenden Dev-Compose-Variante.

## Änderungen

- Multi-Stage-Dockerfiles für Web-API und Frontend ergänzt
- `compose.runtime.yml` für API, Frontend und Gateway ergänzt
- Nginx-Gateway für Same-Origin-Routing zwischen Frontend-Routen und API-Endpunkten ergänzt
- neue Runtime-Skripte für Start, Check und Stopp ergänzt
- Betriebsdokumentation, README und Status-/Roadmap-Texte auf den neuen Stand gebracht
- `.dockerignore` ergänzt, damit Image-Builds klein und reproduzierbar bleiben

## Validierung

```bash
bash -n scripts/runtime/start-runtime-stack.sh scripts/runtime/check-runtime-stack.sh scripts/runtime/stop-runtime-stack.sh
docker compose -f compose.runtime.yml config
./scripts/runtime/start-runtime-stack.sh
./scripts/runtime/check-runtime-stack.sh
PLAYWRIGHT_SKIP_WEBSERVERS=1 FLOWZER_API_URL=http://localhost:5288 FLOWZER_FRONTEND_URL=http://localhost:5288 npm --prefix tests/ui-smoke run test
./scripts/runtime/stop-runtime-stack.sh
```

## Hinweise

- Die neue Runtime-Compose-Variante ist bewusst **lokal produktionsnäher**, aber noch keine vollständige Zielumgebungs-Story mit TLS, Secrets oder Telemetry.
- Die UI-Smoke-Läufe verwenden weiterhin den Playwright-Prozesswächter, damit keine hängenden `chrome-headless-shell`-/`ms-playwright`-Prozesse liegen bleiben.
