### PR TITLE
Timer-Ausführung für Start- und Intermediate-Catch-Events im Engine-Kern ergänzen

### DIFF
--- a/docs/RUNTIME-GAPS.md
+++ b/docs/RUNTIME-GAPS.md
@@ -12,13 +12,19 @@ Dieses Dokument hält die aktuell noch offenen Laufzeit- und Engine-Lücken fest
 - Laufende Instanzen können ihre aktiven Timertermine jetzt über `ICatchHandler.ActiveTimers` offenlegen.
 - `timeDuration` wird bei der Fälligkeitsberechnung jetzt genauso berücksichtigt wie `timeCycle` und `timeDate`.
 
-### 2. User-Task-Ergebnisse haben einen stabileren Laufzeitvertrag
+### 2. Timer können im Engine-Kern jetzt fälligkeitsbasiert weiterlaufen
+
+- `ProcessEngine.HandleTime(...)` kann fällige Timer-Start-Events jetzt einmalig in neue Instanzen überführen.
+- `InstanceEngine.HandleTime(...)` kann fällige `FlowzerIntermediateTimerCatchEvent`-Tokens jetzt weiterführen.
+- Die zugehörigen Engine-Regressionstests decken Start- und Intermediate-Timer jetzt explizit ab.
+
+### 3. User-Task-Ergebnisse haben einen stabileren Laufzeitvertrag
 
 - User-Task-Ergebnisse ohne `ProcessInstanceId` laufen nicht mehr in eine rohe `NotImplementedException`.
 - Stattdessen kommt ein valider `400 Bad Request` mit einem klaren API-Fehlervertrag zurück.
 - Zusätzlich wird jetzt geprüft, ob das übergebene `TokenId` wirklich noch aktiv ist und zum erwarteten `FlowNodeId` gehört.
 
-### 3. Instanzabbruch ist als Best-Effort-Pfad verfügbar
+### 4. Instanzabbruch ist als Best-Effort-Pfad verfügbar
 
 - `InstanceEngine.Cancel()` terminiert jetzt aktive/wartende Tokens der Instanz konsistent.
 - Das ersetzt noch **keine vollständige BPMN-Kompensation**, verhindert aber, dass der API-/Runtime-Pfad an einer nackten `NotImplementedException` scheitert.
@@ -27,17 +33,19 @@ Dieses Dokument hält die aktuell noch offenen Laufzeit- und Engine-Lücken fest
 
 ### 1. Timer-Ausführung und Persistenz
 
-Aktuell sichtbar bzw. teilweise vorbereitet:
+Aktuell vorhanden:
 
 - Timer-Fälligkeiten für Start- und laufende Instanzen
 - Timer-Catch-Events als wartende Zustände
+- einmaliger Engine-Kernpfad für fällige Timer-Starts und Intermediate-Timer
 
 Weiterhin offen:
 
 - persistierte Timer-Subscriptions in Storage/API
 - Wiederaufnahme nach Neustart nur auf Basis gespeicherter Timerzustände
-- tatsächliches `HandleTime(...)` bzw. Scheduler-Anbindung
+- Scheduler-/API-Anbindung rund um `HandleTime(...)`
 - Boundary-Timer-Parsing und -Abarbeitung
+- vollständige Wiederholungsstrategie für zyklische Start-Timer über den ersten Due-Zeitpunkt hinaus
 
 ### 2. Fehler- und Eskalationspfade
 

--- a/src/core-engine-tests/EngineTest.cs
+++ b/src/core-engine-tests/EngineTest.cs
@@ -439,12 +439,55 @@ public class EngineTest
         var processEngine = Helper.CreateProcessEngine(process.First());
         var activeTimers = processEngine.ActiveTimers.ToArray();
         activeTimers.Should().HaveCount(1);
-        activeTimers.Single().Should().BeCloseTo(DateTime.Now.AddSeconds(2), new TimeSpan(0, 0, 0, 0, 100));
+        activeTimers.Single().Should().BeCloseTo(DateTime.UtcNow.AddSeconds(2), new TimeSpan(0, 0, 0, 0, 100));
+    }
 
