### PR TITLE
Quarantänisierte Multi-Instance-Tests wieder im CI-Pfad aktivieren

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -53,9 +53,7 @@ Wenn Architektur, Setup oder bekannte Einschränkungen verändert werden, sollen
 ### Build, Tests und CI
 
 - Auf `next` laufen Restore, Build und eine erste CI inzwischen reproduzierbar.
-- Zwei Tests sind aktuell aber noch bewusst temporär aus dem CI-Pfad herausgenommen:
-  - `core_engine_tests.EngineTest.ParallelTaskTest`
-  - `core_engine_tests.EngineTest.SequentialTest`
+- Die bisher quarantänisierten Multi-Instance-Tests laufen inzwischen wieder regulär im CI-Pfad.
 - Änderungen an Build-/SDK-/Testthemen bitte nicht stillschweigend einbauen, sondern sauber begründen und mit Doku flankieren.
 
 ### Expression-Handling

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,6 @@ env:
   # damit die CI nicht erst kurz vor der Abschaltung von Node 20 überrascht wird.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   NODE_VERSION: '20'
-  QUARANTINED_TEST_FILTER: >-
-    FullyQualifiedName!=core_engine_tests.EngineTest.ParallelTaskTest
-    &FullyQualifiedName!=core_engine_tests.EngineTest.SequentialTest
 
 jobs:
   dotnet:
@@ -56,7 +53,6 @@ jobs:
             --no-restore \
             --no-build \
             --configuration Release \
-            --filter "${QUARANTINED_TEST_FILTER}" \
             --collect:"XPlat Code Coverage" \
             --logger "trx;LogFileName=core-engine-tests.trx" \
             --results-directory ./TestResults/ci
@@ -116,9 +112,7 @@ jobs:
 
           - Restore und Build laufen auf GitHub Actions reproduzierbar.
           - Zusätzlich laufen Web-API- und Frontend-Unit-Tests im selben Job mit.
-          - Quarantänisierte Tests (temporär bis zur separaten Behebung):
-            - `core_engine_tests.EngineTest.ParallelTaskTest`
-            - `core_engine_tests.EngineTest.SequentialTest`
+          - Die Core-Engine-Tests laufen jetzt wieder vollständig ohne Quarantänefilter im CI-Pfad.
           - Coverage (Cobertura): **${{ steps.coverage.outputs.line_rate }} %** Line Rate / **${{ steps.coverage.outputs.branch_rate }} %** Branch Rate
           - Coverage-Report: `${{ steps.coverage.outputs.report }}`
           EOF

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,13 +34,13 @@ Dieses Repository enthält eine BPMN-Engine mit Parser, Laufzeit, API, Frontend 
 ## Bekannte Fallstricke
 
 1. **Tests noch nicht vollständig stabil**
-   Auf `next` laufen Restore, Build und eine erste CI. Die Tests `ParallelTaskTest` und `SequentialTest` sind aktuell aber noch bekannte Ausnahmen und werden separat behoben.
+   Auf `next` laufen Restore, Build und CI inzwischen reproduzierbar. Trotzdem bleibt die Engine-Testbasis ein aktiver Arbeitsvorrat; vor allem Multi-Instance-, Error- und Timer-Pfade sollten weiterhin kritisch geprüft werden.
 
 2. **V8-/Expression-Thema nicht abgeschlossen**
    Die Default-Expression-Logik hängt weiterhin an `ClearScript/V8`. Für Tests und CI gibt es jetzt einen robusteren Fallback-Pfad, die langfristige FEEL-/V8-Strategie bleibt aber offen.
 
 3. **CI ist vorhanden, aber noch im Stabilisierungsmodus**
-   Nutze die GitHub-Checks als Basis, behandle die temporär quarantinierten Tests aber weiterhin als offenen Arbeitsvorrat.
+   Nutze die GitHub-Checks als Basis, behandle trotz grünem Grundlauf weiterhin problematische Randfälle als aktiven Arbeitsvorrat.
 
 4. **Nicht alle Verzeichnisse sind gleich aktiv**
    Es gibt Spuren älterer bzw. unfertiger Arbeit. Prüfe vor Refactorings, welche Projekte tatsächlich von der Solution und vom Produktpfad genutzt werden.


### PR DESCRIPTION
## Zusammenfassung

Dieses PR aktiviert die bisher quarantänisierten Multi-Instance-Tests wieder im regulären CI-Pfad.

## Änderungen

- Quarantänefilter für `ParallelTaskTest` und `SequentialTest` aus dem CI-Workflow entfernt
- CI-Zusammenfassung entsprechend angepasst
- Agent-/Copilot-Hinweise auf den neuen Stand gebracht

## Validierung

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "YAML ok"'`
- `dotnet build core-engine.sln --configuration Release --no-restore`
- `dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-restore`

## Bezug

Closes #69
