### PR TITLE
Statusdokumentation nach Timer- und API-Härtung aktualisieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ npm run build
 Diese Punkte sollte man kennen, bevor man loslegt:
 
 1. **Kernpfade sind stabil, aber noch nicht vollständig aufgeräumt**
-   Build, CI sowie Kern-, WebAPI-, Frontend- und UI-Smoke-Pfade laufen auf `next` reproduzierbar grün. Die wichtigsten offenen Lücken liegen inzwischen eher in fachlichen Runtime- und Betriebsfragen als in der nackten Build-Stabilität.
+   Build, CI sowie Kern-, Web-API-, Frontend- und UI-Smoke-Pfade laufen auf `next` reproduzierbar grün. Die wichtigsten offenen Lücken liegen inzwischen eher in fachlichen Runtime- und Betriebsfragen als in der nackten Build-Stabilität.
 
 2. **Expression-/V8-Thema nicht abgeschlossen**
    Test- und CI-Umgebungen laufen inzwischen auch ohne native V8-Abhängigkeit stabiler. Die vollständige FEEL-/V8-Strategie der Engine ist fachlich aber weiterhin ein eigener Architekturstrang.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Eine BPMN-Ausführungsengine in C#/.NET mit Parser, Laufzeitmodell, Web-API, Frontend und ersten Beispielprozessen.
 
-> **Stand: 11. April 2026**
-> Das Repository hat eine gute fachliche Basis, ist aktuell aber eher ein **starker Prototyp** als ein produktionsreifes Framework. Wer das Projekt weiterführen will, sollte zuerst Stabilisierung, Build/CI und die offene PR-/Issue-Lage bereinigen.
+> **Stand: 12. April 2026**
+> Das Repository ist auf `next` wieder klar arbeitsfähig und deutlich weiter als noch in der reinen Rettungsphase. Es bleibt aber eher ein **produktnaher Prototyp mit belastbarer Basis** als ein fertig gehärtetes Framework.
 
 ## Warum das Projekt spannend ist
 
@@ -24,10 +24,10 @@ Kurz gesagt: **Die Richtung stimmt.** Die Engine ist nicht „tot“, aber sie b
 Die bisherige Dokumentation klang teilweise deutlich reifer als der aktuelle Stand der Codebasis. Realistischer formuliert:
 
 - Es gibt bereits eine **brauchbare Kernarchitektur**.
-- Es gibt **fachlich wertvolle Tests und BPMN-Beispiele**.
-- Es gibt **offene technische Schulden** in Build, Tooling und Repository-Hygiene.
-- Mehrere Bereiche sind **begonnen, aber nicht sauber abgeschlossen**.
-- Das Projekt ist **revivierbar**, wenn man die nächsten Schritte konsequent priorisiert.
+- Es gibt **fachlich wertvolle Tests, BPMN-Beispiele und eine grüne CI-Basis auf `next`**.
+- Zentrale Produktpfade wie Demo, UI-Smokes, API-Fehlerverträge und ein erster Timer-Kernpfad sind inzwischen vorhanden.
+- Es gibt aber weiterhin **offene Restlücken** bei Timer-Persistenz, Boundary-Timern, Auth/Identity und Betriebsreife.
+- Das Projekt ist **klar revivierbar und aktiv weiterentwickelbar**, wenn die nächsten Schritte weiter fokussiert bleiben.
 
 Mehr Details: [docs/PROJECT-STATUS.md](docs/PROJECT-STATUS.md)
 
@@ -85,16 +85,16 @@ npm run build
 Diese Punkte sollte man kennen, bevor man loslegt:
 
 1. **Kernpfade sind stabil, aber noch nicht vollständig aufgeräumt**
-   Build, CI sowie die Kern- und WebAPI-Tests laufen auf `next` reproduzierbar grün. Offen sind jedoch weiterhin mehrere Compiler-, Nullability- und Frontend-Warnungen.
+   Build, CI sowie Kern-, WebAPI-, Frontend- und UI-Smoke-Pfade laufen auf `next` reproduzierbar grün. Die wichtigsten offenen Lücken liegen inzwischen eher in fachlichen Runtime- und Betriebsfragen als in der nackten Build-Stabilität.
 
 2. **Expression-/V8-Thema nicht abgeschlossen**
    Test- und CI-Umgebungen laufen inzwischen auch ohne native V8-Abhängigkeit stabiler. Die vollständige FEEL-/V8-Strategie der Engine ist fachlich aber weiterhin ein eigener Architekturstrang.
 