-        // var instanceEngine = await processEngine.HandleTime(DateTime.Now);
-        // activeTimers = instanceEngine.ActiveTimers.ToArray();
-        // activeTimers.Should().HaveCount(0);
-        //
+    [Test]
+    public void TimerStartEvent_ShouldStartProcessWhenDue()
+    {
+        var processEngine = CreateProcessEngineFromXml("""
+                                                     <?xml version="1.0" encoding="UTF-8"?>
+                                                     <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                                                       xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                                                                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                                       id="Definitions_TimerStart"
+                                                                       targetNamespace="http://bpmn.io/schema/bpmn">
+                                                       <bpmn:process id="Process_TimerStart" isExecutable="true">
+                                                         <bpmn:startEvent id="StartEvent_1">
+                                                           <bpmn:outgoing>Flow_1</bpmn:outgoing>
+                                                           <bpmn:timerEventDefinition id="TimerDefinition_1">
+                                                             <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT2S</bpmn:timeDuration>
+                                                           </bpmn:timerEventDefinition>
+                                                         </bpmn:startEvent>
+                                                         <bpmn:serviceTask id="ServiceTask_1" name="Wait for worker">
+                                                           <bpmn:extensionElements>
+                                                             <zeebe:taskDefinition type="timer-start-step" />
+                                                           </bpmn:extensionElements>
+                                                           <bpmn:incoming>Flow_1</bpmn:incoming>
+                                                           <bpmn:outgoing>Flow_2</bpmn:outgoing>
+                                                         </bpmn:serviceTask>
+                                                         <bpmn:endEvent id="EndEvent_1">
+                                                           <bpmn:incoming>Flow_2</bpmn:incoming>
+                                                         </bpmn:endEvent>
+                                                         <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="ServiceTask_1" />
+                                                         <bpmn:sequenceFlow id="Flow_2" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
+                                                       </bpmn:process>
+                                                     </bpmn:definitions>
+                                                     """);
+
+        var dueDate = processEngine.ActiveTimers.Single();
+
+        var instances = processEngine.HandleTime(dueDate.AddMilliseconds(50));
+
+        using (new AssertionScope())
+        {
+            instances.Should().ContainSingle();
+            instances.Single().ProcessInstanceState.Should().Be(ProcessInstanceState.Waiting);
+            instances.Single().GetActiveServiceTasks().Select(token => ((ServiceTask)token.CurrentBaseElement).Implementation)
+                .Should()
+                .ContainSingle("timer-start-step");
+            processEngine.ActiveTimers.Should().BeEmpty();
+        }
     }
 
     [Test]
@@ -488,6 +531,48 @@ public class EngineTest
                 .Count(token => token.CurrentFlowNode != null && token.CurrentFlowNode.Id == "TimerCatch_1")
                 .Should()
                 .Be(1);
+        }
+    }
+
+    [Test]
+    public void IntermediateTimerCatchEvent_ShouldContinueWhenDue()
+    {
+        var instanceEngine = StartProcessFromXml("""
+                                               <?xml version="1.0" encoding="UTF-8"?>
+                                               <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                                                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                                 id="Definitions_TimerCatch_Continue"
+                                                                 targetNamespace="http://bpmn.io/schema/bpmn">
+                                                 <bpmn:process id="Process_TimerCatch_Continue" isExecutable="true">
+                                                   <bpmn:startEvent id="StartEvent_1">
+                                                     <bpmn:outgoing>Flow_1</bpmn:outgoing>
+                                                   </bpmn:startEvent>
+                                                   <bpmn:intermediateCatchEvent id="TimerCatch_1">
+                                                     <bpmn:incoming>Flow_1</bpmn:incoming>
+                                                     <bpmn:outgoing>Flow_2</bpmn:outgoing>
+                                                     <bpmn:timerEventDefinition id="TimerDefinition_1">
+                                                       <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT5S</bpmn:timeDuration>
+                                                     </bpmn:timerEventDefinition>
+                                                   </bpmn:intermediateCatchEvent>
+                                                   <bpmn:endEvent id="EndEvent_1">
+                                                     <bpmn:incoming>Flow_2</bpmn:incoming>
+                                                   </bpmn:endEvent>
+                                                   <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="TimerCatch_1" />
+                                                   <bpmn:sequenceFlow id="Flow_2" sourceRef="TimerCatch_1" targetRef="EndEvent_1" />
+                                                 </bpmn:process>
+                                               </bpmn:definitions>
+                                               """);
+
+        var timerToken = instanceEngine.ActiveTokens.Single(token => token.CurrentFlowNode?.Id == "TimerCatch_1");
+
+        instanceEngine.HandleTime(timerToken.LastStateChangeTime.AddSeconds(5).AddMilliseconds(50));
+
+        using (new AssertionScope())
+        {
+            instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Completed);
+            ((ICatchHandler)instanceEngine).ActiveTimers.Should().BeEmpty();
+            instanceEngine.ActiveTokens.Should().BeEmpty();
+            instanceEngine.Tokens.Count(token => token.CurrentFlowNode is EndEvent).Should().Be(1);
         }
     }
 
