### PR TITLE
GitHub-Actions frühzeitig auf Node 24 vorbereiten

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  # Opt-in vorab in den Node-24-Runtimepfad für JavaScript-basierte GitHub Actions,
+  # damit die CI nicht erst kurz vor der Abschaltung von Node 20 überrascht wird.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   NODE_VERSION: '20'
   QUARANTINED_TEST_FILTER: >-
     FullyQualifiedName!=core_engine_tests.EngineTest.ParallelTaskTest


### PR DESCRIPTION
## Zusammenfassung

Dieses PR bereitet die vorhandene GitHub-CI frühzeitig auf die angekündigte Node-24-Umstellung der GitHub-Runner vor.

## Änderungen

- globales Opt-in in `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`
- kurze Inline-Dokumentation im Workflow, warum die Einstellung bewusst gesetzt ist
- keine Änderung an Produktcode oder Testlogik

## Validierung

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "YAML ok"'`
- GitHub-Checks auf dem PR

## Bezug

Closes #67
