### PR TITLE
Form- und Message-Fehlerpfade in API und Business-Logic weiter härten

### DIFF
--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -176,6 +176,28 @@ public class ApiHardeningIntegrationTest
     }
 
     [Test]
+    public async Task MessageEndpoint_ShouldReturnNotFound_WhenSubscriptionReferencesMissingProcess()
+    {
+        const string correlationKey = "INV-404";
+        var storage = CreateMessageStartStorage(correlationKey, processId: "Missing_Process");
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/message", new MessageDto
+        {
+            Name = "InvoiceReceived",
+            CorrelationKey = correlationKey
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<string>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeFalse();
+        payload.ErrorMessage.Should().Contain("No process with the id");
+    }
+
+    [Test]
     public async Task MessageEndpoint_ShouldReturnSuccessfulResultPayload_WhenMessageWasHandled()
     {
         const string correlationKey = "INV-1000";
@@ -210,7 +232,7 @@ public class ApiHardeningIntegrationTest
         payload.ErrorMessage.Should().BeNull();
     }
 
-    private static TestStorage CreateMessageStartStorage(string correlationKey)
+    private static TestStorage CreateMessageStartStorage(string correlationKey, string processId = "Process_Invoice")
     {
         var storage = new TestStorage();
         var definitionId = Guid.NewGuid();
@@ -249,7 +271,7 @@ public class ApiHardeningIntegrationTest
                 Name = "InvoiceReceived",
                 FlowzerCorrelationKey = correlationKey
             },
-            "Process_Invoice",
+            processId,
             "invoice-process",
             definitionId));
 

--- a/src/WebApiEngine.Tests/FormControllerIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/FormControllerIntegrationTest.cs
@@ -42,6 +42,28 @@ public class FormControllerIntegrationTest
     }
 
     [Test]