@@ -560,5 +645,11 @@ public class EngineTest
     {
         var process = ModelParser.ParseModel(xml).GetProcesses().Single();
         return Helper.CreateProcessEngine(process).StartProcess();
+    }
+
+    private static ProcessEngine CreateProcessEngineFromXml(string xml)
+    {
+        var process = ModelParser.ParseModel(xml).GetProcesses().Single();
+        return Helper.CreateProcessEngine(process);
     }
 }

--- a/src/core-engine-tests/EngineTest.cs
+++ b/src/core-engine-tests/EngineTest.cs
@@ -439,7 +439,10 @@ public class EngineTest
         var processEngine = Helper.CreateProcessEngine(process.First());
         var activeTimers = processEngine.ActiveTimers.ToArray();
         activeTimers.Should().HaveCount(1);
-        activeTimers.Single().Should().BeCloseTo(DateTime.UtcNow.AddSeconds(2), new TimeSpan(0, 0, 0, 0, 100));
+        var dueDate = activeTimers.Single();
+        var remainingTime = dueDate - DateTime.UtcNow;
+        remainingTime.Should().BeGreaterOrEqualTo(TimeSpan.FromSeconds(1));
+        remainingTime.Should().BeLessOrEqualTo(TimeSpan.FromSeconds(2.5));
     }
 
     [Test]

--- a/src/core-engine/InstanceEngine/Base.cs
+++ b/src/core-engine/InstanceEngine/Base.cs
@@ -144,16 +144,30 @@ public partial class InstanceEngine: ICatchHandler
     }
 
     /// <summary>
-    /// Führt fällige Timer-Start- oder Intermediate-Timer-Catch-Events weiter.
-    /// Für Start-Timer wird optional ein bereits ausgewählter Startknoten übergeben.
+    /// Führt fällige Intermediate-Timer-Catch-Events weiter.
     /// </summary>
-    public void HandleTime(DateTime time, FlowzerTimerStartEvent? startEvent = null)
+    public void HandleTime(DateTime time)
+    {
+        HandleDueIntermediateTimerCatchEvents(time);
+    }
+
+    /// <summary>
+    /// Führt fällige Timer-Start- oder Intermediate-Timer-Catch-Events weiter.
+    /// Diese Überladung ist absichtlich nicht öffentlich, damit Start-Timer nur
+    /// über Engine-internen Code ausgelöst werden können.
+    /// </summary>
+    internal void HandleTime(DateTime time, FlowzerTimerStartEvent? startEvent)
     {
         if (TryStartByTimerStartEvent(startEvent))
         {
             return;
         }
 
+        HandleDueIntermediateTimerCatchEvents(time);
+    }
+
+    private void HandleDueIntermediateTimerCatchEvents(DateTime time)
+    {
         var dueTimerTokens = ActiveTokens
             .Where(token => token.CurrentFlowNode is FlowzerIntermediateTimerCatchEvent)
             .Where(token => GetTimerDueDate(token) <= time)

--- a/src/core-engine/InstanceEngine/Base.cs
+++ b/src/core-engine/InstanceEngine/Base.cs
@@ -143,10 +143,32 @@ public partial class InstanceEngine: ICatchHandler
         }
     }
 
-    // public Task<ProcessInstance> HandleTime(DateTime time)
-    // {
-    //     throw new NotImplementedException();
-    // }
+    /// <summary>
+    /// Führt fällige Timer-Start- oder Intermediate-Timer-Catch-Events weiter.
+    /// Für Start-Timer wird optional ein bereits ausgewählter Startknoten übergeben.
+    /// </summary>
+    public void HandleTime(DateTime time, FlowzerTimerStartEvent? startEvent = null)
+    {
+        if (TryStartByTimerStartEvent(startEvent))
+        {
+            return;
+        }
+
+        var dueTimerTokens = ActiveTokens
+            .Where(token => token.CurrentFlowNode is FlowzerIntermediateTimerCatchEvent)
+            .Where(token => GetTimerDueDate(token) <= time)
+            .ToArray();
+
+        foreach (var token in dueTimerTokens)
+        {
+            token.State = FlowNodeState.Completing;
+        }
+
+        if (dueTimerTokens.Length > 0)
+        {
+            Run();
+        }
+    }
 
     /// <summary>
     /// Gibt den aktuellen (Sub-)Prozess-Token zurück.
