### PR TITLE
Fehler- und Eskalationspfade der Engine best-effort absichern

### DIFF
--- a/docs/RUNTIME-GAPS.md
+++ b/docs/RUNTIME-GAPS.md
@@ -49,8 +49,9 @@ Noch nicht produktionsreif umgesetzt:
 
 Aktueller Status:
 
-- `GetActiveEscalations()` liefert jetzt wenigstens stabil eine leere Liste statt sofort zu scheitern
-- echte Eskalations- und Fehlersemantik bleibt ein separates Folgepaket
+- `GetActiveEscalations()` liefert stabil eine leere Liste statt sofort zu scheitern
+- `HandleEscalation(...)` und `HandleError(...)` führen jetzt mindestens in einen kontrollierten Best-Effort-Fehlerzustand statt in eine rohe `NotImplementedException`
+- echte Eskalations- und Fehlersemantik bleibt weiterhin ein separates Folgepaket
 
 ### 3. Vollständige Kompensation bei Abbruch
 

--- a/src/core-engine-tests/EngineTest.cs
+++ b/src/core-engine-tests/EngineTest.cs
@@ -180,6 +180,42 @@ public class EngineTest
     }
 
     [Test]
+    public async Task HandleError_ShouldFailInstanceWithoutThrowingNotImplementedException()
+    {
+        var instanceEngine = await Helper.StartFirstProcessOfFile("SimpleService.bpmn");
+
+        var action = () => instanceEngine.HandleError("ServiceFailure", "SERVICE_ERROR", "Boom");
+
+        action.Should().NotThrow<NotImplementedException>();
+
+        using (new AssertionScope())
+        {
+            instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Failed);
+            instanceEngine.IsFinished.Should().BeTrue();
+            instanceEngine.Tokens.Where(token => token.State == FlowNodeState.Failed).Should().NotBeEmpty();
+            instanceEngine.ActiveTokens.Should().BeEmpty();
+        }
+    }
+
+    [Test]
+    public async Task HandleEscalation_ShouldFailInstanceWithoutThrowingNotImplementedException()
+    {
+        var instanceEngine = await Helper.StartFirstProcessOfFile("SimpleService.bpmn");
+
+        var action = () => instanceEngine.HandleEscalation("EscalationCode", "ESCALATION_CODE");
+
+        action.Should().NotThrow<NotImplementedException>();
+
+        using (new AssertionScope())
+        {
+            instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Failed);
+            instanceEngine.IsFinished.Should().BeTrue();
+            instanceEngine.Tokens.Where(token => token.State == FlowNodeState.Failed).Should().NotBeEmpty();
+            instanceEngine.ActiveTokens.Should().BeEmpty();
+        }
+    }
+
+    [Test]
     public async Task ParallelTaskTest()
     {
         var instanceEngine = await Helper.StartFirstProcessOfFile("ParallelFlowTest.bpmn");

--- a/src/core-engine-tests/EngineTest.cs
+++ b/src/core-engine-tests/EngineTest.cs
@@ -186,7 +186,7 @@ public class EngineTest
 
         var action = () => instanceEngine.HandleError("ServiceFailure", "SERVICE_ERROR", "Boom");
 
-        action.Should().NotThrow<NotImplementedException>();
+        action.Should().NotThrow();
 
         using (new AssertionScope())
         {
@@ -204,7 +204,7 @@ public class EngineTest
 
         var action = () => instanceEngine.HandleEscalation("EscalationCode", "ESCALATION_CODE");
 
-        action.Should().NotThrow<NotImplementedException>();
+        action.Should().NotThrow();
 
         using (new AssertionScope())
         {
@@ -212,6 +212,58 @@ public class EngineTest
             instanceEngine.IsFinished.Should().BeTrue();
             instanceEngine.Tokens.Where(token => token.State == FlowNodeState.Failed).Should().NotBeEmpty();
             instanceEngine.ActiveTokens.Should().BeEmpty();
+        }
+    }
+
+    [Test]
+    public async Task HandleError_OnCompletedInstance_ShouldKeepCompletedState()
+    {
+        var instanceEngine = await Helper.StartFirstProcessOfFile("StartStopWithVariables.bpmn");
+        var serviceTaskToken = instanceEngine.GetActiveServiceTasks().Single();
+
+        var variables = (ExpandoObject?)new
+        {
+            ServiceResult = "World123"
+        }.ToDynamic();
+        instanceEngine.HandleTaskResult(serviceTaskToken.Id, variables);
+
+        instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Completed);
+
+        var action = () => instanceEngine.HandleError("ServiceFailure", "SERVICE_ERROR", "Boom");
+
+        action.Should().NotThrow();
+
+        using (new AssertionScope())
+        {
+            instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Completed);
+            instanceEngine.IsFinished.Should().BeTrue();
+            instanceEngine.Tokens.Should().OnlyContain(token => token.State == FlowNodeState.Completed);
+        }
+    }
+
+    [Test]
+    public async Task HandleEscalation_OnCompletedInstance_ShouldKeepCompletedState()
+    {
+        var instanceEngine = await Helper.StartFirstProcessOfFile("StartStopWithVariables.bpmn");
+        var serviceTaskToken = instanceEngine.GetActiveServiceTasks().Single();
+
+        var variables = (ExpandoObject?)new
+        {
+            ServiceResult = "World123"
+        }.ToDynamic();
+        instanceEngine.HandleTaskResult(serviceTaskToken.Id, variables);
+
+        instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Completed);
+
+        var action = () => instanceEngine.HandleEscalation("EscalationCode", "ESCALATION_CODE");
+
+        action.Should().NotThrow();
+
+        using (new AssertionScope())
+        {
+            instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Completed);
+            instanceEngine.IsFinished.Should().BeTrue();
+            instanceEngine.Tokens.Should().OnlyContain(token => token.State == FlowNodeState.Completed);
         }
     }
 

