### PR TITLE
Timer-Persistenz und Scheduler-Polling für Runtime-Pfade ergänzen

### DIFF
--- a/Model/ICatchHandler.cs
+++ b/Model/ICatchHandler.cs
@@ -5,6 +5,7 @@ namespace Model;
 public interface ICatchHandler
 {
     List<DateTime> ActiveTimers { get; }
+    List<TimerSubscriptionDescriptor> ActiveTimerSubscriptions { get; }
     List<MessageDefinition> ActiveCatchMessages { get; }
     List<string> ActiveCatchSignals { get;  }
     List<Token> ActiveUserTasks();

--- a/Model/TimerSubscription.cs
+++ b/Model/TimerSubscription.cs
@@ -1,0 +1,17 @@
+namespace Model;
+
+/// <summary>
+/// Persistierbarer Laufzeiteintrag für fällige Timer in deployten Definitionen oder laufenden Instanzen.
+/// </summary>
+public class TimerSubscription
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+    public required DateTime DueAt { get; init; }
+    public required string FlowNodeId { get; init; }
+    public required TimerSubscriptionKind Kind { get; init; }
+    public required string ProcessId { get; init; }
+    public required string RelatedDefinitionId { get; init; }
+    public required Guid DefinitionId { get; init; }
+    public Guid? ProcessInstanceId { get; init; }
+    public Guid? TokenId { get; init; }
+}

--- a/Model/TimerSubscriptionDescriptor.cs
+++ b/Model/TimerSubscriptionDescriptor.cs
@@ -1,0 +1,10 @@
+namespace Model;
+
+/// <summary>
+/// Beschreibt einen aktiven Timer aus Sicht der Runtime, bevor daraus ein persistierter Subscription-Eintrag wird.
+/// </summary>
+public record TimerSubscriptionDescriptor(
+    DateTime DueAt,
+    string FlowNodeId,
+    TimerSubscriptionKind Kind,
+    Guid? TokenId = null);

--- a/Model/TimerSubscriptionKind.cs
+++ b/Model/TimerSubscriptionKind.cs
@@ -1,0 +1,7 @@
+namespace Model;
+
+public enum TimerSubscriptionKind
+{
+    ProcessStartEvent,
+    IntermediateCatchEvent
+}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Die bisherige Dokumentation klang teilweise deutlich reifer als der aktuelle Sta
 - Es gibt bereits eine **brauchbare Kernarchitektur**.
 - Es gibt **fachlich wertvolle Tests, BPMN-Beispiele und eine grüne CI-Basis auf `next`**.
 - Zentrale Produktpfade wie Demo, UI-Smokes, API-Fehlerverträge und ein erster Timer-Kernpfad sind inzwischen vorhanden.
-- Es gibt aber weiterhin **offene Restlücken** bei Timer-Persistenz, Boundary-Timern, Auth/Identity und Betriebsreife.
+- Timer-Subscriptions werden jetzt auch in Storage/Web-API persistiert und über einen kleinen Scheduler-Polling-Pfad verarbeitet.
+- Es gibt aber weiterhin **offene Restlücken** bei Boundary-Timern, weitergehender Timer-Semantik, Auth/Identity und Betriebsreife.
 - Das Projekt ist **klar revivierbar und aktiv weiterentwickelbar**, wenn die nächsten Schritte weiter fokussiert bleiben.
 
 Mehr Details: [docs/PROJECT-STATUS.md](docs/PROJECT-STATUS.md)
@@ -112,7 +113,7 @@ Diese Punkte sollte man kennen, bevor man loslegt:
 
 Die sinnvolle Reihenfolge ist aktuell:
 
-1. **Timer-Persistenz, Scheduler-Anbindung und Boundary-Timer sauber nachziehen**
+1. **Boundary-Timer und weitergehende Timer-/Fehlersemantik sauber nachziehen**
 2. **Auth-/Identity- und Fehlerpfade weiter produktionsnah härten**
 3. **Betriebsbasis mit Telemetrie, Secrets und Recovery vertiefen**
 4. **Status-, Architektur- und Contributor-Dokumentation laufend nachziehen**