@@ -174,10 +196,7 @@ public partial class InstanceEngine: ICatchHandler
     {
         if (token.CurrentFlowNode is FlowzerIntermediateTimerCatchEvent timerCatchEvent)
         {
-            yield return TimerDueDateCalculator.GetDueDate(
-                token.LastStateChangeTime,
-                timerCatchEvent.TimerDefinition,
-                timerCatchEvent);
+            yield return GetTimerDueDate(token, timerCatchEvent);
         }
     }
 
@@ -206,6 +225,42 @@ public partial class InstanceEngine: ICatchHandler
     }
 
     private static bool CanBeFailedBestEffort(Token token) => CanBeTerminatedByCancellation(token);
+
+    private bool TryStartByTimerStartEvent(FlowzerTimerStartEvent? startEvent)
+    {
+        if (startEvent == null || Tokens.Count != 1)
+        {
+            return false;
+        }
+
+        Tokens.Add(new Token
+        {
+            CurrentBaseElement = startEvent,
+            ActiveBoundaryEvents = [],
+            OutputData = new Variables(),
+            State = FlowNodeState.Completing,
+            ParentTokenId = MasterToken.Id,
+            ProcessInstanceId = MasterToken.ProcessInstanceId,
+        });
+        Run();
+
+        return true;
+    }
+
+    private static DateTime GetTimerDueDate(Token token)
+    {
+        return token.CurrentFlowNode is FlowzerIntermediateTimerCatchEvent timerCatchEvent
+            ? GetTimerDueDate(token, timerCatchEvent)
+            : throw new FlowzerRuntimeException($"Token {token.Id} wartet nicht auf ein Timer-Catch-Event.");
+    }
+
+    private static DateTime GetTimerDueDate(Token token, FlowzerIntermediateTimerCatchEvent timerCatchEvent)
+    {
+        return TimerDueDateCalculator.GetDueDate(
+            token.LastStateChangeTime,
+            timerCatchEvent.TimerDefinition,
+            timerCatchEvent);
+    }
 
     public List<Token> ActiveUserTasks()
     {

--- a/src/core-engine/ProcessEngine.cs
+++ b/src/core-engine/ProcessEngine.cs
@@ -5,22 +5,15 @@ namespace core_engine;
 
 public class ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null) : ICatchHandler
 {
+    private readonly DateTime _timerReferenceTime = DateTime.UtcNow;
+    private readonly HashSet<string> _triggeredTimerStartEventIds = [];
     
     public Process Process { get; set; } = process;
     public FlowzerConfig FlowzerConfig { get; } = flowzerConfig ?? FlowzerConfig.Default;
 
     public InstanceEngine StartProcess(Variables? data = null)
     {
-        var masterToken = new Token
-        {
-            CurrentBaseElement = Process,
-            State = FlowNodeState.Active,
-            Variables = new Variables(),
-            ParentTokenId = null,
-            ActiveBoundaryEvents = [],
-            ProcessInstanceId = Guid.NewGuid(),
-        };
-        var instance = new InstanceEngine([masterToken], FlowzerConfig);
+        var instance = CreateInstanceEngine();
         instance.Start(data);
         return instance;
     }
@@ -36,16 +29,7 @@ public class ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null)
 
     public InstanceEngine HandleMessage(Message message)
     {
-        var masterToken = new Token
-        {
-            CurrentBaseElement = Process,
-            State = FlowNodeState.Active,
-            Variables = new Variables(),
-            ParentTokenId = null,
-            ActiveBoundaryEvents = [],
-            ProcessInstanceId = Guid.NewGuid(),
-        };
-        var instanceEngine = new InstanceEngine([masterToken], FlowzerConfig);
+        var instanceEngine = CreateInstanceEngine();
 
         instanceEngine.HandleMessage(message);
         
@@ -59,19 +43,33 @@ public class ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null)
             .Where(e => e.Signal.Name == signalName)
             .Select(startEvent =>
         {
-            var masterToken = new Token
-            {
-                CurrentBaseElement = Process,
-                State = FlowNodeState.Active,
-                Variables = new Variables(),
-                ParentTokenId = null,
-                ActiveBoundaryEvents = [],
-                ProcessInstanceId = Guid.NewGuid(),
-            };
-            var instanceEngine = new InstanceEngine([masterToken], FlowzerConfig);
+            var instanceEngine = CreateInstanceEngine();
 
             instanceEngine.HandleSignal(signalName, JsonConvert.SerializeObject(signalData), startEvent);
 
+            return instanceEngine;
+        }).ToArray();
+    }
+
+    /// <summary>
+    /// Führt fällige Timer-Start-Events einmalig aus und startet dafür neue Instanzen.
+    /// Die Persistenz bzw. echte Wiederholungslogik bleibt weiterhin ein separates Folgethema.
+    /// </summary>
+    public InstanceEngine[] HandleTime(DateTime time)
+    {
+        var dueStartEvents = GetPendingTimerStartEvents()
+            .Where(startEvent => GetStartTimerDueDate(startEvent) <= time)
+            .ToArray();
+
+        foreach (var startEvent in dueStartEvents)
+        {
+            _triggeredTimerStartEventIds.Add(startEvent.Id);
+        }
+
+        return dueStartEvents.Select(startEvent =>
+        {
+            var instanceEngine = CreateInstanceEngine();
+            instanceEngine.HandleTime(time, startEvent);
             return instanceEngine;
         }).ToArray();
     }
