### PR TITLE
CI-Warnungen und Frontend-Nullability im Kernpfad abbauen

### DIFF
--- a/src/FlowzerFrontend/Components/FormComponent.razor
+++ b/src/FlowzerFrontend/Components/FormComponent.razor
@@ -9,8 +9,12 @@
         window.dotNetRef = ref;
     }
 
+    function ClearDotNetRef(){
+        window.dotNetRef = null;
+    }
+
     function messageHandler(event){
-        if (event.data.type === "event" && event.data.eventTyp === "formChanged"){
+        if (event.data.type === "event" && event.data.eventTyp === "formChanged" && window.dotNetRef){
             console.log("sending formchange to dotnet");
             window.dotNetRef.invokeMethodAsync('OnFormChange',  event.data);
         }

--- a/src/FlowzerFrontend/Components/FormComponent.razor.cs
+++ b/src/FlowzerFrontend/Components/FormComponent.razor.cs
@@ -5,8 +5,11 @@ using Microsoft.JSInterop;
 
 namespace FlowzerFrontend.Components;
 
-public partial class FormComponent : ComponentBase
+public partial class FormComponent : ComponentBase, IDisposable
 {
+    private DotNetObjectReference<FormComponent>? _dotNetReference;
+    private string? _loadedSchema;
+    private string? _lastAppliedData;
     
     [Inject] public required IJSRuntime JsRuntime { get; set; }
     [Inject] public required ILogger<FormComponent> Logger { get; set; }
@@ -19,36 +22,35 @@ public partial class FormComponent : ComponentBase
 
     
     
-    private string _data = string.Empty;
-    [Parameter] public string Data
-    {
-        get => _data;
-        set
-        {
-            if (IgnoreDataChange)
-                return;
-            _data = value;
-            _ = SetSubmissionData();
-        }
-    }
+    [Parameter] public string Data { get; set; } = string.Empty;
 
     public bool IgnoreDataChange { get; set; }
 
     [Parameter] public EventCallback<string> DataChanged { get; set; }
 
-    protected override void OnAfterRender(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
-            var dotNetReference = DotNetObjectReference.Create(this);
-            JsRuntime.InvokeVoidAsync("SetDotNetRef", dotNetReference);
+            _dotNetReference = DotNetObjectReference.Create(this);
+            await JsRuntime.InvokeVoidAsync("SetDotNetRef", _dotNetReference);
         }
-    }
 
-    protected override async Task OnInitializedAsync()
-    {
-        if (! string.IsNullOrEmpty(Schema))
+        if (!string.IsNullOrEmpty(Schema) && !string.Equals(_loadedSchema, Schema, StringComparison.Ordinal))
+        {
             await LoadWithSchema(Schema);
+            _loadedSchema = Schema;
+            _lastAppliedData = Data;
+            return;
+        }
+
+        if (!IgnoreDataChange &&
+            _loadedSchema != null &&
+            !string.Equals(_lastAppliedData, Data, StringComparison.Ordinal))
+        {
+            await SetSubmissionData();
+            _lastAppliedData = Data;
+        }
     }
     
     [JSInvokable]
@@ -97,6 +99,9 @@ public partial class FormComponent : ComponentBase
         var data = await JsRuntime.InvokeAsyncNoneCached<JsonElement>("executeInIframe", "#iframe_viewer", "getSubmission");
         return JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
     }
-    
-    
+
+    public void Dispose()
+    {
+        _dotNetReference?.Dispose();
+    }
 }

--- a/src/FlowzerFrontend/Components/FormComponent.razor.cs
+++ b/src/FlowzerFrontend/Components/FormComponent.razor.cs
@@ -5,8 +5,12 @@ using Microsoft.JSInterop;
 
 namespace FlowzerFrontend.Components;
 
-public partial class FormComponent : ComponentBase, IDisposable
+public partial class FormComponent : ComponentBase, IAsyncDisposable
 {
+    private static readonly TimeSpan ViewerReadyTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan ViewerReadyPollInterval = TimeSpan.FromMilliseconds(100);
+
+    private readonly CancellationTokenSource _disposeCancellationTokenSource = new();
     private DotNetObjectReference<FormComponent>? _dotNetReference;
     private string? _loadedSchema;
     private string? _lastAppliedData;
@@ -36,20 +40,31 @@ public partial class FormComponent : ComponentBase, IDisposable
             await JsRuntime.InvokeVoidAsync("SetDotNetRef", _dotNetReference);
         }
 