+    public async Task SaveForm_ShouldReturnBadRequest_WhenFormIdIsEmpty()
+    {
+        var storage = TestStorage.Create();
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/form", new FormDto
+        {
+            FormId = Guid.Empty,
+            FormData = "{\"type\":\"form\"}",
+            Version = new VersionDto()
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<FormDto>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeFalse();
+        payload.ErrorMessage.Should().Be("FormId is required");
+    }
+
+    [Test]
     public async Task GetForm_ShouldReturnSpecificVersion_WhenVersionIdentifierIsProvided()
     {
         var storage = TestStorage.Create();
@@ -102,6 +124,27 @@ public class FormControllerIntegrationTest
         payload.Should().NotBeNull();
         payload!.Successful.Should().BeFalse();
         payload.ErrorMessage.Should().Contain("Version string must have two parts separated by a dot.");
+    }
+
+    [Test]
+    public async Task SaveFormMetadata_ShouldUseRouteFormId_WhenBodyFormIdIsEmpty()
+    {
+        var storage = TestStorage.Create();
+        var formId = Guid.NewGuid();
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync($"/form/meta/{formId}", new FormMetaDataDto
+        {
+            FormId = Guid.Empty,
+            Name = "Invoice"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        storage.FormStorageSeed.FormMetadatas.Should().ContainSingle(metadata =>
+            metadata.FormId == formId &&
+            metadata.Name == "Invoice");
     }
 
     private sealed class TestWebApplicationFactory(TestStorage storage) : WebApplicationFactory<Program>

--- a/src/WebApiEngine/BusinessLogic/BpmnBusinessLogic.cs
+++ b/src/WebApiEngine/BusinessLogic/BpmnBusinessLogic.cs
@@ -138,7 +138,7 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider)
             .FirstOrDefault();
 
         if (messageSubscription is null)
-            throw new Exception($"No process instance is waiting for a message with the name \"{message.Name}\" and correlation key \"{message.CorrelationKey}\" and instanceId {message.InstanceId}.");
+            throw new ArgumentException($"No process instance is waiting for a message with the name \"{message.Name}\" and correlation key \"{message.CorrelationKey}\" and instanceId {message.InstanceId}.");
 
         InstanceEngine instance;
         if (messageSubscription.ProcessInstanceId != null) //the message is for a specific instance, so load the instance
@@ -155,7 +155,7 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider)
 
             var process = model.GetProcesses().FirstOrDefault(x => x.Id == messageSubscription.ProcessId);
             if (process == null)
-                throw new Exception($"No process with the id \"{messageSubscription.ProcessId}\" was found in the definition with the id \"{messageSubscription.DefinitionId}\".");
+                throw new FileNotFoundException($"No process with the id \"{messageSubscription.ProcessId}\" was found in the definition with the id \"{messageSubscription.DefinitionId}\".");
             
             instance = StartProcessByMessage(messageSubscription.DefinitionId, messageSubscription.RelatedDefinitionId, process, message);
             

--- a/src/WebApiEngine/Controller/FormController.cs
+++ b/src/WebApiEngine/Controller/FormController.cs
@@ -14,7 +14,7 @@ public class FormController(
 {
 
     [HttpPost()]
-    public async Task<ActionResult<ApiStatusResult>> SaveForm(FormDto formDto)
+    public async Task<ActionResult<ApiStatusResult<FormDto>>> SaveForm(FormDto formDto)
     {
         Form form;
         try

--- a/src/WebApiEngine/Controller/FormController.cs
+++ b/src/WebApiEngine/Controller/FormController.cs
@@ -27,7 +27,7 @@ public class FormController(
         }
         
         if (form.FormId == Guid.Empty)
-            throw new Exception("FormId is required");
+            return BadRequest(new ApiStatusResult<FormDto>("FormId is required"));
         
         form = await formBusinessLogic.SaveForm(form);
         
@@ -98,9 +98,6 @@ public class FormController(
         [HttpPost("meta/{formId}")]
         public async Task<ActionResult<ApiStatusResult>> SaveFormMetadata(Guid formId, FormMetaDataDto formMetadataDto)
         {
-            if (formMetadataDto.FormId == Guid.Empty)
-                throw new Exception("FormId is required");
-            
             formMetadataDto.FormId = formId;
             
             await storageSystem.FormStorage.SaveFormMetaData(formMetadataDto.ToModel());
@@ -123,7 +120,7 @@ public class FormController(
             await bpmnBusinessLogic.HandleUserTask(data, currentUser.UserId);
             return Ok(new ApiStatusResult() {Successful = true});
         }
-        catch (Exception e)
+        catch (ArgumentException e)
         {
             return BadRequest(new ApiStatusResult(e.Message));
         }

--- a/src/WebApiEngine/Controller/MessageController.cs
+++ b/src/WebApiEngine/Controller/MessageController.cs
@@ -22,9 +22,13 @@ public class MessageController(IStorageSystem storageSystem,
             var message = messageDto.ToModel();
             await bpmnBusinessLogic.HandleMessage(message);
         }
-        catch (Exception e)
+        catch (ArgumentException e)
         {
             return BadRequest(new ApiStatusResult<string>(errorMessage: e.Message));
+        }
+        catch (FileNotFoundException e)
+        {
+            return NotFound(new ApiStatusResult<string>(errorMessage: e.Message));
         }
         string correlationText = "";
         if (messageDto.CorrelationKey != null)


### PR DESCRIPTION
## Zusammenfassung

Dieses PR härtet weitere generische Fehlerpfade in Web-API und Business-Logic, damit Form- und Message-Aufrufe konsistentere 400/404-Verträge liefern.

## Änderungen

- `FormController.SaveForm(...)` liefert bei leerer `FormId` jetzt direkt einen sauberen `400 Bad Request`
- `FormController.SaveFormMetadata(...)` verwendet jetzt konsequent die `formId` aus der Route statt einen leeren Body-Wert abzulehnen
- `MessageController` fängt nicht mehr pauschal alle Fehler ab, sondern behandelt erwartete 400/404-Fälle gezielt
- `BpmnBusinessLogic.HandleMessage(...)` nutzt dafür passendere Ausnahmearten statt generischer `Exception`
- neue/ergänzte Integrationstests für Form- und Message-Fehlerverträge

## Validierung

- `dotnet restore core-engine.sln`
- `dotnet build core-engine.sln --configuration Release --no-restore`
- `dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-restore --no-build`
- `dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-restore --no-build`

## Bezug

Closes #75