-3. **Sicherheits- und Dependency-Lage weiter beobachten**
-   Die risikoarmen Updates wurden auf `next` bereits übernommen. Der Security-Status des Default-Branches und weitere Abhängigkeitsentscheidungen sollten dennoch aktiv beobachtet werden.
+3. **Timer-, Fehler- und Abbruchpfade sind verbessert, aber noch nicht vollständig**
+   Der Engine-Kern kann fällige Timer jetzt weiterführen, und rohe `NotImplementedException`-Abbrüche wurden in mehreren Pfaden entschärft. Persistierte Timer, Boundary-Timer, vollständige Fehler-/Eskalationssemantik und echte Kompensation bleiben aber offen.
 
-4. **Produktpfade bleiben im Ausbau**
-   `ICore` und die Console-Demo sind jetzt vorhanden. API-Verträge, UI-Smoke-Tests und weitere Contributor-Pfade werden in den nächsten Paketen weiter geschärft.
+4. **Betrieb und Auth sind noch nicht am Ziel**
+   Lokale Compose- und Runtime-Container sind vorhanden, aber Themen wie Telemetrie, Secrets, TLS, Recovery und eine belastbare Identity-/Auth-Story sind weiterhin Folgepakete.
 
 ## Dokumentation
 
@@ -112,10 +112,10 @@ Diese Punkte sollte man kennen, bevor man loslegt:
 
 Die sinnvolle Reihenfolge ist aktuell:
 
-1. **API- und DTO-Grenzen weiter schärfen**
-2. **Console-Demo und Contributor Experience weiter ausbauen**
-3. **Frontend-Smoke- und E2E-Pfade absichern**
-4. **Warnungen und Nullability-Themen schrittweise abbauen**
+1. **Timer-Persistenz, Scheduler-Anbindung und Boundary-Timer sauber nachziehen**
+2. **Auth-/Identity- und Fehlerpfade weiter produktionsnah härten**
+3. **Betriebsbasis mit Telemetrie, Secrets und Recovery vertiefen**
+4. **Status-, Architektur- und Contributor-Dokumentation laufend nachziehen**
 
 Details dazu stehen in [docs/ROADMAP.md](docs/ROADMAP.md).
 

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -62,7 +62,7 @@ Besonders relevant sind noch:
 - weiter ausgebautes Playwright-/E2E-Smoke-Set
 - Restlücken bei Timer-Persistenz, Boundary-Timern und echter Scheduler-Anbindung
 - weitere Auth-/Identity- und Fehlerpfade
-- Release-/Telemetry-/Secret-/Recovery-Story über die lokale Basis hinaus
+- Release-/Telemetrie-/Secret-/Recovery-Story über die lokale Basis hinaus
 
 ### 2. Es gibt noch Restlücken im Codebestand
 

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -48,6 +48,8 @@ Unter anderem bereits umgesetzt:
 - Demo-Console-App für einen nachvollziehbaren Happy Path
 - DTO-/Warnungsbereinigung und API-Härtung in mehreren Teilbereichen
 - Signal- und Service-Task-Subscriptions im Web-API-Pfad
+- Timer-Ausführung im Engine-Kern für fällige Timer-Starts und Intermediate-Timer-Catches
+- konsistentere Form-/Message-Fehlerverträge in Web-API und Business-Logic
 - Nullability- und Guard-Härtung in zentralen Frontend-Seiten
 - lokale Runtime-Containerbasis für API, Frontend und Gateway
 
@@ -58,14 +60,15 @@ Unter anderem bereits umgesetzt:
 Besonders relevant sind noch:
 
 - weiter ausgebautes Playwright-/E2E-Smoke-Set
-- Restlücken bei Auth-/Identity- und Fehlerpfaden
-- Release-/Telemetry-/Secret-Story über die lokale Basis hinaus
+- Restlücken bei Timer-Persistenz, Boundary-Timern und echter Scheduler-Anbindung
+- weitere Auth-/Identity- und Fehlerpfade
+- Release-/Telemetry-/Secret-/Recovery-Story über die lokale Basis hinaus
 
 ### 2. Es gibt noch Restlücken im Codebestand
 
 Noch offen sind unter anderem:
 