-        if (!string.IsNullOrEmpty(Schema) && !string.Equals(_loadedSchema, Schema, StringComparison.Ordinal))
+        try
         {
-            await LoadWithSchema(Schema);
-            _loadedSchema = Schema;
-            _lastAppliedData = Data;
-            return;
-        }
+            if (!string.IsNullOrEmpty(Schema) && !string.Equals(_loadedSchema, Schema, StringComparison.Ordinal))
+            {
+                await LoadWithSchema(Schema, _disposeCancellationTokenSource.Token);
+                _loadedSchema = Schema;
+                _lastAppliedData = Data;
+                return;
+            }
 
-        if (!IgnoreDataChange &&
-            _loadedSchema != null &&
-            !string.Equals(_lastAppliedData, Data, StringComparison.Ordinal))
+            if (!IgnoreDataChange &&
+                _loadedSchema != null &&
+                !string.Equals(_lastAppliedData, Data, StringComparison.Ordinal))
+            {
+                await SetSubmissionData();
+                _lastAppliedData = Data;
+            }
+        }
+        catch (OperationCanceledException) when (_disposeCancellationTokenSource.IsCancellationRequested)
         {
-            await SetSubmissionData();
-            _lastAppliedData = Data;
+            Logger.LogDebug("Form component rendering was cancelled during disposal.");
+        }
+        catch (TimeoutException exception)
+        {
+            Logger.LogWarning(exception, "Form viewer iframe did not become ready within the configured timeout.");
         }
     }
     
@@ -64,10 +79,15 @@ public partial class FormComponent : ComponentBase, IDisposable
 
     
 
-    private async Task LoadWithSchema(string schema)
+    private async Task LoadWithSchema(string schema, CancellationToken cancellationToken)
     {
+        using var timeoutCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCancellationTokenSource.CancelAfter(ViewerReadyTimeout);
+
         while (true)
         {
+            timeoutCancellationTokenSource.Token.ThrowIfCancellationRequested();
+
             try
             {
                 var ret = await JsRuntime.InvokeAsyncNoneCached<bool>("executeInIframe", "#iframe_viewer", "IsReady");
@@ -80,7 +100,14 @@ public partial class FormComponent : ComponentBase, IDisposable
                 Logger.LogWarning(e, "Waiting for iframe to be ready");
             }
 
-            await Task.Delay(100);
+            try
+            {
+                await Task.Delay(ViewerReadyPollInterval, timeoutCancellationTokenSource.Token);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException("The form viewer iframe did not become ready in time.");
+            }
         }
         
         using var doc = JsonDocument.Parse(schema);
@@ -100,8 +127,20 @@ public partial class FormComponent : ComponentBase, IDisposable
         return JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
+        _disposeCancellationTokenSource.Cancel();
+
+        try
+        {
+            await JsRuntime.InvokeVoidAsync("ClearDotNetRef");
+        }
+        catch (Exception exception) when (exception is JSDisconnectedException or InvalidOperationException)
+        {
+            Logger.LogDebug(exception, "The JS runtime was no longer available while disposing the form component.");
+        }
+
         _dotNetReference?.Dispose();
+        _disposeCancellationTokenSource.Dispose();
     }
 }

--- a/src/FlowzerFrontend/Pages/FilloutForm.razor
+++ b/src/FlowzerFrontend/Pages/FilloutForm.razor
@@ -2,7 +2,4 @@
 @using Microsoft.FluentUI.AspNetCore.Components
 @implements Microsoft.FluentUI.AspNetCore.Components.IDialogContentComponent<FilloutFormParameter>
 
-@if (Content is not null)
-{
-    <FormComponent Schema="@Content.Schema" @bind-Data="@Content.Data" @bind-OutData="@Content.OutData"></FormComponent>
-}
+<FormComponent Schema="@Content.Schema" @bind-Data="@Content.Data" @bind-OutData="@Content.OutData"></FormComponent>

--- a/src/FlowzerFrontend/Pages/FilloutForm.razor.cs
+++ b/src/FlowzerFrontend/Pages/FilloutForm.razor.cs
@@ -4,6 +4,6 @@ namespace FlowzerFrontend.Pages;
 
 public partial class FilloutForm : ComponentBase
 {
-    [Parameter] public FilloutFormParameter? Content { get; set; }
+    [Parameter] public FilloutFormParameter Content { get; set; } = new();
 
 }