@@ -167,6 +168,24 @@ Für einen reproduzierbaren API-/Frontend-Start gibt es jetzt zusätzlich einen 
 ```
 
 Weitere Betriebs- und Diagnosehinweise stehen in [docs/OPERATIONS.md](docs/OPERATIONS.md).
+
+## Timer-Scheduler im Web-API-Host
+
+Die Web-API enthält jetzt zusätzlich einen kleinen Hintergrund-Poller für fällige Timer-Subscriptions.
+
+Relevante Konfiguration:
+
+```json
+"TimerScheduler": {
+  "Enabled": true,
+  "PollIntervalSeconds": 5
+}
+```
+
+Zusätzlich sichtbar sind Timer-Subscriptions jetzt über:
+
+- `GET /timer`
+- `GET /instance/{instanceId}/subscription/timers`
 
 ## Runtime-Container für lokale Release-Checks
 

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -49,6 +49,8 @@ Unter anderem bereits umgesetzt:
 - DTO-/Warnungsbereinigung und API-Härtung in mehreren Teilbereichen
 - Signal- und Service-Task-Subscriptions im Web-API-Pfad
 - Timer-Ausführung im Engine-Kern für fällige Timer-Starts und Intermediate-Timer-Catches
+- persistierte Timer-Subscriptions in Storage und Web-API
+- kleiner Scheduler-/Polling-Pfad im Web-API-Host für fällige Timer
 - konsistentere Form-/Message-Fehlerverträge in Web-API und Business-Logic
 - Nullability- und Guard-Härtung in zentralen Frontend-Seiten
 - lokale Runtime-Containerbasis für API, Frontend und Gateway
@@ -60,7 +62,7 @@ Unter anderem bereits umgesetzt:
 Besonders relevant sind noch:
 
 - weiter ausgebautes Playwright-/E2E-Smoke-Set
-- Restlücken bei Timer-Persistenz, Boundary-Timern und echter Scheduler-Anbindung
+- Restlücken bei Boundary-Timern, wiederkehrenden Timer-Strategien und weitergehender Scheduler-/Recovery-Semantik
 - weitere Auth-/Identity- und Fehlerpfade
 - Release-/Telemetrie-/Secret-/Recovery-Story über die lokale Basis hinaus
 
@@ -90,7 +92,6 @@ Die Basisdokumentation ist deutlich besser als zuvor, aber für die nächste Rei
 
 Die erste große Revitalisierungs- und Stabilisierungswelle ist inzwischen weitgehend abgearbeitet. Der nächste sinnvolle Backlog ergibt sich aktuell weniger aus alten Sammel-Issues, sondern aus den noch verbleibenden Produktlücken:
 
-- Timer-Persistenz und Scheduler-Anbindung
 - Boundary-Timer und weitergehende BPMN-Fehler-/Eskalationssemantik
 - Auth-/Identity-Härtung
 - Telemetrie, Secrets, Recovery und operationsnahe Doku
@@ -102,7 +103,7 @@ Das Projekt sollte jetzt **nicht mehr primär gerettet**, sondern gezielt **zur 
 
 Die sinnvolle Reihenfolge ist aus heutiger Sicht:
 
-1. Timer- und Runtime-Restlücken mit Persistenz-/Scheduler-Sicht weiter abbauen
+1. Boundary-Timer sowie weitergehende Timer-/Recovery-Semantik weiter abbauen
 2. Auth-/Identity- und API-Verträge weiter schärfen
 3. Betriebsbasis um Telemetrie, Secrets, TLS und Recovery erweitern
 4. E2E-, Architektur- und Operations-Dokumentation weiter vertiefen

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,6 +14,8 @@ Die erste große Stabilisierungsrunde ist bereits erfolgt:
 - Demo-Console-App ergänzt
 - wesentliche Engine-/Subscription-/Frontend-Härtungen umgesetzt
 - Timer-Ausführung im Engine-Kern für fällige Start- und Intermediate-Timer ergänzt
+- persistierte Timer-Subscriptions in Storage/Web-API ergänzt
+- Scheduler-/Polling-Pfad für fällige Timer im Web-API-Host ergänzt
 - Form-/Message-Fehlerverträge in der Web-API weiter geschärft
 - lokale und CI-nahe Testpfade wieder grün gemacht
 - lokale Runtime-Containerbasis für Release-nahe Prüfpfade ergänzt
@@ -24,17 +26,17 @@ Die Roadmap startet also **nicht mehr bei Null**, sondern baut auf einer funktio
 
 ## Priorität 1: Timer- und Runtime-Restlücken schließen
 
-### 1.1 Timer-Persistenz und Scheduler-Anbindung
-
-- persistierte Timer-Subscriptions ergänzen
-- Wiederaufnahme nach Neustart für fällige Timer vorbereiten
-- klaren Scheduler-/Polling-Pfad um `HandleTime(...)` modellieren und testen
-
 ### 1.2 Boundary-Timer und BPMN-Fehlerpfade vertiefen
 
 - Boundary-Timer-Parsing und -Abarbeitung ergänzen
 - Error-/Escalation-Semantik jenseits des Best-Effort-Fallbacks modellieren
 - Kompensations- und Abbruchpfade weiter präzisieren
+
+### 1.3 Timer-Recovery und wiederkehrende Strategien vertiefen
+
+- Recovery-Verhalten für bereits persistierte Timer nach Neustarts weiter härten
+- wiederkehrende Start-Timer über den ersten Due-Zeitpunkt hinaus sauber modellieren
+- Boundary-Timer später in denselben Persistenz-/Scheduler-Pfad integrieren
 
 ## Priorität 2: Betriebs- und Auth-Reife erhöhen
 
@@ -67,11 +69,11 @@ Die Roadmap startet also **nicht mehr bei Null**, sondern baut auf einer funktio
 
 ## Empfohlene Reihenfolge der nächsten Sprints
 
-### Sprint A – Timer und Runtime
+### Sprint A – Timer-Runtime vertiefen
 
-- Timer-Persistenz
-- Scheduler-/Polling-Pfad
 - Boundary-Timer-Sicht
+- Timer-Recovery
+- wiederkehrende Timer-Strategien
 
 ### Sprint B – Betrieb und Auth
 

--- a/docs/RUNTIME-GAPS.md
+++ b/docs/RUNTIME-GAPS.md
@@ -18,13 +18,25 @@ Dieses Dokument hält die aktuell noch offenen Laufzeit- und Engine-Lücken fest
 - `InstanceEngine.HandleTime(...)` kann fällige `FlowzerIntermediateTimerCatchEvent`-Tokens jetzt weiterführen.
 - Die zugehörigen Engine-Regressionstests decken Start- und Intermediate-Timer jetzt explizit ab.
 
-### 3. User-Task-Ergebnisse haben einen stabileren Laufzeitvertrag
+### 3. Timer-Subscriptions sind jetzt als Runtime-Vertrag persistiert
+
+- Timer-Subscriptions werden jetzt analog zu anderen Runtime-Subscriptions in Storage und Web-API abgelegt.
+- `BpmnBusinessLogic` speichert aktive Start- und Intermediate-Timer jetzt als `TimerSubscription`.
+- `GET /timer` und `GET /instance/{instanceId}/subscription/timers` machen die aktiven Timer im API-Pfad sichtbar.
+
+### 4. Ein kleiner Scheduler-/Polling-Pfad ist jetzt vorhanden
+
+- Die Web-API startet jetzt einen Hintergrunddienst, der fällige Timer regelmäßig über `HandleTime(...)` verarbeitet.
+- Beim Start werden persistierte Instanz-Timer erneut aus den gespeicherten Tokenzuständen synchronisiert.
+- Das Poll-Intervall ist über `TimerScheduler:PollIntervalSeconds` konfigurierbar.
+
+### 5. User-Task-Ergebnisse haben einen stabileren Laufzeitvertrag
 
 - User-Task-Ergebnisse ohne `ProcessInstanceId` laufen nicht mehr in eine rohe `NotImplementedException`.
 - Stattdessen kommt ein valider `400 Bad Request` mit einem klaren API-Fehlervertrag zurück.
 - Zusätzlich wird jetzt geprüft, ob das übergebene `TokenId` wirklich noch aktiv ist und zum erwarteten `FlowNodeId` gehört.
 
-### 4. Instanzabbruch ist als Best-Effort-Pfad verfügbar
+### 6. Instanzabbruch ist als Best-Effort-Pfad verfügbar
 
 - `InstanceEngine.Cancel()` terminiert jetzt aktive/wartende Tokens der Instanz konsistent.
 - Das ersetzt noch **keine vollständige BPMN-Kompensation**, verhindert aber, dass der API-/Runtime-Pfad an einer nackten `NotImplementedException` scheitert.
@@ -38,12 +50,12 @@ Aktuell vorhanden:
 - Timer-Fälligkeiten für Start- und laufende Instanzen
 - Timer-Catch-Events als wartende Zustände
 - einmaliger Engine-Kernpfad für fällige Timer-Starts und Intermediate-Timer
+- persistierte Timer-Subscriptions in Storage und Web-API
+- kleiner Scheduler-/Polling-Pfad rund um `HandleTime(...)`
 
 Weiterhin offen:
 
-- persistierte Timer-Subscriptions in Storage/API
-- Wiederaufnahme nach Neustart nur auf Basis gespeicherter Timerzustände
-- Scheduler-/API-Anbindung rund um `HandleTime(...)`
+- Recovery-Strategie für bereits persistierte Start-Timer über harte Neustarts hinweg weiter schärfen
 - Boundary-Timer-Parsing und -Abarbeitung
 - vollständige Wiederholungsstrategie für zyklische Start-Timer über den ersten Due-Zeitpunkt hinaus
 
@@ -76,7 +88,7 @@ Nicht enthalten:
 
 ## Empfohlene nächste Runtime-Schritte
 
-1. Timer-Storage + Scheduler-Pfad ergänzen
-2. Boundary-Timer parsen und persistierbar machen
+1. Boundary-Timer parsen und in den Persistenzpfad integrieren
+2. Recovery- und Wiederholungsstrategie für Start-Timer weiter härten
 3. Error-/Escalation-Semantik gezielt modellieren und testen
 4. `Cancel()` später um echte Kompensationsstrategien erweitern

--- a/src/FilesystemStorageSystem/MessageSubscriptionStorage.cs
+++ b/src/FilesystemStorageSystem/MessageSubscriptionStorage.cs
@@ -208,4 +208,57 @@ public class MessageSubscriptionStorage : IMessageSubscriptionStorage
 
         return Task.CompletedTask;
     }
+
+    public Task<IEnumerable<TimerSubscription>> GetAllTimerSubscriptions()
+    {
+        return Task.FromResult(Directory.GetFiles(_messageSubscriptionsPath, "timer_*.json").Select(file =>
+        {
+            var content = File.ReadAllText(file);
+            return JsonConvert.DeserializeObject<TimerSubscription>(content, _newtonSoftDefaultSettings)!;
+        }));
+    }
+
+    public async Task<IEnumerable<TimerSubscription>> GetTimerSubscriptions(Guid instanceId)
+    {
+        var subscriptions = await GetAllTimerSubscriptions();
+        return subscriptions.Where(subscription => subscription.ProcessInstanceId == instanceId);
+    }
+
+    public Task AddTimerSubscription(TimerSubscription timerSubscription)
+    {
+        var fullFileName = Path.Combine(_messageSubscriptionsPath, $"timer_{timerSubscription.Id}.json");
+        var data = JsonConvert.SerializeObject(timerSubscription, _newtonSoftDefaultSettings);
+        return File.WriteAllTextAsync(fullFileName, data);
+    }
+
+    public Task RemoveTimerSubscription(Guid timerSubscriptionId)
+    {
+        var files = Directory.GetFiles(_messageSubscriptionsPath, $"timer_{timerSubscriptionId}.json");
+        foreach (var file in files)
+        {
+            File.Delete(file);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public async Task RemoveProcessTimerSubscriptionsByProcessInstanceId(Guid instanceId)
+    {
+        var subscriptions = await GetAllTimerSubscriptions();
+        foreach (var subscription in subscriptions.Where(subscription => subscription.ProcessInstanceId == instanceId))
+        {
+            await RemoveTimerSubscription(subscription.Id);
+        }
+    }
+
+    public async Task RemoveAllProcessTimerSubscriptionsWithNoInstanceId(string relatedDefinitionId)
+    {
+        var subscriptions = await GetAllTimerSubscriptions();
+        foreach (var subscription in subscriptions.Where(subscription =>
+                     string.Equals(subscription.RelatedDefinitionId, relatedDefinitionId, StringComparison.Ordinal) &&
+                     subscription.ProcessInstanceId == null))
+        {
+            await RemoveTimerSubscription(subscription.Id);
+        }
+    }
 }

--- a/src/StorageSystemShared/IMessageSubscriptionStorage.cs
+++ b/src/StorageSystemShared/IMessageSubscriptionStorage.cs
@@ -38,6 +38,17 @@ public interface IMessageSubscriptionStorage
     Task RemoveAllUserTaskSubscriptionsWithNoInstanceId(string relatedDefinitionId);
     #endregion
 
+    #region Timers
+
+    Task<IEnumerable<TimerSubscription>> GetAllTimerSubscriptions();
+    Task<IEnumerable<TimerSubscription>> GetTimerSubscriptions(Guid instanceId);
+    Task AddTimerSubscription(TimerSubscription timerSubscription);
+    Task RemoveTimerSubscription(Guid timerSubscriptionId);
+    Task RemoveProcessTimerSubscriptionsByProcessInstanceId(Guid instanceId);
+    Task RemoveAllProcessTimerSubscriptionsWithNoInstanceId(string relatedDefinitionId);
+
+    #endregion
+
 
 
 }

--- a/src/WebApiEngine.Shared/TimerSubscriptionDto.cs
+++ b/src/WebApiEngine.Shared/TimerSubscriptionDto.cs
@@ -1,0 +1,14 @@
+namespace WebApiEngine.Shared;
+
+public class TimerSubscriptionDto
+{
+    public Guid Id { get; set; }
+    public DateTime DueAt { get; set; }
+    public string FlowNodeId { get; set; } = string.Empty;
+    public string ProcessId { get; set; } = string.Empty;
+    public string RelatedDefinitionId { get; set; } = string.Empty;
+    public Guid DefinitionId { get; set; }
+    public Guid? ProcessInstanceId { get; set; }
+    public Guid? TokenId { get; set; }
+    public string Kind { get; set; } = string.Empty;
+}

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Model;
@@ -313,6 +314,13 @@ public class ApiHardeningIntegrationTest
         protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
         {
             builder.UseSetting(WebHostDefaults.EnvironmentKey, "Development");
+            builder.ConfigureAppConfiguration((_, configBuilder) =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["TimerScheduler:Enabled"] = "false"
+                });
+            });
             builder.ConfigureServices(services =>
             {
                 services.RemoveAll<IStorageSystem>();
@@ -524,6 +532,20 @@ public class ApiHardeningIntegrationTest
         }
 
         public Task RemoveAllUserTaskSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
+
+        public Task<IEnumerable<TimerSubscription>> GetAllTimerSubscriptions() =>
+            Task.FromResult(Enumerable.Empty<TimerSubscription>());
+
+        public Task<IEnumerable<TimerSubscription>> GetTimerSubscriptions(Guid instanceId) =>
+            Task.FromResult(Enumerable.Empty<TimerSubscription>());
+
+        public Task AddTimerSubscription(TimerSubscription timerSubscription) => Task.CompletedTask;
+
+        public Task RemoveTimerSubscription(Guid timerSubscriptionId) => Task.CompletedTask;
+
+        public Task RemoveProcessTimerSubscriptionsByProcessInstanceId(Guid instanceId) => Task.CompletedTask;
+
+        public Task RemoveAllProcessTimerSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
     }
 
     private sealed class TestInstanceStorage : IInstanceStorage

--- a/src/WebApiEngine.Tests/FormControllerIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/FormControllerIntegrationTest.cs
@@ -1,7 +1,9 @@
 using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Model;
@@ -151,6 +153,14 @@ public class FormControllerIntegrationTest
     {
         protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
         {
+            builder.ConfigureAppConfiguration((_, configBuilder) =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["TimerScheduler:Enabled"] = "false"
+                });
+            });
+
             builder.ConfigureServices(services =>
             {
                 services.RemoveAll<IStorageSystem>();
@@ -308,6 +318,12 @@ public class FormControllerIntegrationTest
         public Task RemoveUserTaskSubscription(Guid userTaskSubscriptionId) => Task.CompletedTask;
         public void RemoveAllUserTaskSubscriptionsByInstanceId(Guid instanceId) { }
         public Task RemoveAllUserTaskSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
+        public Task<IEnumerable<TimerSubscription>> GetAllTimerSubscriptions() => Task.FromResult(Enumerable.Empty<TimerSubscription>());
+        public Task<IEnumerable<TimerSubscription>> GetTimerSubscriptions(Guid instanceId) => Task.FromResult(Enumerable.Empty<TimerSubscription>());
+        public Task AddTimerSubscription(TimerSubscription timerSubscription) => Task.CompletedTask;
+        public Task RemoveTimerSubscription(Guid timerSubscriptionId) => Task.CompletedTask;
+        public Task RemoveProcessTimerSubscriptionsByProcessInstanceId(Guid instanceId) => Task.CompletedTask;
+        public Task RemoveAllProcessTimerSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
     }
 
     private sealed class NoOpInstanceStorage : IInstanceStorage

--- a/src/WebApiEngine.Tests/InstanceControllerIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/InstanceControllerIntegrationTest.cs
@@ -1,7 +1,9 @@
 using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Model;
@@ -62,6 +64,38 @@ public class InstanceControllerIntegrationTest
     }
 
     [Test]
+    public async Task GetTimerSubscriptions_ShouldReturnTimersForInstance()
+    {
+        var instanceId = Guid.NewGuid();
+        var storage = TestStorage.CreateWithInstance(instanceId);
+        storage.SubscriptionStorageSeed.TimerSubscriptions.Add(new TimerSubscription
+        {
+            DueAt = DateTime.UtcNow.AddMinutes(3),
+            FlowNodeId = "TimerCatch_1",
+            Kind = TimerSubscriptionKind.IntermediateCatchEvent,
+            ProcessId = "Process_Invoice",
+            RelatedDefinitionId = "invoice-process",
+            DefinitionId = storage.DefinitionId,
+            ProcessInstanceId = instanceId,
+            TokenId = Guid.NewGuid()
+        });
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync($"/instance/{instanceId}/subscription/timers");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<TimerSubscriptionDto[]>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeTrue();
+        payload.Result.Should().ContainSingle();
+        payload.Result![0].FlowNodeId.Should().Be("TimerCatch_1");
+        payload.Result[0].ProcessInstanceId.Should().Be(instanceId);
+        payload.Result[0].Kind.Should().Be(nameof(TimerSubscriptionKind.IntermediateCatchEvent));
+    }
+
+    [Test]
     public async Task GetAllInstances_ShouldIncludeFinishedInstances_ForDoneAndErrorFilters()
     {
         var activeInstanceId = Guid.NewGuid();
@@ -93,6 +127,14 @@ public class InstanceControllerIntegrationTest
     {
         protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
         {
+            builder.ConfigureAppConfiguration((_, configBuilder) =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["TimerScheduler:Enabled"] = "false"
+                });
+            });
+
             builder.ConfigureServices(services =>
             {
                 services.RemoveAll<IStorageSystem>();
@@ -277,6 +319,7 @@ public class InstanceControllerIntegrationTest
     private sealed class TestMessageSubscriptionStorage : IMessageSubscriptionStorage
     {
         public List<SignalSubscription> SignalSubscriptions { get; } = [];
+        public List<TimerSubscription> TimerSubscriptions { get; } = [];
 
         public Task<IEnumerable<MessageSubscription>> GetAllMessageSubscriptions() =>
             Task.FromResult(Enumerable.Empty<MessageSubscription>());
@@ -316,6 +359,38 @@ public class InstanceControllerIntegrationTest
         public Task RemoveUserTaskSubscription(Guid userTaskSubscriptionId) => Task.CompletedTask;
         public void RemoveAllUserTaskSubscriptionsByInstanceId(Guid instanceId) { }
         public Task RemoveAllUserTaskSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
+
+        public Task<IEnumerable<TimerSubscription>> GetAllTimerSubscriptions() =>
+            Task.FromResult(TimerSubscriptions.AsEnumerable());
+
+        public Task<IEnumerable<TimerSubscription>> GetTimerSubscriptions(Guid instanceId) =>
+            Task.FromResult(TimerSubscriptions.Where(subscription => subscription.ProcessInstanceId == instanceId).AsEnumerable());
+
+        public Task AddTimerSubscription(TimerSubscription timerSubscription)
+        {
+            TimerSubscriptions.Add(timerSubscription);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveTimerSubscription(Guid timerSubscriptionId)
+        {
+            TimerSubscriptions.RemoveAll(subscription => subscription.Id == timerSubscriptionId);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveProcessTimerSubscriptionsByProcessInstanceId(Guid instanceId)
+        {
+            TimerSubscriptions.RemoveAll(subscription => subscription.ProcessInstanceId == instanceId);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveAllProcessTimerSubscriptionsWithNoInstanceId(string relatedDefinitionId)
+        {
+            TimerSubscriptions.RemoveAll(subscription =>
+                subscription.ProcessInstanceId == null &&
+                string.Equals(subscription.RelatedDefinitionId, relatedDefinitionId, StringComparison.Ordinal));
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class TestInstanceStorage(params ProcessInstanceInfo[] instances) : IInstanceStorage

--- a/src/WebApiEngine.Tests/TimerControllerIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/TimerControllerIntegrationTest.cs
@@ -1,0 +1,201 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Model;
+using StorageSystem;
+using WebApiEngine.Shared;
+
+namespace WebApiEngine.Tests;
+
+[NonParallelizable]
+public class TimerControllerIntegrationTest
+{
+    [Test]
+    public async Task GetAllTimers_ShouldReturnDefinitionAndInstanceScopedTimerSubscriptions()
+    {
+        var definitionId = Guid.NewGuid();
+        var instanceId = Guid.NewGuid();
+        var storage = new TestStorage();
+        storage.SubscriptionStorageSeed.TimerSubscriptions.AddRange(
+        [
+            new TimerSubscription
+            {
+                DueAt = DateTime.UtcNow.AddMinutes(1),
+                FlowNodeId = "StartEvent_Timer",
+                Kind = TimerSubscriptionKind.ProcessStartEvent,
+                ProcessId = "Process_Start",
+                RelatedDefinitionId = "definition-start",
+                DefinitionId = definitionId
+            },
+            new TimerSubscription
+            {
+                DueAt = DateTime.UtcNow.AddMinutes(2),
+                FlowNodeId = "TimerCatch_1",
+                Kind = TimerSubscriptionKind.IntermediateCatchEvent,
+                ProcessId = "Process_Catch",
+                RelatedDefinitionId = "definition-catch",
+                DefinitionId = definitionId,
+                ProcessInstanceId = instanceId,
+                TokenId = Guid.NewGuid()
+            }
+        ]);
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/timer");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<TimerSubscriptionDto[]>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeTrue();
+        payload.Result.Should().HaveCount(2);
+        payload.Result!.Should().Contain(subscription => subscription.Kind == nameof(TimerSubscriptionKind.ProcessStartEvent));
+        payload.Result.Should().Contain(subscription => subscription.ProcessInstanceId == instanceId);
+    }
+
+    private sealed class TestWebApplicationFactory(TestStorage storage) : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
+        {
+            builder.ConfigureAppConfiguration((_, configBuilder) =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["TimerScheduler:Enabled"] = "false"
+                });
+            });
+
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IStorageSystem>();
+                services.RemoveAll<ITransactionalStorageProvider>();
+
+                services.AddSingleton<IStorageSystem>(storage);
+                services.AddSingleton<ITransactionalStorageProvider>(new TestTransactionalStorageProvider(storage));
+            });
+        }
+    }
+
+    private sealed class TestTransactionalStorageProvider(TestStorage storage) : ITransactionalStorageProvider
+    {
+        public ITransactionalStorage GetTransactionalStorage()
+        {
+            return storage;
+        }
+    }
+
+    private sealed class TestStorage : ITransactionalStorage
+    {
+        public TestTimerSubscriptionStorage SubscriptionStorageSeed { get; } = new();
+
+        public IDefinitionStorage DefinitionStorage { get; } = new NoOpDefinitionStorage();
+        public IMessageSubscriptionStorage SubscriptionStorage => SubscriptionStorageSeed;
+        public IInstanceStorage InstanceStorage { get; } = new NoOpInstanceStorage();
+        public IFormStorage FormStorage { get; } = new NoOpFormStorage();
+
+        public void CommitChanges()
+        {
+        }
+
+        public void RollbackTransaction()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class TestTimerSubscriptionStorage : IMessageSubscriptionStorage
+    {
+        public List<TimerSubscription> TimerSubscriptions { get; } = [];
+
+        public Task<IEnumerable<MessageSubscription>> GetAllMessageSubscriptions() => Task.FromResult(Enumerable.Empty<MessageSubscription>());
+        public Task<IEnumerable<MessageSubscription>> GetMessageSubscription(string messageName, string? correlationKey, Guid? messageInstanceId) => Task.FromResult(Enumerable.Empty<MessageSubscription>());
+        public Task<IEnumerable<MessageSubscription>> GetMessageSubscription(Guid instanceId) => Task.FromResult(Enumerable.Empty<MessageSubscription>());
+        public Task AddMessageSubscription(MessageSubscription messageSubscription) => Task.CompletedTask;
+        public Task RemoveProcessMessageSubscriptionsByProcessInstanceId(Guid instanceId) => Task.CompletedTask;
+        public Task RemoveAllProcessMessageSubscriptionsWithNoInstancedId(string metaDefinitionId) => Task.CompletedTask;
+        public Task RemoveAllProcessSignalSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
+        public void AddSignalSubscription(SignalSubscription signalSubscription) { }
+        public Task<IEnumerable<SignalSubscription>> GetSignalSubscriptions(Guid instanceId) => Task.FromResult(Enumerable.Empty<SignalSubscription>());
+        public void RemoveProcessSingalSubscriptionsByProcessInstanceId(Guid instanceId) { }
+        public Task<IEnumerable<UserTaskSubscription>> GetAllUserTasks(Guid instanceId) => Task.FromResult(Enumerable.Empty<UserTaskSubscription>());
+        public Task<IEnumerable<ExtendedUserTaskSubscription>> GetAllUserTasksExtended(Guid userId) => Task.FromResult(Enumerable.Empty<ExtendedUserTaskSubscription>());
+        public Task AddUserTaskSubscription(UserTaskSubscription userTasks) => Task.CompletedTask;
+        public Task RemoveUserTaskSubscription(Guid userTaskSubscriptionId) => Task.CompletedTask;
+        public void RemoveAllUserTaskSubscriptionsByInstanceId(Guid instanceId) { }
+        public Task RemoveAllUserTaskSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
+        public Task<IEnumerable<TimerSubscription>> GetAllTimerSubscriptions() => Task.FromResult(TimerSubscriptions.AsEnumerable());
+        public Task<IEnumerable<TimerSubscription>> GetTimerSubscriptions(Guid instanceId) => Task.FromResult(TimerSubscriptions.Where(subscription => subscription.ProcessInstanceId == instanceId).AsEnumerable());
+
+        public Task AddTimerSubscription(TimerSubscription timerSubscription)
+        {
+            TimerSubscriptions.Add(timerSubscription);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveTimerSubscription(Guid timerSubscriptionId)
+        {
+            TimerSubscriptions.RemoveAll(subscription => subscription.Id == timerSubscriptionId);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveProcessTimerSubscriptionsByProcessInstanceId(Guid instanceId)
+        {
+            TimerSubscriptions.RemoveAll(subscription => subscription.ProcessInstanceId == instanceId);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveAllProcessTimerSubscriptionsWithNoInstanceId(string relatedDefinitionId)
+        {
+            TimerSubscriptions.RemoveAll(subscription => subscription.ProcessInstanceId == null && subscription.RelatedDefinitionId == relatedDefinitionId);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class NoOpDefinitionStorage : IDefinitionStorage
+    {
+        public Task StoreBinary(Guid guid, string data) => Task.CompletedTask;
+        public Task<string> GetBinary(Guid guid) => throw new NotSupportedException();
+        public Task<Guid[]> GetAllBinaryDefinitions() => Task.FromResult(Array.Empty<Guid>());
+        public Task<BpmnDefinition[]> GetAllDefinitions() => Task.FromResult(Array.Empty<BpmnDefinition>());
+        public Task StoreDefinition(BpmnDefinition definition) => Task.CompletedTask;
+        public Task<Model.Version?> GetMaxVersionId(string modelId) => Task.FromResult<Model.Version?>(null);
+        public Task<BpmnDefinition> GetDefinitionById(Guid id) => throw new NotSupportedException();
+        public Task<BpmnDefinition> GetLatestDefinition(string definitionId) => throw new NotSupportedException();
+        public Task<BpmnDefinition?> GetDeployedDefinition(string definitionDefinitionId) => Task.FromResult<BpmnDefinition?>(null);
+        public Task<ExtendedBpmnMetaDefinition[]> GetAllMetaDefinitions() => Task.FromResult(Array.Empty<ExtendedBpmnMetaDefinition>());
+        public Task StoreMetaDefinition(BpmnMetaDefinition metaDefinition) => Task.CompletedTask;
+        public Task UpdateMetaDefinition(BpmnMetaDefinition metaDefinition) => Task.CompletedTask;
+        public Task<BpmnMetaDefinition> GetMetaDefinitionById(string id) => throw new NotSupportedException();
+    }
+
+    private sealed class NoOpInstanceStorage : IInstanceStorage
+    {
+        public Task<ProcessInstanceInfo> GetProcessInstance(Guid processInstanceId) => throw new NotSupportedException();
+        public Task AddOrUpdateInstance(ProcessInstanceInfo processInstanceInfo) => Task.CompletedTask;
+        public Task<IEnumerable<ProcessInstanceInfo>> GetAllActiveInstances() => Task.FromResult(Enumerable.Empty<ProcessInstanceInfo>());
+        public Task<IEnumerable<ProcessInstanceInfo>> GetAllInstances() => Task.FromResult(Enumerable.Empty<ProcessInstanceInfo>());
+    }
+
+    private sealed class NoOpFormStorage : IFormStorage
+    {
+        public Task SaveFormMetaData(FormMetadata formMetadata) => Task.CompletedTask;
+        public Task<FormMetadata> GetFormMetaData(Guid formId) => throw new NotSupportedException();
+        public Task<IEnumerable<FormMetadata>> GetFormMetadatas() => Task.FromResult(Enumerable.Empty<FormMetadata>());
+        public Task UpdateFormMetaData(FormMetadata formMetaData) => Task.CompletedTask;
+        public Task DeleteFormMetaData(Guid formId) => Task.CompletedTask;
+        public Task SaveForm(Form form) => Task.CompletedTask;
+        public Task<Form> GetForm(Guid id) => throw new NotSupportedException();
+        public Task<IEnumerable<Form>> GetForms(Guid formId) => Task.FromResult(Enumerable.Empty<Form>());
+        public Task DeleteForm(Guid id) => Task.CompletedTask;
+        public Task<Model.Version> GetMaxVersion(Guid formId) => Task.FromResult(new Model.Version());
+    }
+}

--- a/src/WebApiEngine.Tests/TimerRuntimeIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/TimerRuntimeIntegrationTest.cs
@@ -1,0 +1,379 @@
+using BPMN.Process;
+using core_engine;
+using core_engine.Extensions;
+using FluentAssertions;
+using Model;
+using StorageSystem;
+using WebApiEngine.BusinessLogic;
+
+namespace WebApiEngine.Tests;
+
+[NonParallelizable]
+public class TimerRuntimeIntegrationTest
+{
+    [Test]
+    public async Task DeployDefinition_ShouldPersistProcessStartTimerSubscription()
+    {
+        var definition = CreateDefinition();
+        var storage = new TimerRuntimeTestStorage();
+        storage.Definitions[definition.Id] = definition;
+        storage.Binaries[definition.Id] = CreateTimerStartXml();
+
+        var businessLogic = new BpmnBusinessLogic(new TestTransactionalStorageProvider(storage));
+
+        var beforeDeploy = DateTime.UtcNow;
+        await businessLogic.DeployDefinition(definition);
+        var afterDeploy = DateTime.UtcNow;
+
+        storage.TimerSubscriptions.Should().ContainSingle();
+        var timerSubscription = storage.TimerSubscriptions.Single();
+        timerSubscription.ProcessInstanceId.Should().BeNull();
+        timerSubscription.Kind.Should().Be(TimerSubscriptionKind.ProcessStartEvent);
+        timerSubscription.FlowNodeId.Should().Be("StartEvent_Timer");
+        timerSubscription.ProcessId.Should().Be("Process_TimerStart");
+        timerSubscription.RelatedDefinitionId.Should().Be(definition.DefinitionId);
+        timerSubscription.DefinitionId.Should().Be(definition.Id);
+        timerSubscription.DueAt.Should().BeAfter(beforeDeploy.AddSeconds(1));
+        timerSubscription.DueAt.Should().BeBefore(afterDeploy.AddSeconds(3));
+
+        definition.IsActive.Should().BeTrue();
+        definition.DeployedOn.Should().NotBeNull();
+    }
+
+    [Test]
+    public async Task HandleTime_ShouldStartDueDefinitionTimer_AndRemoveStartSubscription()
+    {
+        var definition = CreateDefinition();
+        var storage = new TimerRuntimeTestStorage();
+        storage.Definitions[definition.Id] = definition;
+        storage.Binaries[definition.Id] = CreateTimerStartXml();
+
+        var businessLogic = new BpmnBusinessLogic(new TestTransactionalStorageProvider(storage));
+        await businessLogic.DeployDefinition(definition);
+
+        var processedTimers = await businessLogic.HandleTime(DateTime.UtcNow.AddSeconds(5));
+
+        processedTimers.Should().Be(1);
+        storage.TimerSubscriptions.Should().BeEmpty();
+        storage.Instances.Should().ContainSingle();
+        storage.Instances.Values.Single().State.Should().Be(ProcessInstanceState.Completed);
+        storage.Instances.Values.Single().IsFinished.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task HandleTime_ShouldAdvanceDueInstanceTimer_AndClearPersistedInstanceTimer()
+    {
+        var definitionId = Guid.NewGuid();
+        var process = ParseSingleProcess(CreateIntermediateTimerXml());
+        var instance = new ProcessEngine(process).StartProcess();
+        instance.InstanceId = Guid.NewGuid();
+
+        var storage = new TimerRuntimeTestStorage();
+        storage.Definitions[definitionId] = new BpmnDefinition
+        {
+            Id = definitionId,
+            DefinitionId = "definition-timer-catch",
+            Hash = "hash",
+            SavedByUser = Guid.NewGuid(),
+            SavedOn = DateTime.UtcNow,
+            Version = new Model.Version(1, 0),
+            IsActive = true
+        };
+
+        storage.Instances[instance.InstanceId] = new ProcessInstanceInfo
+        {
+            InstanceId = instance.InstanceId,
+            metaDefinitionId = "definition-timer-catch",
+            DefinitionId = definitionId,
+            ProcessId = process.Id,
+            Tokens = instance.Tokens,
+            IsFinished = instance.IsFinished,
+            State = instance.State,
+            MessageSubscriptionCount = 0,
+            SignalSubscriptionCount = 0,
+            UserTaskSubscriptionCount = 0,
+            ServiceSubscriptionCount = 0
+        };
+
+        var timerDescriptor = ((ICatchHandler)instance).ActiveTimerSubscriptions.Should().ContainSingle().Subject;
+        storage.TimerSubscriptions.Add(new TimerSubscription
+        {
+            DueAt = timerDescriptor.DueAt,
+            FlowNodeId = timerDescriptor.FlowNodeId,
+            Kind = timerDescriptor.Kind,
+            ProcessId = process.Id,
+            RelatedDefinitionId = "definition-timer-catch",
+            DefinitionId = definitionId,
+            ProcessInstanceId = instance.InstanceId,
+            TokenId = timerDescriptor.TokenId
+        });
+
+        var businessLogic = new BpmnBusinessLogic(new TestTransactionalStorageProvider(storage));
+        var processedTimers = await businessLogic.HandleTime(timerDescriptor.DueAt.AddMilliseconds(50));
+
+        processedTimers.Should().Be(1);
+        storage.TimerSubscriptions.Should().BeEmpty();
+        storage.Instances[instance.InstanceId].State.Should().Be(ProcessInstanceState.Completed);
+        storage.Instances[instance.InstanceId].IsFinished.Should().BeTrue();
+    }
+
+    private static BpmnDefinition CreateDefinition()
+    {
+        return new BpmnDefinition
+        {
+            Id = Guid.NewGuid(),
+            DefinitionId = "definition-timer-start",
+            Hash = "hash",
+            SavedByUser = Guid.NewGuid(),
+            SavedOn = DateTime.UtcNow,
+            Version = new Model.Version(1, 0),
+            IsActive = false
+        };
+    }
+
+    private static Process ParseSingleProcess(string xml)
+    {
+        return ModelParser.ParseModel(xml).GetProcesses().Single();
+    }
+
+    private static string CreateTimerStartXml()
+    {
+        return """
+               <?xml version="1.0" encoding="UTF-8"?>
+               <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                 id="Definitions_TimerStart"
+                                 targetNamespace="http://bpmn.io/schema/bpmn">
+                 <bpmn:process id="Process_TimerStart" isExecutable="true">
+                   <bpmn:startEvent id="StartEvent_Timer">
+                     <bpmn:outgoing>Flow_1</bpmn:outgoing>
+                     <bpmn:timerEventDefinition id="TimerDefinition_1">
+                       <bpmn:timeDuration xsi:type="bpmn:tFormalExpression" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">PT2S</bpmn:timeDuration>
+                     </bpmn:timerEventDefinition>
+                   </bpmn:startEvent>
+                   <bpmn:endEvent id="EndEvent_1">
+                     <bpmn:incoming>Flow_1</bpmn:incoming>
+                   </bpmn:endEvent>
+                   <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_Timer" targetRef="EndEvent_1" />
+                 </bpmn:process>
+               </bpmn:definitions>
+               """;
+    }
+
+    private static string CreateIntermediateTimerXml()
+    {
+        return """
+               <?xml version="1.0" encoding="UTF-8"?>
+               <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                 id="Definitions_TimerCatch"
+                                 targetNamespace="http://bpmn.io/schema/bpmn">
+                 <bpmn:process id="Process_TimerCatch" isExecutable="true">
+                   <bpmn:startEvent id="StartEvent_1">
+                     <bpmn:outgoing>Flow_1</bpmn:outgoing>
+                   </bpmn:startEvent>
+                   <bpmn:intermediateCatchEvent id="TimerCatch_1">
+                     <bpmn:incoming>Flow_1</bpmn:incoming>
+                     <bpmn:outgoing>Flow_2</bpmn:outgoing>
+                     <bpmn:timerEventDefinition id="TimerDefinition_1">
+                       <bpmn:timeDuration xsi:type="bpmn:tFormalExpression" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">PT2S</bpmn:timeDuration>
+                     </bpmn:timerEventDefinition>
+                   </bpmn:intermediateCatchEvent>
+                   <bpmn:endEvent id="EndEvent_1">
+                     <bpmn:incoming>Flow_2</bpmn:incoming>
+                   </bpmn:endEvent>
+                   <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="TimerCatch_1" />
+                   <bpmn:sequenceFlow id="Flow_2" sourceRef="TimerCatch_1" targetRef="EndEvent_1" />
+                 </bpmn:process>
+               </bpmn:definitions>
+               """;
+    }
+
+    private sealed class TestTransactionalStorageProvider(TimerRuntimeTestStorage storage) : ITransactionalStorageProvider
+    {
+        public ITransactionalStorage GetTransactionalStorage()
+        {
+            return storage;
+        }
+    }
+
+    private sealed class TimerRuntimeTestStorage : ITransactionalStorage
+    {
+        public Dictionary<Guid, BpmnDefinition> Definitions { get; } = [];
+        public Dictionary<Guid, string> Binaries { get; } = [];
+        public Dictionary<Guid, ProcessInstanceInfo> Instances { get; } = [];
+        public List<TimerSubscription> TimerSubscriptions { get; } = [];
+
+        public IDefinitionStorage DefinitionStorage => new TestDefinitionStorage(this);
+        public IMessageSubscriptionStorage SubscriptionStorage => new TestSubscriptionStorage(this);
+        public IInstanceStorage InstanceStorage => new TestInstanceStorage(this);
+        public IFormStorage FormStorage { get; } = new NoOpFormStorage();
+
+        public void CommitChanges()
+        {
+        }
+
+        public void RollbackTransaction()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class TestDefinitionStorage(TimerRuntimeTestStorage storage) : IDefinitionStorage
+    {
+        public Task StoreBinary(Guid guid, string data)
+        {
+            storage.Binaries[guid] = data;
+            return Task.CompletedTask;
+        }
+
+        public Task<string> GetBinary(Guid guid)
+        {
+            return storage.Binaries.TryGetValue(guid, out var data)
+                ? Task.FromResult(data)
+                : throw new FileNotFoundException($"Binary definition {guid} was not found.");
+        }
+
+        public Task<Guid[]> GetAllBinaryDefinitions() => Task.FromResult(storage.Binaries.Keys.ToArray());
+        public Task<BpmnDefinition[]> GetAllDefinitions() => Task.FromResult(storage.Definitions.Values.ToArray());
+
+        public Task StoreDefinition(BpmnDefinition definition)
+        {
+            storage.Definitions[definition.Id] = definition;
+            return Task.CompletedTask;
+        }
+
+        public Task<Model.Version?> GetMaxVersionId(string modelId)
+        {
+            var version = storage.Definitions.Values
+                .Where(definition => definition.DefinitionId == modelId)
+                .Select(definition => definition.Version)
+                .OrderByDescending(definition => definition)
+                .Cast<Model.Version?>()
+                .FirstOrDefault();
+            return Task.FromResult(version);
+        }
+
+        public Task<BpmnDefinition> GetDefinitionById(Guid id)
+        {
+            return storage.Definitions.TryGetValue(id, out var definition)
+                ? Task.FromResult(definition)
+                : throw new FileNotFoundException($"Definition {id} was not found.");
+        }
+
+        public Task<BpmnDefinition> GetLatestDefinition(string definitionId)
+        {
+            var definition = storage.Definitions.Values
+                .Where(candidate => candidate.DefinitionId == definitionId)
+                .OrderByDescending(candidate => candidate.Version)
+                .FirstOrDefault()
+                ?? throw new FileNotFoundException($"Definition {definitionId} was not found.");
+            return Task.FromResult(definition);
+        }
+
+        public Task<BpmnDefinition?> GetDeployedDefinition(string definitionDefinitionId)
+        {
+            var definition = storage.Definitions.Values
+                .SingleOrDefault(candidate => candidate.DefinitionId == definitionDefinitionId && candidate.IsActive);
+            return Task.FromResult(definition);
+        }
+
+        public Task<ExtendedBpmnMetaDefinition[]> GetAllMetaDefinitions() => Task.FromResult(Array.Empty<ExtendedBpmnMetaDefinition>());
+        public Task StoreMetaDefinition(BpmnMetaDefinition metaDefinition) => Task.CompletedTask;
+        public Task UpdateMetaDefinition(BpmnMetaDefinition metaDefinition) => Task.CompletedTask;
+        public Task<BpmnMetaDefinition> GetMetaDefinitionById(string id) => throw new FileNotFoundException($"Meta definition {id} was not found.");
+    }
+
+    private sealed class TestSubscriptionStorage(TimerRuntimeTestStorage storage) : IMessageSubscriptionStorage
+    {
+        public Task<IEnumerable<MessageSubscription>> GetAllMessageSubscriptions() => Task.FromResult(Enumerable.Empty<MessageSubscription>());
+        public Task<IEnumerable<MessageSubscription>> GetMessageSubscription(string messageName, string? correlationKey, Guid? messageInstanceId) => Task.FromResult(Enumerable.Empty<MessageSubscription>());
+        public Task<IEnumerable<MessageSubscription>> GetMessageSubscription(Guid instanceId) => Task.FromResult(Enumerable.Empty<MessageSubscription>());
+        public Task AddMessageSubscription(MessageSubscription messageSubscription) => Task.CompletedTask;
+        public Task RemoveProcessMessageSubscriptionsByProcessInstanceId(Guid instanceId) => Task.CompletedTask;
+        public Task RemoveAllProcessMessageSubscriptionsWithNoInstancedId(string metaDefinitionId) => Task.CompletedTask;
+        public Task RemoveAllProcessSignalSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
+        public void AddSignalSubscription(SignalSubscription signalSubscription) { }
+        public Task<IEnumerable<SignalSubscription>> GetSignalSubscriptions(Guid instanceId) => Task.FromResult(Enumerable.Empty<SignalSubscription>());
+        public void RemoveProcessSingalSubscriptionsByProcessInstanceId(Guid instanceId) { }
+        public Task<IEnumerable<UserTaskSubscription>> GetAllUserTasks(Guid instanceId) => Task.FromResult(Enumerable.Empty<UserTaskSubscription>());
+        public Task<IEnumerable<ExtendedUserTaskSubscription>> GetAllUserTasksExtended(Guid userId) => Task.FromResult(Enumerable.Empty<ExtendedUserTaskSubscription>());
+        public Task AddUserTaskSubscription(UserTaskSubscription userTasks) => Task.CompletedTask;
+        public Task RemoveUserTaskSubscription(Guid userTaskSubscriptionId) => Task.CompletedTask;
+        public void RemoveAllUserTaskSubscriptionsByInstanceId(Guid instanceId) { }
+        public Task RemoveAllUserTaskSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
+
+        public Task<IEnumerable<TimerSubscription>> GetAllTimerSubscriptions() => Task.FromResult(storage.TimerSubscriptions.AsEnumerable());
+
+        public Task<IEnumerable<TimerSubscription>> GetTimerSubscriptions(Guid instanceId)
+        {
+            return Task.FromResult(storage.TimerSubscriptions
+                .Where(subscription => subscription.ProcessInstanceId == instanceId)
+                .AsEnumerable());
+        }
+
+        public Task AddTimerSubscription(TimerSubscription timerSubscription)
+        {
+            storage.TimerSubscriptions.RemoveAll(existing => existing.Id == timerSubscription.Id);
+            storage.TimerSubscriptions.Add(timerSubscription);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveTimerSubscription(Guid timerSubscriptionId)
+        {
+            storage.TimerSubscriptions.RemoveAll(subscription => subscription.Id == timerSubscriptionId);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveProcessTimerSubscriptionsByProcessInstanceId(Guid instanceId)
+        {
+            storage.TimerSubscriptions.RemoveAll(subscription => subscription.ProcessInstanceId == instanceId);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveAllProcessTimerSubscriptionsWithNoInstanceId(string relatedDefinitionId)
+        {
+            storage.TimerSubscriptions.RemoveAll(subscription =>
+                string.Equals(subscription.RelatedDefinitionId, relatedDefinitionId, StringComparison.Ordinal) &&
+                subscription.ProcessInstanceId == null);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestInstanceStorage(TimerRuntimeTestStorage storage) : IInstanceStorage
+    {
+        public Task<ProcessInstanceInfo> GetProcessInstance(Guid processInstanceId)
+        {
+            return storage.Instances.TryGetValue(processInstanceId, out var instance)
+                ? Task.FromResult(instance)
+                : throw new FileNotFoundException($"Process instance {processInstanceId} was not found.");
+        }
+
+        public Task AddOrUpdateInstance(ProcessInstanceInfo processInstanceInfo)
+        {
+            storage.Instances[processInstanceInfo.InstanceId] = processInstanceInfo;
+            return Task.CompletedTask;
+        }
+
+        public Task<IEnumerable<ProcessInstanceInfo>> GetAllActiveInstances() =>
+            Task.FromResult(storage.Instances.Values.Where(instance => !instance.IsFinished).AsEnumerable());
+
+        public Task<IEnumerable<ProcessInstanceInfo>> GetAllInstances() =>
+            Task.FromResult(storage.Instances.Values.AsEnumerable());
+    }
+
+    private sealed class NoOpFormStorage : IFormStorage
+    {
+        public Task SaveFormMetaData(FormMetadata formMetadata) => Task.CompletedTask;
+        public Task<FormMetadata> GetFormMetaData(Guid formId) => throw new NotSupportedException();
+        public Task<IEnumerable<FormMetadata>> GetFormMetadatas() => Task.FromResult(Enumerable.Empty<FormMetadata>());
+        public Task UpdateFormMetaData(FormMetadata formMetaData) => Task.CompletedTask;
+        public Task DeleteFormMetaData(Guid formId) => Task.CompletedTask;
+        public Task SaveForm(Form form) => Task.CompletedTask;
+        public Task<Form> GetForm(Guid id) => throw new NotSupportedException();
+        public Task<IEnumerable<Form>> GetForms(Guid formId) => Task.FromResult(Enumerable.Empty<Form>());
+        public Task DeleteForm(Guid id) => Task.CompletedTask;
+        public Task<Model.Version> GetMaxVersion(Guid formId) => Task.FromResult(new Model.Version());
+    }
+}

--- a/src/WebApiEngine.Tests/TimerSubscriptionStorageTest.cs
+++ b/src/WebApiEngine.Tests/TimerSubscriptionStorageTest.cs
@@ -1,0 +1,128 @@
+using FilesystemStorageSystem;
+using FluentAssertions;
+using Model;
+
+namespace WebApiEngine.Tests;
+
+[NonParallelizable]
+public class TimerSubscriptionStorageTest
+{
+    [Test]
+    public async Task AddAndGetTimerSubscriptions_ShouldPersistDefinitionAndInstanceTimers()
+    {
+        using var context = new TimerSubscriptionStorageTestContext();
+        var instanceId = Guid.NewGuid();
+
+        var definitionTimer = context.CreateTimerSubscription(
+            TimerSubscriptionKind.ProcessStartEvent,
+            processInstanceId: null,
+            tokenId: null,
+            flowNodeId: "StartEvent_Timer");
+        var instanceTimer = context.CreateTimerSubscription(
+            TimerSubscriptionKind.IntermediateCatchEvent,
+            processInstanceId: instanceId,
+            tokenId: Guid.NewGuid(),
+            flowNodeId: "CatchEvent_Timer");
+
+        await context.SubscriptionStorage.AddTimerSubscription(definitionTimer);
+        await context.SubscriptionStorage.AddTimerSubscription(instanceTimer);
+
+        var allTimers = (await context.SubscriptionStorage.GetAllTimerSubscriptions()).ToArray();
+        var instanceTimers = (await context.SubscriptionStorage.GetTimerSubscriptions(instanceId)).ToArray();
+
+        allTimers.Should().HaveCount(2);
+        allTimers.Should().Contain(subscription => subscription.Id == definitionTimer.Id);
+        allTimers.Should().Contain(subscription => subscription.Id == instanceTimer.Id);
+        instanceTimers.Should().ContainSingle(subscription => subscription.Id == instanceTimer.Id);
+    }
+
+    [Test]
+    public async Task RemoveOperations_ShouldDeleteMatchingTimerSubscriptionsOnly()
+    {
+        using var context = new TimerSubscriptionStorageTestContext();
+        var firstInstanceId = Guid.NewGuid();
+        var secondInstanceId = Guid.NewGuid();
+
+        var definitionTimer = context.CreateTimerSubscription(
+            TimerSubscriptionKind.ProcessStartEvent,
+            processInstanceId: null,
+            tokenId: null,
+            flowNodeId: "StartEvent_Timer");
+        var firstInstanceTimer = context.CreateTimerSubscription(
+            TimerSubscriptionKind.IntermediateCatchEvent,
+            processInstanceId: firstInstanceId,
+            tokenId: Guid.NewGuid(),
+            flowNodeId: "CatchEvent_Timer_1");
+        var secondInstanceTimer = context.CreateTimerSubscription(
+            TimerSubscriptionKind.IntermediateCatchEvent,
+            processInstanceId: secondInstanceId,
+            tokenId: Guid.NewGuid(),
+            flowNodeId: "CatchEvent_Timer_2");
+
+        await context.SubscriptionStorage.AddTimerSubscription(definitionTimer);
+        await context.SubscriptionStorage.AddTimerSubscription(firstInstanceTimer);
+        await context.SubscriptionStorage.AddTimerSubscription(secondInstanceTimer);
+
+        await context.SubscriptionStorage.RemoveProcessTimerSubscriptionsByProcessInstanceId(firstInstanceId);
+        var afterInstanceRemoval = (await context.SubscriptionStorage.GetAllTimerSubscriptions()).ToArray();
+        afterInstanceRemoval.Should().HaveCount(2);
+        afterInstanceRemoval.Should().NotContain(subscription => subscription.Id == firstInstanceTimer.Id);
+
+        await context.SubscriptionStorage.RemoveAllProcessTimerSubscriptionsWithNoInstanceId(context.RelatedDefinitionId);
+        var afterDefinitionRemoval = (await context.SubscriptionStorage.GetAllTimerSubscriptions()).ToArray();
+        afterDefinitionRemoval.Should().ContainSingle(subscription => subscription.Id == secondInstanceTimer.Id);
+
+        await context.SubscriptionStorage.RemoveTimerSubscription(secondInstanceTimer.Id);
+        (await context.SubscriptionStorage.GetAllTimerSubscriptions()).Should().BeEmpty();
+    }
+
+    private sealed class TimerSubscriptionStorageTestContext : IDisposable
+    {
+        private readonly string? _previousStorageRoot;
+        private readonly string _storageRoot;
+
+        public TimerSubscriptionStorageTestContext()
+        {
+            _previousStorageRoot = Environment.GetEnvironmentVariable(Storage.StorageRootEnvironmentVariableName);
+            _storageRoot = Path.Combine(Path.GetTempPath(), "flowzer-timer-storage-test", Guid.NewGuid().ToString("N"));
+            Environment.SetEnvironmentVariable(Storage.StorageRootEnvironmentVariableName, _storageRoot);
+
+            Storage = new Storage();
+            SubscriptionStorage = Storage.SubscriptionStorage;
+        }
+
+        public Storage Storage { get; }
+        public StorageSystem.IMessageSubscriptionStorage SubscriptionStorage { get; }
+        public string RelatedDefinitionId { get; } = "definition-timer-storage";
+        public Guid DefinitionId { get; } = Guid.NewGuid();
+
+        public TimerSubscription CreateTimerSubscription(
+            TimerSubscriptionKind kind,
+            Guid? processInstanceId,
+            Guid? tokenId,
+            string flowNodeId)
+        {
+            return new TimerSubscription
+            {
+                DueAt = DateTime.UtcNow.AddMinutes(5),
+                FlowNodeId = flowNodeId,
+                Kind = kind,
+                ProcessId = "Process_Timer",
+                RelatedDefinitionId = RelatedDefinitionId,
+                DefinitionId = DefinitionId,
+                ProcessInstanceId = processInstanceId,
+                TokenId = tokenId
+            };
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(Storage.StorageRootEnvironmentVariableName, _previousStorageRoot);
+
+            if (Directory.Exists(_storageRoot))
+            {
+                Directory.Delete(_storageRoot, recursive: true);
+            }
+        }
+    }
+}

--- a/src/WebApiEngine/Background/TimerSchedulerBackgroundService.cs
+++ b/src/WebApiEngine/Background/TimerSchedulerBackgroundService.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Options;
+using WebApiEngine.BusinessLogic;
+
+namespace WebApiEngine.Background;
+
+public class TimerSchedulerBackgroundService(
+    BpmnBusinessLogic bpmnBusinessLogic,
+    IOptions<TimerSchedulerOptions> options,
+    ILogger<TimerSchedulerBackgroundService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var schedulerOptions = options.Value;
+        if (!schedulerOptions.Enabled)
+        {
+            logger.LogInformation("Timer scheduler is disabled.");
+            return;
+        }
+
+        var pollInterval = TimeSpan.FromSeconds(Math.Max(1, schedulerOptions.PollIntervalSeconds));
+
+        await RunTimerTick(stoppingToken);
+
+        using var periodicTimer = new PeriodicTimer(pollInterval);
+        while (await periodicTimer.WaitForNextTickAsync(stoppingToken))
+        {
+            await RunTimerTick(stoppingToken);
+        }
+    }
+
+    private async Task RunTimerTick(CancellationToken stoppingToken)
+    {
+        try
+        {
+            var processedTimers = await bpmnBusinessLogic.HandleTime(DateTime.UtcNow);
+            if (processedTimers > 0)
+            {
+                logger.LogInformation("Processed {ProcessedTimers} due timer subscriptions.", processedTimers);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Normales Herunterfahren des Host-Prozesses.
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Timer scheduler tick failed.");
+        }
+    }
+}

--- a/src/WebApiEngine/Background/TimerSchedulerOptions.cs
+++ b/src/WebApiEngine/Background/TimerSchedulerOptions.cs
@@ -1,0 +1,17 @@
+namespace WebApiEngine.Background;
+
+public class TimerSchedulerOptions
+{
+    public const string SectionName = "TimerScheduler";
+
+    /// <summary>
+    /// Aktiviert oder deaktiviert den Hintergrund-Poller für fällige Timer.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Poll-Intervall in Sekunden. Kleine Default-Werte erleichtern lokale Tests,
+    /// ohne in CI künstlich aggressive Loops zu erzeugen.
+    /// </summary>
+    public int PollIntervalSeconds { get; set; } = 5;
+}

--- a/src/WebApiEngine/BusinessLogic/BpmnBusinessLogic.cs
+++ b/src/WebApiEngine/BusinessLogic/BpmnBusinessLogic.cs
@@ -6,9 +6,13 @@ namespace WebApiEngine.BusinessLogic;
 
 public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider, ILogger<BpmnBusinessLogic>? logger = null)
 {
-    
-    public void Load()
+    public void Load(bool enableTimerAutomation = true)
     {
+        if (!enableTimerAutomation)
+        {
+            return;
+        }
+
         RestoreInstanceTimerSubscriptions().GetAwaiter().GetResult();
         HandleTime(DateTime.UtcNow).GetAwaiter().GetResult();
     }
@@ -139,10 +143,6 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider, IL
         {
             await storageSystem.SubscriptionStorage.RemoveProcessTimerSubscriptionsByProcessInstanceId(processInstanceId.Value);
         }
-        else
-        {
-            await storageSystem.SubscriptionStorage.RemoveAllProcessTimerSubscriptionsWithNoInstanceId(relatedDefinitionId);
-        }
 
         foreach (var activeTimer in catchHandler.ActiveTimerSubscriptions)
         {
@@ -173,17 +173,37 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider, IL
 
         foreach (var dueStartTimer in dueTimers.Where(subscription => subscription.ProcessInstanceId == null))
         {
-            await HandleStartTimer(storageSystem, dueStartTimer);
-            processedTimers++;
+            try
+            {
+                await HandleStartTimer(storageSystem, dueStartTimer);
+                processedTimers++;
+            }
+            catch (Exception exception)
+            {
+                (logger ?? NullLogger<BpmnBusinessLogic>.Instance).LogError(
+                    exception,
+                    "Processing start timer subscription {TimerSubscriptionId} for definition {DefinitionId} failed.",
+                    dueStartTimer.Id,
+                    dueStartTimer.DefinitionId);
+            }
         }
 
-        foreach (var instanceId in dueTimers
+        foreach (var dueInstanceTimerGroup in dueTimers
                      .Where(subscription => subscription.ProcessInstanceId != null)
-                     .Select(subscription => subscription.ProcessInstanceId!.Value)
-                     .Distinct())
+                     .GroupBy(subscription => subscription.ProcessInstanceId!.Value))
         {
-            await HandleInstanceTimers(storageSystem, instanceId, time);
-            processedTimers++;
+            try
+            {
+                await HandleInstanceTimers(storageSystem, dueInstanceTimerGroup.Key, time);
+                processedTimers += dueInstanceTimerGroup.Count();
+            }
+            catch (Exception exception)
+            {
+                (logger ?? NullLogger<BpmnBusinessLogic>.Instance).LogError(
+                    exception,
+                    "Processing due timer subscriptions for instance {InstanceId} failed.",
+                    dueInstanceTimerGroup.Key);
+            }
         }
 
         if (processedTimers > 0)

--- a/src/WebApiEngine/BusinessLogic/BpmnBusinessLogic.cs
+++ b/src/WebApiEngine/BusinessLogic/BpmnBusinessLogic.cs
@@ -1,14 +1,16 @@
 using BPMN.HumanInteraction;
 using BPMN.Process;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace WebApiEngine.BusinessLogic;
 
-public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider)
+public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider, ILogger<BpmnBusinessLogic>? logger = null)
 {
     
     public void Load()
     {
-        //TODO: load timers   
+        RestoreInstanceTimerSubscriptions().GetAwaiter().GetResult();
+        HandleTime(DateTime.UtcNow).GetAwaiter().GetResult();
     }
     
     public async Task DeployDefinition(BpmnDefinition definition)
@@ -25,7 +27,7 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider)
         foreach (var process in model.GetProcesses())
         {
             var pe = new ProcessEngine(process);
-            SaveSubscriptions(storageSystem, pe, definition.DefinitionId, definition.Id, process.Id);
+            await SaveSubscriptions(storageSystem, pe, definition.DefinitionId, definition.Id, process.Id);
         }
 
 
@@ -37,6 +39,7 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider)
         }
 
         definition.IsActive = true;
+        definition.DeployedOn = DateTime.UtcNow;
         await storageSystem.DefinitionStorage.StoreDefinition(definition);
         
         storageSystem.CommitChanges();
@@ -53,17 +56,19 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider)
         await storageSystem.SubscriptionStorage.RemoveAllProcessMessageSubscriptionsWithNoInstancedId(relatedDefinitionId);
         await storageSystem.SubscriptionStorage.RemoveAllProcessSignalSubscriptionsWithNoInstanceId(relatedDefinitionId);
         await storageSystem.SubscriptionStorage.RemoveAllUserTaskSubscriptionsWithNoInstanceId(relatedDefinitionId);
+        await storageSystem.SubscriptionStorage.RemoveAllProcessTimerSubscriptionsWithNoInstanceId(relatedDefinitionId);
     }
 
 
-    private void SaveSubscriptions(IStorageSystem storageSystem, ICatchHandler catchHandler, string relatedDefinitionId, Guid definitionId, string processId, Guid? processInstanceId = null)
+    private async Task SaveSubscriptions(IStorageSystem storageSystem, ICatchHandler catchHandler, string relatedDefinitionId, Guid definitionId, string processId, Guid? processInstanceId = null)
     {
-        SaveCatchMessages(storageSystem, catchHandler, relatedDefinitionId, definitionId, processId, processInstanceId);
+        await SaveCatchMessages(storageSystem, catchHandler, relatedDefinitionId, definitionId, processId, processInstanceId);
         SaveActiveSignals(storageSystem, catchHandler, relatedDefinitionId, definitionId, processId, processInstanceId);
-        SaveUserTasks(storageSystem, catchHandler, relatedDefinitionId, definitionId, processId, processInstanceId);
+        await SaveUserTasks(storageSystem, catchHandler, relatedDefinitionId, definitionId, processId, processInstanceId);
+        await SaveActiveTimers(storageSystem, catchHandler, relatedDefinitionId, definitionId, processId, processInstanceId);
     }
 
-    private void SaveUserTasks(IStorageSystem storageSystem, ICatchHandler catchHandler, string metaDefinitionId, Guid definitionId, string processId, Guid? processInstanceId)
+    private async Task SaveUserTasks(IStorageSystem storageSystem, ICatchHandler catchHandler, string metaDefinitionId, Guid definitionId, string processId, Guid? processInstanceId)
     {
         if (processInstanceId != null) //if there are already stored user task subscriptions for this instance, remove them
             storageSystem.SubscriptionStorage.RemoveAllUserTaskSubscriptionsByInstanceId(processInstanceId.Value);
@@ -71,7 +76,7 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider)
         foreach (var activeUserTask in catchHandler.ActiveUserTasks())
         {
             var userTask = (UserTask)activeUserTask.CurrentFlowNode!; 
-            storageSystem.SubscriptionStorage.AddUserTaskSubscription(
+            await storageSystem.SubscriptionStorage.AddUserTaskSubscription(
                 new UserTaskSubscription()
                 {
                     Id = Guid.NewGuid(),
@@ -88,15 +93,15 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider)
         }
     }
 
-    private void SaveCatchMessages(IStorageSystem storageSystem, ICatchHandler catchHandler, string relatedDefinitionId, 
+    private async Task SaveCatchMessages(IStorageSystem storageSystem, ICatchHandler catchHandler, string relatedDefinitionId,
         Guid definitionId, string processId, Guid? processInstanceId)
     {
         if (processInstanceId != null) //if there are already stored catch messages subscriptions for this instance, remove them
-            storageSystem.SubscriptionStorage.RemoveProcessMessageSubscriptionsByProcessInstanceId(processInstanceId.Value);
+            await storageSystem.SubscriptionStorage.RemoveProcessMessageSubscriptionsByProcessInstanceId(processInstanceId.Value);
         
         foreach (var activeCatchMessage in catchHandler.ActiveCatchMessages)
         {
-            storageSystem.SubscriptionStorage.AddMessageSubscription(
+            await storageSystem.SubscriptionStorage.AddMessageSubscription(
                 new MessageSubscription(
                     activeCatchMessage,
                     processId,
@@ -125,6 +130,68 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider)
                     processInstanceId
                 ));    
         }
+    }
+
+    private async Task SaveActiveTimers(IStorageSystem storageSystem, ICatchHandler catchHandler, string relatedDefinitionId, Guid definitionId,
+        string processId, Guid? processInstanceId)
+    {
+        if (processInstanceId != null)
+        {
+            await storageSystem.SubscriptionStorage.RemoveProcessTimerSubscriptionsByProcessInstanceId(processInstanceId.Value);
+        }
+        else
+        {
+            await storageSystem.SubscriptionStorage.RemoveAllProcessTimerSubscriptionsWithNoInstanceId(relatedDefinitionId);
+        }
+
+        foreach (var activeTimer in catchHandler.ActiveTimerSubscriptions)
+        {
+            await storageSystem.SubscriptionStorage.AddTimerSubscription(new TimerSubscription
+            {
+                DueAt = activeTimer.DueAt,
+                FlowNodeId = activeTimer.FlowNodeId,
+                Kind = activeTimer.Kind,
+                ProcessId = processId,
+                RelatedDefinitionId = relatedDefinitionId,
+                DefinitionId = definitionId,
+                ProcessInstanceId = processInstanceId,
+                TokenId = activeTimer.TokenId
+            });
+        }
+    }
+
+    public async Task<int> HandleTime(DateTime time)
+    {
+        using var storageSystem = storageProvider.GetTransactionalStorage();
+
+        var dueTimers = (await storageSystem.SubscriptionStorage.GetAllTimerSubscriptions())
+            .Where(subscription => subscription.DueAt <= time)
+            .OrderBy(subscription => subscription.DueAt)
+            .ToArray();
+
+        var processedTimers = 0;
+
+        foreach (var dueStartTimer in dueTimers.Where(subscription => subscription.ProcessInstanceId == null))
+        {
+            await HandleStartTimer(storageSystem, dueStartTimer);
+            processedTimers++;
+        }
+
+        foreach (var instanceId in dueTimers
+                     .Where(subscription => subscription.ProcessInstanceId != null)
+                     .Select(subscription => subscription.ProcessInstanceId!.Value)
+                     .Distinct())
+        {
+            await HandleInstanceTimers(storageSystem, instanceId, time);
+            processedTimers++;
+        }
+
+        if (processedTimers > 0)
+        {
+            storageSystem.CommitChanges();
+        }
+
+        return processedTimers;
     }
 
 
@@ -206,7 +273,7 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider)
 
     private async Task SaveInstance(ITransactionalStorage storageSystem, InstanceEngine instance, string relatedDefinitionId, Guid definitionId, string processId)
     {
-        SaveSubscriptions(storageSystem, instance, relatedDefinitionId, definitionId, processId, instance.InstanceId);
+        await SaveSubscriptions(storageSystem, instance, relatedDefinitionId, definitionId, processId, instance.InstanceId);
         await AddOrUpdateInstance(definitionId, relatedDefinitionId, processId, storageSystem, instance);
     }
     
@@ -251,6 +318,71 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider)
                 UserTaskSubscriptionCount = instance.GetActiveUserTasks().Count(),
                 ServiceSubscriptionCount = instance.GetActiveServiceTasks().Count()
             });
+    }
+
+    private async Task RestoreInstanceTimerSubscriptions()
+    {
+        using var storageSystem = storageProvider.GetTransactionalStorage();
+
+        var activeInstances = await storageSystem.InstanceStorage.GetAllActiveInstances();
+        foreach (var processInstance in activeInstances)
+        {
+            if (!HasSingleMasterToken(processInstance))
+            {
+                (logger ?? NullLogger<BpmnBusinessLogic>.Instance).LogWarning(
+                    "Skipping timer subscription restore for instance {InstanceId} because the stored token set has no single master token.",
+                    processInstance.InstanceId);
+                continue;
+            }
+
+            var instance = new InstanceEngine(processInstance.Tokens);
+            instance.InstanceId = processInstance.InstanceId;
+            await SaveActiveTimers(
+                storageSystem,
+                instance,
+                processInstance.metaDefinitionId,
+                processInstance.DefinitionId,
+                processInstance.ProcessId,
+                processInstance.InstanceId);
+        }
+
+        storageSystem.CommitChanges();
+    }
+
+    private async Task HandleStartTimer(ITransactionalStorage storageSystem, TimerSubscription timerSubscription)
+    {
+        var xmlData = await storageSystem.DefinitionStorage.GetBinary(timerSubscription.DefinitionId);
+        var model = ModelParser.ParseModel(xmlData);
+        var process = model.GetProcesses().FirstOrDefault(candidate => candidate.Id == timerSubscription.ProcessId);
+        if (process == null)
+        {
+            throw new FileNotFoundException(
+                $"No process with the id \"{timerSubscription.ProcessId}\" was found in the definition with the id \"{timerSubscription.DefinitionId}\".");
+        }
+
+        var processEngine = new ProcessEngine(process);
+        var instance = processEngine.StartProcessByTimerStartEvent(timerSubscription.FlowNodeId);
+        await SaveInstance(
+            storageSystem,
+            instance,
+            timerSubscription.RelatedDefinitionId,
+            timerSubscription.DefinitionId,
+            timerSubscription.ProcessId);
+        await storageSystem.SubscriptionStorage.RemoveTimerSubscription(timerSubscription.Id);
+    }
+
+    private async Task HandleInstanceTimers(ITransactionalStorage storageSystem, Guid instanceId, DateTime time)
+    {
+        var processInstance = await storageSystem.InstanceStorage.GetProcessInstance(instanceId);
+        var instance = new InstanceEngine(processInstance.Tokens);
+        instance.InstanceId = processInstance.InstanceId;
+        instance.HandleTime(time);
+        await SaveInstance(storageSystem, instance, processInstance.metaDefinitionId, processInstance.DefinitionId, processInstance.ProcessId);
+    }
+
+    private static bool HasSingleMasterToken(ProcessInstanceInfo processInstance)
+    {
+        return processInstance.Tokens.Count(token => token.ParentTokenId == null) == 1;
     }
     
 

--- a/src/WebApiEngine/Controller/InstanceController.cs
+++ b/src/WebApiEngine/Controller/InstanceController.cs
@@ -69,6 +69,17 @@ public class InstanceController(
         return Ok(new ApiStatusResult<SignalSubscriptionDto[]>(result));
     }
 
+    [HttpGet("{instanceId}/subscription/timers")]
+    public async Task<ActionResult<TimerSubscriptionDto[]>> GetTimerSubscriptions(Guid instanceId)
+    {
+        var timerSubscriptions = await storageSystem.SubscriptionStorage.GetTimerSubscriptions(instanceId);
+        var result = timerSubscriptions
+            .OrderBy(subscription => subscription.DueAt)
+            .Select(subscription => subscription.ToDto())
+            .ToArray();
+        return Ok(new ApiStatusResult<TimerSubscriptionDto[]>(result));
+    }
+
     [HttpGet("{instanceId}/subscription/services")]
     public async Task<ActionResult<TokenDto[]>> GetServiceSubscriptions(Guid instanceId)
     {

--- a/src/WebApiEngine/Controller/TimerController.cs
+++ b/src/WebApiEngine/Controller/TimerController.cs
@@ -1,0 +1,19 @@
+using WebApiEngine.Mappers;
+using WebApiEngine.Shared;
+
+namespace WebApiEngine.Controller;
+
+[ApiController, Route("[controller]")]
+public class TimerController(IStorageSystem storageSystem) : FlowzerControllerBase
+{
+    [HttpGet]
+    public async Task<ActionResult<ApiStatusResult<TimerSubscriptionDto[]>>> GetAllTimers()
+    {
+        var timers = (await storageSystem.SubscriptionStorage.GetAllTimerSubscriptions())
+            .OrderBy(subscription => subscription.DueAt)
+            .Select(subscription => subscription.ToDto())
+            .ToArray();
+
+        return Ok(new ApiStatusResult<TimerSubscriptionDto[]>(timers));
+    }
+}

--- a/src/WebApiEngine/Mappers/InteractionMappingExtensions.cs
+++ b/src/WebApiEngine/Mappers/InteractionMappingExtensions.cs
@@ -93,6 +93,24 @@ public static class InteractionMappingExtensions
         };
     }
 
+    public static TimerSubscriptionDto ToDto(this TimerSubscription timerSubscription)
+    {
+        ArgumentNullException.ThrowIfNull(timerSubscription);
+
+        return new TimerSubscriptionDto
+        {
+            Id = timerSubscription.Id,
+            DueAt = timerSubscription.DueAt,
+            FlowNodeId = timerSubscription.FlowNodeId,
+            ProcessId = timerSubscription.ProcessId,
+            RelatedDefinitionId = timerSubscription.RelatedDefinitionId,
+            DefinitionId = timerSubscription.DefinitionId,
+            ProcessInstanceId = timerSubscription.ProcessInstanceId,
+            TokenId = timerSubscription.TokenId,
+            Kind = timerSubscription.Kind.ToString()
+        };
+    }
+
     public static FormDto ToDto(this Form form)
     {
         ArgumentNullException.ThrowIfNull(form);

--- a/src/WebApiEngine/Program.cs
+++ b/src/WebApiEngine/Program.cs
@@ -3,6 +3,7 @@ using WebApiEngine.Auth;
 using WebApiEngine.Background;
 using WebApiEngine.BusinessLogic;
 using WebApiEngine.Middleware;
+using Microsoft.Extensions.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -55,7 +56,8 @@ app.UseCors("AllowAllOrigins"); // Diese Zeile stellt sicher, dass die CORS-Rich
 
 app.MapControllers();
 
-app.Services.GetRequiredService<BpmnBusinessLogic>().Load();
+var timerSchedulerOptions = app.Services.GetRequiredService<IOptions<TimerSchedulerOptions>>().Value;
+app.Services.GetRequiredService<BpmnBusinessLogic>().Load(timerSchedulerOptions.Enabled);
 
 app.Run();
 

--- a/src/WebApiEngine/Program.cs
+++ b/src/WebApiEngine/Program.cs
@@ -1,5 +1,6 @@
 using WebApiEngine;
 using WebApiEngine.Auth;
+using WebApiEngine.Background;
 using WebApiEngine.BusinessLogic;
 using WebApiEngine.Middleware;
 
@@ -24,6 +25,8 @@ builder.Services.AddSingleton<ICurrentUserContextAccessor, HttpContextCurrentUse
 builder.Services.AddSingleton<FormBusinessLogic>();
 builder.Services.AddSingleton<DefinitionBusinessLogic>();
 builder.Services.AddSingleton<BpmnBusinessLogic>();
+builder.Services.Configure<TimerSchedulerOptions>(builder.Configuration.GetSection(TimerSchedulerOptions.SectionName));
+builder.Services.AddHostedService<TimerSchedulerBackgroundService>();
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowAllOrigins",

--- a/src/WebApiEngine/appsettings.Development.json
+++ b/src/WebApiEngine/appsettings.Development.json
@@ -4,5 +4,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "TimerScheduler": {
+    "Enabled": true,
+    "PollIntervalSeconds": 2
   }
 }

--- a/src/WebApiEngine/appsettings.json
+++ b/src/WebApiEngine/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "TimerScheduler": {
+    "Enabled": true,
+    "PollIntervalSeconds": 5
+  },
   "AllowedHosts": "*"
 }

--- a/src/core-engine/InstanceEngine/Base.cs
+++ b/src/core-engine/InstanceEngine/Base.cs
@@ -206,11 +206,28 @@ public partial class InstanceEngine: ICatchHandler
         .Distinct()
         .ToList();
 
+    List<TimerSubscriptionDescriptor> ICatchHandler.ActiveTimerSubscriptions => Tokens
+        .Where(token => token.State == FlowNodeState.Active)
+        .SelectMany(GetActiveTimerSubscriptionDescriptors)
+        .ToList();
+
     private static IEnumerable<DateTime> GetActiveTimerDates(Token token)
     {
         if (token.CurrentFlowNode is FlowzerIntermediateTimerCatchEvent timerCatchEvent)
         {
             yield return GetTimerDueDate(token, timerCatchEvent);
+        }
+    }
+
+    private static IEnumerable<TimerSubscriptionDescriptor> GetActiveTimerSubscriptionDescriptors(Token token)
+    {
+        if (token.CurrentFlowNode is FlowzerIntermediateTimerCatchEvent timerCatchEvent)
+        {
+            yield return new TimerSubscriptionDescriptor(
+                GetTimerDueDate(token, timerCatchEvent),
+                timerCatchEvent.Id,
+                TimerSubscriptionKind.IntermediateCatchEvent,
+                token.Id);
         }
     }
 

--- a/src/core-engine/ProcessEngine.cs
+++ b/src/core-engine/ProcessEngine.cs
@@ -18,6 +18,23 @@ public class ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null)
         return instance;
     }
 
+    public InstanceEngine StartProcessByTimerStartEvent(string flowNodeId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(flowNodeId);
+
+        var startEvent = Process.FlowElements
+            .OfType<FlowzerTimerStartEvent>()
+            .SingleOrDefault(element => string.Equals(element.Id, flowNodeId, StringComparison.Ordinal))
+            ?? throw new ArgumentException(
+                $"No timer start event with the id \"{flowNodeId}\" exists in process \"{Process.Id}\".",
+                nameof(flowNodeId));
+
+        var instance = CreateInstanceEngine();
+        instance.HandleTime(DateTime.UtcNow, startEvent);
+        _triggeredTimerStartEventIds.Add(startEvent.Id);
+        return instance;
+    }
+
     // public async Task<InstanceEngine> HandleTime(DateTime time)
     // {
     //     var processInstance = new ProcessInstance
@@ -83,6 +100,13 @@ public class ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null)
                 .ToList();
         }
     }
+
+    public List<TimerSubscriptionDescriptor> ActiveTimerSubscriptions => GetPendingTimerStartEvents()
+        .Select(startEvent => new TimerSubscriptionDescriptor(
+            GetStartTimerDueDate(startEvent),
+            startEvent.Id,
+            TimerSubscriptionKind.ProcessStartEvent))
+        .ToList();
 
     public List<MessageDefinition> ActiveCatchMessages
     {


### PR DESCRIPTION
## Zusammenfassung

Dieser PR zieht den nächsten Runtime-Schritt aus der Roadmap nach: **persistierte Timer-Subscriptions plus ein kleiner Scheduler-/Polling-Pfad im Web-API-Host**.

## Was umgesetzt wurde

- neue persistierte `TimerSubscription`-Modelle für Start- und Intermediate-Timer
- Storage- und API-Verträge für Timer-Subscriptions ergänzt
- Timer-Subscriptions werden jetzt beim Deployen und beim Speichern laufender Instanzen mitgeschrieben
- neuer Web-API-Hintergrunddienst verarbeitet fällige Timer regelmäßig über `HandleTime(...)`
- neue API-Endpunkte:
  - `GET /timer`
  - `GET /instance/{instanceId}/subscription/timers`
- `BpmnBusinessLogic.Load()` synchronisiert persistierte Instanz-Timer beim Start neu
- robuste Schutzlogik: Instanzen mit kaputtem Token-Set crashen den Restore-Pfad nicht mehr

## Tests

Lokal erfolgreich ausgeführt:

- `dotnet build core-engine.sln --configuration Release`
- `dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'`
- `dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --logger 'console;verbosity=minimal'`
- `dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'`

Zusätzlich neu ergänzt:

- Storage-Tests für Timer-Subscriptions
- Runtime-Integrationstests für Deploy + Timer-Tick
- API-Integrationstests für Timer-Endpunkte

## Doku

Aktualisiert:

- `README.md`
- `docs/PROJECT-STATUS.md`
- `docs/ROADMAP.md`
- `docs/RUNTIME-GAPS.md`

Closes #79