-- einzelne `NotImplementedException`-Stellen in Runtime-/Storage-Pfaden
+- Restlücken in Timer-, Boundary- und Kompensationssemantik
 - provisorische Auth-/Identity-Platzhalter
 - Betriebs- und Deployment-Themen wie Reverse Proxy, TLS, Logging-/Telemetry und Recovery
 - Altlasten und Doppelstrukturen im Repository
@@ -83,13 +86,15 @@ Die Basisdokumentation ist deutlich besser als zuvor, aber für die nächste Rei
 - Test- und E2E-Dokumentation
 - aktualisierte Status-/Roadmap-Texte bei größeren Fortschritten
 
-## Offene GitHub-Issues auf dem aktuellen Stand
+## Offener Backlog auf dem aktuellen Stand
 
-Die erste große Stabilisierungsrunde ist inzwischen weitgehend geschlossen. Der aktuelle nächste Ausbaupunkt ist:
+Die erste große Revitalisierungs- und Stabilisierungswelle ist inzwischen weitgehend abgearbeitet. Der nächste sinnvolle Backlog ergibt sich aktuell weniger aus alten Sammel-Issues, sondern aus den noch verbleibenden Produktlücken:
 
-- [#63 Release-Dockerfiles und runtime-nahe Compose-Variante ergänzen](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/63)
-
-Die frühere Frontend-Aufteilung über [#47](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/47) bis [#50](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/50) sowie die Härtungen [#52](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/52) bis [#55](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/55) sind bereits abgeschlossen.
+- Timer-Persistenz und Scheduler-Anbindung
+- Boundary-Timer und weitergehende BPMN-Fehler-/Eskalationssemantik
+- Auth-/Identity-Härtung
+- Telemetrie, Secrets, Recovery und operationsnahe Doku
+- weitere Architektur- und Repo-Hygiene
 
 ## Aktuelle Gesamtempfehlung
 
@@ -97,10 +102,10 @@ Das Projekt sollte jetzt **nicht mehr primär gerettet**, sondern gezielt **zur 
 
 Die sinnvolle Reihenfolge ist aus heutiger Sicht:
 
-1. runtime-nahe Release-Containerbasis sauber abschließen
-2. Reverse-Proxy-/Secret-/Telemetry-Story weiter schärfen
-3. verbleibende Runtime- und Auth-Lücken abbauen
-4. E2E- und Recovery-/Operations-Dokumentation weiter vertiefen
+1. Timer- und Runtime-Restlücken mit Persistenz-/Scheduler-Sicht weiter abbauen
+2. Auth-/Identity- und API-Verträge weiter schärfen
+3. Betriebsbasis um Telemetrie, Secrets, TLS und Recovery erweitern
+4. E2E-, Architektur- und Operations-Dokumentation weiter vertiefen
 
 ## Gesamturteil
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,54 +13,53 @@ Die erste große Stabilisierungsrunde ist bereits erfolgt:
 - Build- und CI-Basis stabilisiert
 - Demo-Console-App ergänzt
 - wesentliche Engine-/Subscription-/Frontend-Härtungen umgesetzt
+- Timer-Ausführung im Engine-Kern für fällige Start- und Intermediate-Timer ergänzt
+- Form-/Message-Fehlerverträge in der Web-API weiter geschärft
 - lokale und CI-nahe Testpfade wieder grün gemacht
 - lokale Runtime-Containerbasis für Release-nahe Prüfpfade ergänzt
 - das ursprüngliche Frontend-Epic (#7) und seine Teilpakete #47–#50 sind abgeschlossen
+- der erste große Revitalisierungs-Backlog ist damit weitgehend abgearbeitet
 
 Die Roadmap startet also **nicht mehr bei Null**, sondern baut auf einer funktionierenden Basis auf.
 
-## Priorität 1: Release-nahe Betriebsbasis abschließen
+## Priorität 1: Timer- und Runtime-Restlücken schließen
 
-### 1.1 Runtime-Container und Release-Compose ergänzen
+### 1.1 Timer-Persistenz und Scheduler-Anbindung
 
-Referenz: [#63](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/63)
+- persistierte Timer-Subscriptions ergänzen
+- Wiederaufnahme nach Neustart für fällige Timer vorbereiten
+- klaren Scheduler-/Polling-Pfad um `HandleTime(...)` modellieren und testen
 
-- dedizierte Runtime-Container für API und Frontend bereitstellen
-- Gateway-/Reverse-Proxy-Basis für Same-Origin-Betrieb ergänzen
-- lokalen Build-/Start-/Check-Pfad für echte Runtime-Images dokumentieren
+### 1.2 Boundary-Timer und BPMN-Fehlerpfade vertiefen
 
-### 1.2 Weitere Betriebsaspekte nachziehen
+- Boundary-Timer-Parsing und -Abarbeitung ergänzen
+- Error-/Escalation-Semantik jenseits des Best-Effort-Fallbacks modellieren
+- Kompensations- und Abbruchpfade weiter präzisieren
+
+## Priorität 2: Betriebs- und Auth-Reife erhöhen
+
+### 2.1 Operations-Basis über die lokale Compose-Story hinaus vertiefen
 
 - Metrics/Tracing
 - Secret-/Konfigurationsstory
 - Recovery-/Backup-Hinweise
 - Reverse-Proxy-/TLS-Härtung für echte Zielumgebungen
 
-## Priorität 2: Restliche Produktpfade vertiefen
+### 2.2 Auth-/Identity-Pfade weiter absichern
 
-### 2.1 Weitere E2E-/Smoke-Pfade ausbauen
+- Fallback-/Development-Pfade weiter reduzieren
+- Nutzer- und Rollenmodell klarer kapseln
+- API-Verträge und Betriebssignale entlang der Auth-Story ergänzen
+
+## Priorität 3: Test- und Dokumentationsreife nachziehen
+
+### 3.1 Weitere E2E-/Smoke-Pfade gezielt ausbauen
 
 - Kernpfade für Direktaufrufe, Refreshes und Betriebsfehler weiter ausbauen
 - Testdaten und Hilfslogik für reproduzierbare Läufe schaffen
 - die Suite klein und CI-tauglich halten
 
-### 2.2 API-Fehlerverträge und Auth-/Betriebssignale weiter verbessern
-
-- Fehlerantworten weiter vereinheitlichen
-- Betriebsmetriken ergänzen
-- Auth-Platzhalter technisch sauberer kapseln
-
-## Priorität 3: Restlücken abbauen
-
-### 3.1 Engine- und Runtime-Restbestand bereinigen
-
-- `NotImplementedException`-Stellen inventarisieren
-- produktionskritische Pfade priorisiert schließen
-- Regressionstests ergänzen
-
-### 3.2 Repository- und Dokumentationshygiene weiter verbessern
-
-Referenz: [#55](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/55)
+### 3.2 Architektur-, Status- und Repo-Hygiene weiter verbessern
 
 - Altlasten und Doppelstrukturen bewerten und bereinigen
 - Status- und Roadmap-Dokumente laufend aktualisieren
@@ -68,19 +67,21 @@ Referenz: [#55](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/55
 
 ## Empfohlene Reihenfolge der nächsten Sprints
 
-### Sprint A – Runtime-Container abschließen
+### Sprint A – Timer und Runtime
 
-- #63 Release-Dockerfiles und runtime-nahe Compose-Variante ergänzen
+- Timer-Persistenz
+- Scheduler-/Polling-Pfad
+- Boundary-Timer-Sicht
 
-### Sprint B – Betriebs- und E2E-Reife
+### Sprint B – Betrieb und Auth
 
-- Gateway-/Reverse-Proxy-Pfade weiter härten
-- zusätzliche direkte Refresh-/Fehlerpfade in Playwright abdecken
+- Telemetrie/Secrets/Recovery
+- Auth-/Identity-Härtung
 
-### Sprint C – Runtime- und Auth-Restlücken
+### Sprint C – E2E und Dokumentation
 
-- verbleibende Runtime-/Storage-/Auth-Lücken abbauen
-- Recovery- und Operations-Dokumentation vertiefen
+- zusätzliche E2E-/Smoke-Pfade
+- Architektur- und Operations-Dokumentation vertiefen
 
 ## Leitprinzip für die weitere Arbeit
 


### PR DESCRIPTION
## Zusammenfassung

Dieses PR bringt README, Projektstatus und Roadmap wieder auf den tatsächlichen Stand von `next`.

## Änderungen

- README auf den aktuellen Reifegrad und die neuen Kernpfade aktualisiert
- `docs/PROJECT-STATUS.md` an die Timer- und API-Härtungen angepasst
- `docs/ROADMAP.md` auf die jetzt realistischen nächsten Ausbaupakete umgestellt

## Validierung

- Doku-Update ohne Codeänderungen
- Inhalte gegen den aktuellen Stand von `next`, `docs/RUNTIME-GAPS.md` und die zuletzt gemergten Pakete abgeglichen

## Bezug

Closes #77