--- a/src/core-engine/InstanceEngine/Base.cs
+++ b/src/core-engine/InstanceEngine/Base.cs
@@ -83,12 +83,12 @@ public partial class InstanceEngine: ICatchHandler
     
     public void HandleEscalation(string escalationCode, string? code, object? escalationBody = null)
     {
-        throw new NotImplementedException();
+        FailInstanceBestEffort();
     }
 
     public void HandleError(string name, string errorCode, string? errorMessage = null, object? errorBody = null)
     {
-        throw new NotImplementedException();
+        FailInstanceBestEffort();
     }
 
     public void HandleTaskResult(Guid tokenId, Variables? data, Guid? userId = null)
@@ -182,6 +182,30 @@ public partial class InstanceEngine: ICatchHandler
     }
 
     private static bool CanBeTerminatedByCancellation(Token token)
+    {
+        return token.State is
+            FlowNodeState.Ready or
+            FlowNodeState.Active or
+            FlowNodeState.Completing or
+            FlowNodeState.WaitingForLoopEnd or
+            FlowNodeState.Failing or
+            FlowNodeState.Terminating;
+    }
+
+    private void FailInstanceBestEffort()
+    {
+        foreach (var token in Tokens.Where(CanBeFailedBestEffort))
+        {
+            token.State = FlowNodeState.Failed;
+        }
+
+        if (MasterToken.State != FlowNodeState.Failed)
+        {
+            MasterToken.State = FlowNodeState.Failed;
+        }
+    }
+
+    private static bool CanBeFailedBestEffort(Token token)
     {
         return token.State is
             FlowNodeState.Ready or

--- a/src/core-engine/InstanceEngine/Base.cs
+++ b/src/core-engine/InstanceEngine/Base.cs
@@ -194,27 +194,18 @@ public partial class InstanceEngine: ICatchHandler
 
     private void FailInstanceBestEffort()
     {
+        if (IsFinished)
+        {
+            return;
+        }
+
         foreach (var token in Tokens.Where(CanBeFailedBestEffort))
         {
             token.State = FlowNodeState.Failed;
         }
-
-        if (MasterToken.State != FlowNodeState.Failed)
-        {
-            MasterToken.State = FlowNodeState.Failed;
-        }
     }
 
-    private static bool CanBeFailedBestEffort(Token token)
-    {
-        return token.State is
-            FlowNodeState.Ready or
-            FlowNodeState.Active or
-            FlowNodeState.Completing or
-            FlowNodeState.WaitingForLoopEnd or
-            FlowNodeState.Failing or
-            FlowNodeState.Terminating;
-    }
+    private static bool CanBeFailedBestEffort(Token token) => CanBeTerminatedByCancellation(token);
 
     public List<Token> ActiveUserTasks()
     {


### PR DESCRIPTION
## Zusammenfassung

Dieses PR entschärft die verbliebenen rohen `NotImplementedException`-Pfade für Fehler- und Eskalationsaufrufe in der Engine durch eine kleine Best-Effort-Absicherung.

## Änderungen

- `HandleError(...)` führt die Instanz jetzt in einen kontrollierten Fehlerzustand statt in eine rohe `NotImplementedException`
- `HandleEscalation(...)` verhält sich analog als Best-Effort-Fallback
- neue Engine-Tests für beide Pfade
- `docs/RUNTIME-GAPS.md` auf den neuen Status angepasst

## Validierung

- `dotnet restore core-engine.sln`
- `dotnet build core-engine.sln --configuration Release --no-restore`
- `dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-restore`

## Bezug

Closes #71