--- a/src/core-engine-tests/EngineTest.cs
+++ b/src/core-engine-tests/EngineTest.cs
@@ -222,7 +222,8 @@ public class EngineTest
         {
             ((List<object>?)multiInstanceToken.OutputData?.GetValue("MitarbeiterOut")).Should().HaveCount(3);
             //check if the order is correct
-            outList.Select(x => x.GetValue("Vorname")?.ToString()).Should()
+            outList.Should().NotBeNull();
+            outList!.Select(x => x.GetValue("Vorname")?.ToString()).Should()
                 .ContainInOrder(["Lukas", "Christian", "Max"]);
             instanceEngine.Tokens.Should().OnlyContain(x => x.State == FlowNodeState.Completed);
         }

--- a/src/core-engine-tests/ExpandoHelperTest.cs
+++ b/src/core-engine-tests/ExpandoHelperTest.cs
@@ -45,5 +45,5 @@ public class Order
 
 public class Address
 {
-    public string Firstname { get; set; }
+    public string Firstname { get; set; } = string.Empty;
 }

--- a/src/core-engine-tests/ModelParserTest.cs
+++ b/src/core-engine-tests/ModelParserTest.cs
@@ -72,6 +72,37 @@ public class ModelParserTest
         process.FlowElements.OfType<SubProcess>().Count(p => p.LoopCharacteristics != null).Should().Be(1);
     }
 
+    [Test]
+    public async Task ParseModel_ShouldOnlyReturnExecutableProcesses()
+    {
+        const string xml = """
+                           <?xml version="1.0" encoding="UTF-8"?>
+                           <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                             id="Definitions_ExecutableFilter">
+                             <bpmn:process id="ExecutableProcess" isExecutable="true">
+                               <bpmn:startEvent id="StartEvent_1" />
+                             </bpmn:process>
+                             <bpmn:process id="CallableButInactiveProcess" isExecutable="false">
+                               <bpmn:startEvent id="StartEvent_2" />
+                             </bpmn:process>
+                             <bpmn:process id="MissingExecutableFlag">
+                               <bpmn:startEvent id="StartEvent_3" />
+                             </bpmn:process>
+                           </bpmn:definitions>
+                           """;
+
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(xml));
+
+        var model = await ModelParser.ParseModel(stream);
+
+        model.GetProcesses()
+            .Select(process => process.Id)
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be("ExecutableProcess");
+    }
+
     private static void AssertFlowNodeOfTypes<T>(Process process, int? count, string? id = null, string? name = null)
         where T : FlowElement
     {

--- a/src/core-engine/ModelParser.cs
+++ b/src/core-engine/ModelParser.cs
@@ -81,7 +81,7 @@ public static class ModelParser
 
         var xmlProcessNodes = root.Elements().Where(n =>
             n.Name.LocalName.Equals("process", StringComparison.InvariantCultureIgnoreCase) &&
-            (bool)n.Attribute("isExecutable")?.Value.Equals("true", StringComparison.InvariantCultureIgnoreCase));
+            string.Equals((string?)n.Attribute("isExecutable"), "true", StringComparison.InvariantCultureIgnoreCase));
 
         processes.AddRange(
             xmlProcessNodes.Select(xmlProcessNode => new Process


### PR DESCRIPTION
## Zusammenfassung

Dieses PR baut die aktuellen CI-Warnungen im Kernpfad gezielt ab, ohne fachliche Produktpfade umzubauen.

## Änderungen

- `ModelParser` wertet `isExecutable` jetzt nullability-sicher aus
- Multi-Instance-Test in `EngineTest` wurde nullability-sicher nachgeschärft
- Testmodell in `ExpandoHelperTest` initialisiert Pflichtwerte sauber
- `FilloutForm` verwendet einen stabilen Default-Parameter statt nullable Dialog-Content
- `FormComponent` synchronisiert Schema-/Daten-Updates jetzt lifecycle-basiert statt über Logik im `[Parameter]`-Setter
- zusätzlicher Parser-Regressionstest für nicht ausführbare Prozesse

## Validierung

- `dotnet restore core-engine.sln`
- `dotnet build core-engine.sln --configuration Release --no-restore`
- `dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-restore --no-build --filter "FullyQualifiedName!=core_engine_tests.EngineTest.ParallelTaskTest&FullyQualifiedName!=core_engine_tests.EngineTest.SequentialTest"`
- `dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-restore --no-build`
- `dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-restore --no-build`
- `npm --prefix tests/ui-smoke ci`
- `npm --prefix tests/ui-smoke run test`

## Bezug

Closes #65