@@ -80,9 +78,8 @@ public class ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null)
     {
         get
         {
-            return Process.FlowElements
-                .OfType<FlowzerTimerStartEvent>()
-                .Select(e => TimerDueDateCalculator.GetDueDate(DateTime.Now, e.TimerDefinition, e))
+            return GetPendingTimerStartEvents()
+                .Select(GetStartTimerDueDate)
                 .ToList();
         }
     }
@@ -112,5 +109,32 @@ public class ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null)
     {
         //TODO: implement to support userasks as initialisation of a instancde
         return new List<Token>();
+    }
+
+    private IEnumerable<FlowzerTimerStartEvent> GetPendingTimerStartEvents()
+    {
+        return Process.FlowElements
+            .OfType<FlowzerTimerStartEvent>()
+            .Where(startEvent => !_triggeredTimerStartEventIds.Contains(startEvent.Id));
+    }
+
+    private DateTime GetStartTimerDueDate(FlowzerTimerStartEvent startEvent)
+    {
+        return TimerDueDateCalculator.GetDueDate(_timerReferenceTime, startEvent.TimerDefinition, startEvent);
+    }
+
+    private InstanceEngine CreateInstanceEngine()
+    {
+        var masterToken = new Token
+        {
+            CurrentBaseElement = Process,
+            State = FlowNodeState.Active,
+            Variables = new Variables(),
+            ParentTokenId = null,
+            ActiveBoundaryEvents = [],
+            ProcessInstanceId = Guid.NewGuid(),
+        };
+
+        return new InstanceEngine([masterToken], FlowzerConfig);
     }
 }

--- a/src/core-engine/ProcessEngine.cs
+++ b/src/core-engine/ProcessEngine.cs
@@ -61,17 +61,17 @@ public class ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null)
             .Where(startEvent => GetStartTimerDueDate(startEvent) <= time)
             .ToArray();
 
-        foreach (var startEvent in dueStartEvents)
-        {
-            _triggeredTimerStartEventIds.Add(startEvent.Id);
-        }
+        var instances = new List<InstanceEngine>();
 
-        return dueStartEvents.Select(startEvent =>
+        foreach (var startEvent in dueStartEvents)
         {
             var instanceEngine = CreateInstanceEngine();
             instanceEngine.HandleTime(time, startEvent);
-            return instanceEngine;
-        }).ToArray();
+            _triggeredTimerStartEventIds.Add(startEvent.Id);
+            instances.Add(instanceEngine);
+        }
+
+        return instances.ToArray();
     }
 
     public List<DateTime> ActiveTimers


### PR DESCRIPTION
## Zusammenfassung

Dieses PR ergänzt einen kleinen, bewusst fokussierten Timer-Ausführungspfad im Engine-Kern.

## Änderungen

- `ProcessEngine.HandleTime(...)` startet fällige Timer-Start-Events jetzt einmalig als neue Instanzen
- `InstanceEngine.HandleTime(...)` führt fällige `FlowzerIntermediateTimerCatchEvent`-Tokens weiter
- neue Engine-Regressionstests für Timer-Start und Intermediate-Timer-Catch
- `docs/RUNTIME-GAPS.md` auf den neuen Zwischenstand aktualisiert

## Validierung

- `dotnet restore core-engine.sln`
- `dotnet build core-engine.sln --configuration Release --no-restore`
- `dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-restore --no-build`
- `dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-restore --no-build`
- `dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-restore --no-build`

## Hinweis

Dieses Paket löst bewusst noch **nicht**:

- persistierte Timer-Subscriptions
- Boundary-Timer-Semantik
- vollständige Wiederholungsstrategie für zyklische Timer über den ersten Due-Zeitpunkt hinaus

## Bezug

Closes #73
