### PR TITLE
Boundary-Timer in Parser, Runtime und Subscription-Pfad ergänzen

### DIFF
--- a/Model/TimerSubscriptionKind.cs
+++ b/Model/TimerSubscriptionKind.cs
@@ -3,5 +3,6 @@ namespace Model;
 public enum TimerSubscriptionKind
 {
     ProcessStartEvent,
-    IntermediateCatchEvent
+    IntermediateCatchEvent,
+    BoundaryEvent
 }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Die bisherige Dokumentation klang teilweise deutlich reifer als der aktuelle Sta
 - Es gibt **fachlich wertvolle Tests, BPMN-Beispiele und eine grüne CI-Basis auf `next`**.
 - Zentrale Produktpfade wie Demo, UI-Smokes, API-Fehlerverträge und ein erster Timer-Kernpfad sind inzwischen vorhanden.
 - Timer-Subscriptions werden jetzt auch in Storage/Web-API persistiert und über einen kleinen Scheduler-Polling-Pfad verarbeitet.
-- Es gibt aber weiterhin **offene Restlücken** bei Boundary-Timern, weitergehender Timer-Semantik, Auth/Identity und Betriebsreife.
+- Es gibt aber weiterhin **offene Restlücken** bei weitergehender Timer-/Recovery-Semantik, Auth/Identity und Betriebsreife.
 - Das Projekt ist **klar revivierbar und aktiv weiterentwickelbar**, wenn die nächsten Schritte weiter fokussiert bleiben.
 
 Mehr Details: [docs/PROJECT-STATUS.md](docs/PROJECT-STATUS.md)
@@ -92,7 +92,7 @@ Diese Punkte sollte man kennen, bevor man loslegt:
    Test- und CI-Umgebungen laufen inzwischen auch ohne native V8-Abhängigkeit stabiler. Die vollständige FEEL-/V8-Strategie der Engine ist fachlich aber weiterhin ein eigener Architekturstrang.
 
 3. **Timer-, Fehler- und Abbruchpfade sind verbessert, aber noch nicht vollständig**
-   Der Engine-Kern kann fällige Timer jetzt weiterführen, und rohe `NotImplementedException`-Abbrüche wurden in mehreren Pfaden entschärft. Persistierte Timer, Boundary-Timer, vollständige Fehler-/Eskalationssemantik und echte Kompensation bleiben aber offen.
+   Der Engine-Kern kann fällige Timer jetzt weiterführen, Boundary-Timer im bestehenden Subscription-Pfad verarbeiten und rohe `NotImplementedException`-Abbrüche in mehreren Pfaden vermeiden. Offen bleiben weiterhin wiederkehrende Start-Timer, weitergehende Recovery-Fragen, vollständige Fehler-/Eskalationssemantik und echte Kompensation.
 
 4. **Betrieb und Auth sind noch nicht am Ziel**
    Lokale Compose- und Runtime-Container sind vorhanden, aber Themen wie Telemetrie, Secrets, TLS, Recovery und eine belastbare Identity-/Auth-Story sind weiterhin Folgepakete.
@@ -113,7 +113,7 @@ Diese Punkte sollte man kennen, bevor man loslegt:
 
 Die sinnvolle Reihenfolge ist aktuell:
 
-1. **Boundary-Timer und weitergehende Timer-/Fehlersemantik sauber nachziehen**
+1. **Timer-Recovery, wiederkehrende Start-Timer und weitergehende Fehlersemantik sauber nachziehen**
 2. **Auth-/Identity- und Fehlerpfade weiter produktionsnah härten**
 3. **Betriebsbasis mit Telemetrie, Secrets und Recovery vertiefen**
 4. **Status-, Architektur- und Contributor-Dokumentation laufend nachziehen**

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -49,6 +49,7 @@ Unter anderem bereits umgesetzt:
 - DTO-/Warnungsbereinigung und API-Härtung in mehreren Teilbereichen
 - Signal- und Service-Task-Subscriptions im Web-API-Pfad
 - Timer-Ausführung im Engine-Kern für fällige Timer-Starts und Intermediate-Timer-Catches
+- Boundary-Timer im Parser, in der Runtime und im persistierten Timer-Subscription-Pfad
 - persistierte Timer-Subscriptions in Storage und Web-API
 - kleiner Scheduler-/Polling-Pfad im Web-API-Host für fällige Timer
 - konsistentere Form-/Message-Fehlerverträge in Web-API und Business-Logic
@@ -62,7 +63,7 @@ Unter anderem bereits umgesetzt:
 Besonders relevant sind noch:
 
 - weiter ausgebautes Playwright-/E2E-Smoke-Set
-- Restlücken bei Boundary-Timern, wiederkehrenden Timer-Strategien und weitergehender Scheduler-/Recovery-Semantik
+- Restlücken bei wiederkehrenden Timer-Strategien und weitergehender Scheduler-/Recovery-Semantik
 - weitere Auth-/Identity- und Fehlerpfade
 - Release-/Telemetrie-/Secret-/Recovery-Story über die lokale Basis hinaus
 
@@ -92,7 +93,7 @@ Die Basisdokumentation ist deutlich besser als zuvor, aber für die nächste Rei
 
 Die erste große Revitalisierungs- und Stabilisierungswelle ist inzwischen weitgehend abgearbeitet. Der nächste sinnvolle Backlog ergibt sich aktuell weniger aus alten Sammel-Issues, sondern aus den noch verbleibenden Produktlücken:
 
-- Boundary-Timer und weitergehende BPMN-Fehler-/Eskalationssemantik
+- weitergehende Timer-Recovery sowie BPMN-Fehler-/Eskalationssemantik
 - Auth-/Identity-Härtung
 - Telemetrie, Secrets, Recovery und operationsnahe Doku
 - weitere Architektur- und Repo-Hygiene
@@ -103,7 +104,7 @@ Das Projekt sollte jetzt **nicht mehr primär gerettet**, sondern gezielt **zur 
 
 Die sinnvolle Reihenfolge ist aus heutiger Sicht:
 
-1. Boundary-Timer sowie weitergehende Timer-/Recovery-Semantik weiter abbauen
+1. Timer-Recovery und wiederkehrende Start-Timer weiter abbauen
 2. Auth-/Identity- und API-Verträge weiter schärfen
 3. Betriebsbasis um Telemetrie, Secrets, TLS und Recovery erweitern
 4. E2E-, Architektur- und Operations-Dokumentation weiter vertiefen

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,6 +14,7 @@ Die erste große Stabilisierungsrunde ist bereits erfolgt:
 - Demo-Console-App ergänzt
 - wesentliche Engine-/Subscription-/Frontend-Härtungen umgesetzt
 - Timer-Ausführung im Engine-Kern für fällige Start- und Intermediate-Timer ergänzt
+- Boundary-Timer im Parser, in der Runtime und im persistierten Subscription-Pfad ergänzt
 - persistierte Timer-Subscriptions in Storage/Web-API ergänzt
 - Scheduler-/Polling-Pfad für fällige Timer im Web-API-Host ergänzt
 - Form-/Message-Fehlerverträge in der Web-API weiter geschärft
@@ -26,17 +27,17 @@ Die Roadmap startet also **nicht mehr bei Null**, sondern baut auf einer funktio
 
 ## Priorität 1: Timer- und Runtime-Restlücken schließen
 
-### 1.2 Boundary-Timer und BPMN-Fehlerpfade vertiefen
+### 1.2 BPMN-Fehlerpfade und weitergehende Timer-Semantik vertiefen
 
-- Boundary-Timer-Parsing und -Abarbeitung ergänzen
 - Error-/Escalation-Semantik jenseits des Best-Effort-Fallbacks modellieren
 - Kompensations- und Abbruchpfade weiter präzisieren
+- Boundary-Timer bei Bedarf um speziellere Randfälle wie konkurrierende Timer oder komplexere Recovery-Szenarien vertiefen
 
 ### 1.3 Timer-Recovery und wiederkehrende Strategien vertiefen
 
 - Recovery-Verhalten für bereits persistierte Timer nach Neustarts weiter härten
 - wiederkehrende Start-Timer über den ersten Due-Zeitpunkt hinaus sauber modellieren
-- Boundary-Timer später in denselben Persistenz-/Scheduler-Pfad integrieren
+- wiederkehrende Boundary- oder Spezialtimer nur dann ergänzen, wenn sie fachlich wirklich benötigt werden
 
 ## Priorität 2: Betriebs- und Auth-Reife erhöhen
 
@@ -71,9 +72,9 @@ Die Roadmap startet also **nicht mehr bei Null**, sondern baut auf einer funktio
 
 ### Sprint A – Timer-Runtime vertiefen
 
-- Boundary-Timer-Sicht
 - Timer-Recovery
 - wiederkehrende Timer-Strategien
+- verbleibende Boundary-Timer-Randfälle
 
 ### Sprint B – Betrieb und Auth
 

--- a/docs/RUNTIME-GAPS.md
+++ b/docs/RUNTIME-GAPS.md
@@ -30,13 +30,20 @@ Dieses Dokument hält die aktuell noch offenen Laufzeit- und Engine-Lücken fest
 - Beim Start werden persistierte Instanz-Timer erneut aus den gespeicherten Tokenzuständen synchronisiert.
 - Das Poll-Intervall ist über `TimerScheduler:PollIntervalSeconds` konfigurierbar.
 
-### 5. User-Task-Ergebnisse haben einen stabileren Laufzeitvertrag
+### 5. Boundary-Timer laufen jetzt über denselben Timer-Subscription-Pfad
+
+- `ModelParser` erkennt Boundary-Timer jetzt als eigenes Flowzer-Ereignis.
+- aktive Boundary-Timer werden über `ICatchHandler.ActiveTimerSubscriptions` sichtbar.
+- fällige Boundary-Timer werden im `HandleTime(...)`-Pfad genau einmal ausgelöst.
+- interrupting Boundary-Timer ziehen die Aktivität zurück, non-interrupting Boundary-Timer starten einen parallelen Pfad.
+
+### 6. User-Task-Ergebnisse haben einen stabileren Laufzeitvertrag
 
 - User-Task-Ergebnisse ohne `ProcessInstanceId` laufen nicht mehr in eine rohe `NotImplementedException`.
 - Stattdessen kommt ein valider `400 Bad Request` mit einem klaren API-Fehlervertrag zurück.
 - Zusätzlich wird jetzt geprüft, ob das übergebene `TokenId` wirklich noch aktiv ist und zum erwarteten `FlowNodeId` gehört.
 
-### 6. Instanzabbruch ist als Best-Effort-Pfad verfügbar
+### 7. Instanzabbruch ist als Best-Effort-Pfad verfügbar
 
 - `InstanceEngine.Cancel()` terminiert jetzt aktive/wartende Tokens der Instanz konsistent.
 - Das ersetzt noch **keine vollständige BPMN-Kompensation**, verhindert aber, dass der API-/Runtime-Pfad an einer nackten `NotImplementedException` scheitert.
@@ -56,8 +63,8 @@ Aktuell vorhanden:
 Weiterhin offen:
 
 - Recovery-Strategie für bereits persistierte Start-Timer über harte Neustarts hinweg weiter schärfen
-- Boundary-Timer-Parsing und -Abarbeitung
 - vollständige Wiederholungsstrategie für zyklische Start-Timer über den ersten Due-Zeitpunkt hinaus
+- Sonderfälle wie konkurrierende Timer oder weitergehende Boundary-Timer-Recovery nur bei echtem Bedarf vertiefen
 
 ### 2. Fehler- und Eskalationspfade
 
@@ -88,7 +95,7 @@ Nicht enthalten:
 
 ## Empfohlene nächste Runtime-Schritte
 
-1. Boundary-Timer parsen und in den Persistenzpfad integrieren
-2. Recovery- und Wiederholungsstrategie für Start-Timer weiter härten
-3. Error-/Escalation-Semantik gezielt modellieren und testen
-4. `Cancel()` später um echte Kompensationsstrategien erweitern
+1. Recovery- und Wiederholungsstrategie für Start-Timer weiter härten
+2. Error-/Escalation-Semantik gezielt modellieren und testen
+3. `Cancel()` später um echte Kompensationsstrategien erweitern
+4. Boundary-Timer nur noch bei echten Randfällen weiter vertiefen

--- a/src/FlowzerBPMN/Flowzer/Events/FlowzerBoundaryTimerEvent.cs
+++ b/src/FlowzerBPMN/Flowzer/Events/FlowzerBoundaryTimerEvent.cs
@@ -1,0 +1,8 @@
+namespace BPMN.Flowzer.Events;
+
+public record FlowzerBoundaryTimerEvent : BoundaryEvent, IFlowzerTimerEvent
+{
+    public FlowzerTimerType? TimerType => FlowzerTimerTypeResolver.GetTimerType(TimerDefinition);
+
+    public required TimerEventDefinition TimerDefinition { get; init; }
+}

--- a/src/WebApiEngine.Tests/TimerRuntimeIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/TimerRuntimeIntegrationTest.cs
@@ -117,6 +117,70 @@ public class TimerRuntimeIntegrationTest
         storage.Instances[instance.InstanceId].IsFinished.Should().BeTrue();
     }
 
+    [Test]
+    public async Task HandleTime_ShouldAdvanceDueBoundaryTimer_AndClearPersistedBoundaryTimer()
+    {
+        var definitionId = Guid.NewGuid();
+        var process = ParseSingleProcess(CreateBoundaryTimerXml());
+        var instance = new ProcessEngine(process).StartProcess();
+        instance.InstanceId = Guid.NewGuid();
+
+        var storage = new TimerRuntimeTestStorage();
+        storage.Definitions[definitionId] = new BpmnDefinition
+        {
+            Id = definitionId,
+            DefinitionId = "definition-boundary-timer",
+            Hash = "hash",
+            SavedByUser = Guid.NewGuid(),
+            SavedOn = DateTime.UtcNow,
+            Version = new Model.Version(1, 0),
+            IsActive = true
+        };
+
+        storage.Instances[instance.InstanceId] = new ProcessInstanceInfo
+        {
+            InstanceId = instance.InstanceId,
+            metaDefinitionId = "definition-boundary-timer",
+            DefinitionId = definitionId,
+            ProcessId = process.Id,
+            Tokens = instance.Tokens,
+            IsFinished = instance.IsFinished,
+            State = instance.State,
+            MessageSubscriptionCount = 0,
+            SignalSubscriptionCount = 0,
+            UserTaskSubscriptionCount = 0,
+            ServiceSubscriptionCount = 1
+        };
+
+        var timerDescriptor = ((ICatchHandler)instance).ActiveTimerSubscriptions
+            .Should()
+            .ContainSingle(subscription => subscription.Kind == TimerSubscriptionKind.BoundaryEvent)
+            .Subject;
+        storage.TimerSubscriptions.Add(new TimerSubscription
+        {
+            DueAt = timerDescriptor.DueAt,
+            FlowNodeId = timerDescriptor.FlowNodeId,
+            Kind = timerDescriptor.Kind,
+            ProcessId = process.Id,
+            RelatedDefinitionId = "definition-boundary-timer",
+            DefinitionId = definitionId,
+            ProcessInstanceId = instance.InstanceId,
+            TokenId = timerDescriptor.TokenId
+        });
+
+        var businessLogic = new BpmnBusinessLogic(new TestTransactionalStorageProvider(storage));
+        var processedTimers = await businessLogic.HandleTime(timerDescriptor.DueAt.AddMilliseconds(50));
+
+        processedTimers.Should().Be(1);
+        storage.TimerSubscriptions.Should().BeEmpty();
+        storage.Instances[instance.InstanceId].State.Should().Be(ProcessInstanceState.Completed);
+        storage.Instances[instance.InstanceId].IsFinished.Should().BeTrue();
+        storage.Instances[instance.InstanceId].Tokens.Should().Contain(token =>
+            token.CurrentFlowNode != null &&
+            token.CurrentFlowNode.Id == "ServiceTask_1" &&
+            token.State == FlowNodeState.Withdrawn);
+    }
+
     private static BpmnDefinition CreateDefinition()
     {
         return new BpmnDefinition
@@ -182,6 +246,46 @@ public class TimerRuntimeIntegrationTest
                    </bpmn:endEvent>
                    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="TimerCatch_1" />
                    <bpmn:sequenceFlow id="Flow_2" sourceRef="TimerCatch_1" targetRef="EndEvent_1" />
+                 </bpmn:process>
+               </bpmn:definitions>
+               """;
+    }
+
+    private static string CreateBoundaryTimerXml()
+    {
+        return """
+               <?xml version="1.0" encoding="UTF-8"?>
+               <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                 xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                 id="Definitions_BoundaryTimer"
+                                 targetNamespace="http://bpmn.io/schema/bpmn">
+                 <bpmn:process id="Process_BoundaryTimer" isExecutable="true">
+                   <bpmn:startEvent id="StartEvent_1">
+                     <bpmn:outgoing>Flow_1</bpmn:outgoing>
+                   </bpmn:startEvent>
+                   <bpmn:serviceTask id="ServiceTask_1" name="Wait for timeout">
+                     <bpmn:extensionElements>
+                       <zeebe:taskDefinition type="main-step" />
+                     </bpmn:extensionElements>
+                     <bpmn:incoming>Flow_1</bpmn:incoming>
+                     <bpmn:outgoing>Flow_2</bpmn:outgoing>
+                   </bpmn:serviceTask>
+                   <bpmn:boundaryEvent id="BoundaryTimer_1" attachedToRef="ServiceTask_1">
+                     <bpmn:outgoing>Flow_3</bpmn:outgoing>
+                     <bpmn:timerEventDefinition id="TimerDefinition_1">
+                       <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT2S</bpmn:timeDuration>
+                     </bpmn:timerEventDefinition>
+                   </bpmn:boundaryEvent>
+                   <bpmn:endEvent id="EndEvent_Main">
+                     <bpmn:incoming>Flow_2</bpmn:incoming>
+                   </bpmn:endEvent>
+                   <bpmn:endEvent id="EndEvent_Boundary">
+                     <bpmn:incoming>Flow_3</bpmn:incoming>
+                   </bpmn:endEvent>
+                   <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="ServiceTask_1" />
+                   <bpmn:sequenceFlow id="Flow_2" sourceRef="ServiceTask_1" targetRef="EndEvent_Main" />
+                   <bpmn:sequenceFlow id="Flow_3" sourceRef="BoundaryTimer_1" targetRef="EndEvent_Boundary" />
                  </bpmn:process>
                </bpmn:definitions>
                """;

--- a/src/core-engine-tests/EngineTest.cs
+++ b/src/core-engine-tests/EngineTest.cs
@@ -580,6 +580,93 @@ public class EngineTest
     }
 
     [Test]
+    public void BoundaryTimerEvent_ShouldInterruptActivityAndCompleteBoundaryPathWhenDue()
+    {
+        var instanceEngine = StartProcessFromXml(CreateBoundaryTimerProcessXml(cancelActivity: true));
+
+        var serviceTaskToken = instanceEngine.GetActiveServiceTasks().Should().ContainSingle().Subject;
+        var timerSubscription = ((ICatchHandler)instanceEngine).ActiveTimerSubscriptions
+            .Should()
+            .ContainSingle(subscription => subscription.Kind == TimerSubscriptionKind.BoundaryEvent)
+            .Subject;
+
+        using (new AssertionScope())
+        {
+            timerSubscription.FlowNodeId.Should().Be("BoundaryTimer_1");
+            timerSubscription.TokenId.Should().Be(serviceTaskToken.Id);
+            timerSubscription.DueAt.Should().BeCloseTo(serviceTaskToken.LastStateChangeTime.AddSeconds(5), TimeSpan.FromMilliseconds(250));
+        }
+
+        instanceEngine.HandleTime(timerSubscription.DueAt.AddMilliseconds(50));
+
+        using (new AssertionScope())
+        {
+            instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Completed);
+            instanceEngine.ActiveTokens.Should().BeEmpty();
+            ((ICatchHandler)instanceEngine).ActiveTimerSubscriptions.Should().BeEmpty();
+            instanceEngine.Tokens.Should().Contain(token =>
+                token.CurrentFlowNode != null &&
+                token.CurrentFlowNode.Id == "ServiceTask_1" &&
+                token.State == FlowNodeState.Withdrawn);
+            instanceEngine.Tokens.Should().Contain(token =>
+                token.CurrentFlowNode != null &&
+                token.CurrentFlowNode.Id == "BoundaryTimer_1" &&
+                token.State == FlowNodeState.Completed);
+        }
+    }
+
+    [Test]
+    public void BoundaryTimerEvent_ShouldTriggerOnlyOnceForNonInterruptingBoundaryTimer()
+    {
+        var instanceEngine = StartProcessFromXml(CreateBoundaryTimerProcessXml(cancelActivity: false));
+
+        var timerSubscription = ((ICatchHandler)instanceEngine).ActiveTimerSubscriptions
+            .Should()
+            .ContainSingle(subscription => subscription.Kind == TimerSubscriptionKind.BoundaryEvent)
+            .Subject;
+
+        instanceEngine.HandleTime(timerSubscription.DueAt.AddMilliseconds(50));
+
+        using (new AssertionScope())
+        {
+            instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Waiting);
+            instanceEngine.GetActiveServiceTasks()
+                .Select(token => ((ServiceTask)token.CurrentBaseElement).Implementation)
+                .Should()
+                .BeEquivalentTo(["main-step", "boundary-step"]);
+            ((ICatchHandler)instanceEngine).ActiveTimerSubscriptions.Should().BeEmpty();
+        }
+
+        var tokenCountAfterFirstFire = instanceEngine.Tokens.Count;
+        instanceEngine.HandleTime(timerSubscription.DueAt.AddSeconds(10));
+
+        using (new AssertionScope())
+        {
+            instanceEngine.Tokens.Should().HaveCount(tokenCountAfterFirstFire);
+            instanceEngine.GetActiveServiceTasks()
+                .Select(token => ((ServiceTask)token.CurrentBaseElement).Implementation)
+                .Should()
+                .BeEquivalentTo(["main-step", "boundary-step"]);
+        }
+
+        var boundaryServiceTaskToken = instanceEngine.GetActiveServiceTasks()
+            .Single(token => ((ServiceTask)token.CurrentBaseElement).Implementation == "boundary-step");
+        var mainServiceTaskToken = instanceEngine.GetActiveServiceTasks()
+            .Single(token => ((ServiceTask)token.CurrentBaseElement).Implementation == "main-step");
+
+        instanceEngine.HandleTaskResult(boundaryServiceTaskToken.Id, null);
+        instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Waiting);
+
+        instanceEngine.HandleTaskResult(mainServiceTaskToken.Id, null);
+
+        using (new AssertionScope())
+        {
+            instanceEngine.ProcessInstanceState.Should().Be(ProcessInstanceState.Completed);
+            instanceEngine.ActiveTokens.Should().BeEmpty();
+        }
+    }
+
+    [Test]
     public void Cancel_ShouldTerminateWaitingInstanceAndClearActiveTasks()
     {
         var instanceEngine = StartProcessFromXml("""
@@ -654,5 +741,65 @@ public class EngineTest
     {
         var process = ModelParser.ParseModel(xml).GetProcesses().Single();
         return Helper.CreateProcessEngine(process);
+    }
+
+    private static string CreateBoundaryTimerProcessXml(bool cancelActivity)
+    {
+        var cancelActivityAttribute = cancelActivity ? string.Empty : " cancelActivity=\"false\"";
+        var boundaryTarget = cancelActivity ? "EndEvent_Boundary" : "ServiceTask_Boundary";
+        var boundaryTargetDefinition = cancelActivity
+            ? """
+              <bpmn:endEvent id="EndEvent_Boundary">
+                <bpmn:incoming>Flow_3</bpmn:incoming>
+              </bpmn:endEvent>
+              """
+            : """
+              <bpmn:serviceTask id="ServiceTask_Boundary" name="Boundary worker">
+                <bpmn:extensionElements>
+                  <zeebe:taskDefinition type="boundary-step" />
+                </bpmn:extensionElements>
+                <bpmn:incoming>Flow_3</bpmn:incoming>
+                <bpmn:outgoing>Flow_4</bpmn:outgoing>
+              </bpmn:serviceTask>
+              <bpmn:endEvent id="EndEvent_Boundary">
+                <bpmn:incoming>Flow_4</bpmn:incoming>
+              </bpmn:endEvent>
+              <bpmn:sequenceFlow id="Flow_4" sourceRef="ServiceTask_Boundary" targetRef="EndEvent_Boundary" />
+              """;
+
+        return $$"""
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                   xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                   id="Definitions_BoundaryTimer"
+                                   targetNamespace="http://bpmn.io/schema/bpmn">
+                   <bpmn:process id="Process_BoundaryTimer" isExecutable="true">
+                     <bpmn:startEvent id="StartEvent_1">
+                       <bpmn:outgoing>Flow_1</bpmn:outgoing>
+                     </bpmn:startEvent>
+                     <bpmn:serviceTask id="ServiceTask_1" name="Main worker">
+                       <bpmn:extensionElements>
+                         <zeebe:taskDefinition type="main-step" />
+                       </bpmn:extensionElements>
+                       <bpmn:incoming>Flow_1</bpmn:incoming>
+                       <bpmn:outgoing>Flow_2</bpmn:outgoing>
+                     </bpmn:serviceTask>
+                     <bpmn:boundaryEvent id="BoundaryTimer_1"{{cancelActivityAttribute}} attachedToRef="ServiceTask_1">
+                       <bpmn:outgoing>Flow_3</bpmn:outgoing>
+                       <bpmn:timerEventDefinition id="TimerDefinition_1">
+                         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT5S</bpmn:timeDuration>
+                       </bpmn:timerEventDefinition>
+                     </bpmn:boundaryEvent>
+                     {{boundaryTargetDefinition}}
+                     <bpmn:endEvent id="EndEvent_Main">
+                       <bpmn:incoming>Flow_2</bpmn:incoming>
+                     </bpmn:endEvent>
+                     <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="ServiceTask_1" />
+                     <bpmn:sequenceFlow id="Flow_2" sourceRef="ServiceTask_1" targetRef="EndEvent_Main" />
+                     <bpmn:sequenceFlow id="Flow_3" sourceRef="BoundaryTimer_1" targetRef="{{boundaryTarget}}" />
+                   </bpmn:process>
+                 </bpmn:definitions>
+                 """;
     }
 }

--- a/src/core-engine-tests/ModelParserTest.cs
+++ b/src/core-engine-tests/ModelParserTest.cs
@@ -1,10 +1,12 @@
 using BPMN.Common;
 using BPMN.Events;
+using BPMN.Flowzer;
 using BPMN.Flowzer.Events;
 using BPMN.Gateways;
 using BPMN.HumanInteraction;
 using BPMN.Process;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Task = System.Threading.Tasks.Task;
 
 namespace core_engine_tests;
@@ -101,6 +103,60 @@ public class ModelParserTest
             .ContainSingle()
             .Which.Should()
             .Be("ExecutableProcess");
+    }
+
+    [Test]
+    public void ParseModel_ShouldParseBoundaryTimerEvent()
+    {
+        const string xml = """
+                           <?xml version="1.0" encoding="UTF-8"?>
+                           <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                             xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                                             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                             id="Definitions_BoundaryTimer"
+                                             targetNamespace="http://bpmn.io/schema/bpmn">
+                             <bpmn:process id="Process_BoundaryTimer" isExecutable="true">
+                               <bpmn:startEvent id="StartEvent_1">
+                                 <bpmn:outgoing>Flow_1</bpmn:outgoing>
+                               </bpmn:startEvent>
+                               <bpmn:serviceTask id="Activity_1" name="Wait for boundary timer">
+                                 <bpmn:extensionElements>
+                                   <zeebe:taskDefinition type="wait-for-boundary" />
+                                 </bpmn:extensionElements>
+                                 <bpmn:incoming>Flow_1</bpmn:incoming>
+                                 <bpmn:outgoing>Flow_2</bpmn:outgoing>
+                               </bpmn:serviceTask>
+                               <bpmn:boundaryEvent id="BoundaryTimer_1" cancelActivity="false" attachedToRef="Activity_1">
+                                 <bpmn:outgoing>Flow_3</bpmn:outgoing>
+                                 <bpmn:timerEventDefinition id="TimerDefinition_1">
+                                   <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT5S</bpmn:timeDuration>
+                                 </bpmn:timerEventDefinition>
+                               </bpmn:boundaryEvent>
+                               <bpmn:endEvent id="EndEvent_Main">
+                                 <bpmn:incoming>Flow_2</bpmn:incoming>
+                               </bpmn:endEvent>
+                               <bpmn:endEvent id="EndEvent_Boundary">
+                                 <bpmn:incoming>Flow_3</bpmn:incoming>
+                               </bpmn:endEvent>
+                               <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Activity_1" />
+                               <bpmn:sequenceFlow id="Flow_2" sourceRef="Activity_1" targetRef="EndEvent_Main" />
+                               <bpmn:sequenceFlow id="Flow_3" sourceRef="BoundaryTimer_1" targetRef="EndEvent_Boundary" />
+                             </bpmn:process>
+                           </bpmn:definitions>
+                           """;
+
+        var model = ModelParser.ParseModel(xml);
+        var process = model.GetProcesses().Single();
+        var boundaryTimer = process.FlowElements.OfType<FlowzerBoundaryTimerEvent>().Should().ContainSingle().Subject;
+
+        using (new AssertionScope())
+        {
+            boundaryTimer.Id.Should().Be("BoundaryTimer_1");
+            boundaryTimer.CancelActivity.Should().BeFalse();
+            boundaryTimer.AttachedToRef.Id.Should().Be("Activity_1");
+            boundaryTimer.TimerType.Should().Be(FlowzerTimerType.TimeDuration);
+            boundaryTimer.TimerDefinition.TimeDuration!.Body.Should().Be("PT5S");
+        }
     }
 
     private static void AssertFlowNodeOfTypes<T>(Process process, int? count, string? id = null, string? name = null)

--- a/src/core-engine/InstanceEngine/Base.cs
+++ b/src/core-engine/InstanceEngine/Base.cs
@@ -144,15 +144,15 @@ public partial class InstanceEngine: ICatchHandler
     }
 
     /// <summary>
-    /// Führt fällige Intermediate-Timer-Catch-Events weiter.
+    /// Führt fällige Intermediate-Timer-Catch-Events und Boundary-Timer weiter.
     /// </summary>
     public void HandleTime(DateTime time)
     {
-        HandleDueIntermediateTimerCatchEvents(time);
+        HandleDueTimers(time);
     }
 
     /// <summary>
-    /// Führt fällige Timer-Start- oder Intermediate-Timer-Catch-Events weiter.
+    /// Führt fällige Timer-Start-, Intermediate-Timer-Catch- oder Boundary-Timer-Events weiter.
     /// Diese Überladung ist absichtlich nicht öffentlich, damit Start-Timer nur
     /// über Engine-internen Code ausgelöst werden können.
     /// </summary>
@@ -163,11 +163,13 @@ public partial class InstanceEngine: ICatchHandler
             return;
         }
 
-        HandleDueIntermediateTimerCatchEvents(time);
+        HandleDueTimers(time);
     }
 
-    private void HandleDueIntermediateTimerCatchEvents(DateTime time)
+    private void HandleDueTimers(DateTime time)
     {
+        var requiresRun = false;
+
         var dueTimerTokens = ActiveTokens
             .Where(token => token.CurrentFlowNode is FlowzerIntermediateTimerCatchEvent)
             .Where(token => GetTimerDueDate(token) <= time)
@@ -179,6 +181,52 @@ public partial class InstanceEngine: ICatchHandler
         }
 
         if (dueTimerTokens.Length > 0)
+        {
+            requiresRun = true;
+        }
+
+        var dueBoundaryTimers = ActiveTokens
+            .Select(token => new
+            {
+                Token = token,
+                DueBoundaryEvents = token.ActiveBoundaryEvents
+                    .OfType<FlowzerBoundaryTimerEvent>()
+                    .Where(boundaryTimer => GetBoundaryTimerDueDate(token, boundaryTimer) <= time)
+                    .ToArray()
+            })
+            .Where(entry => entry.DueBoundaryEvents.Length > 0)
+            .ToArray();
+
+        foreach (var dueBoundaryTimer in dueBoundaryTimers)
+        {
+            foreach (var boundaryTimerEvent in dueBoundaryTimer.DueBoundaryEvents)
+            {
+                dueBoundaryTimer.Token.ActiveBoundaryEvents.Remove(boundaryTimerEvent);
+
+                if (boundaryTimerEvent.CancelActivity)
+                {
+                    dueBoundaryTimer.Token.State = FlowNodeState.Withdrawn;
+                }
+
+                Tokens.Add(new Token
+                {
+                    CurrentBaseElement = boundaryTimerEvent,
+                    ActiveBoundaryEvents = [],
+                    OutputData = new Variables(),
+                    State = FlowNodeState.Completing,
+                    ParentTokenId = dueBoundaryTimer.Token.ParentTokenId,
+                    ProcessInstanceId = dueBoundaryTimer.Token.ProcessInstanceId,
+                });
+                requiresRun = true;
+
+                if (boundaryTimerEvent.CancelActivity)
+                {
+                    break;
+                }
+            }
+        }
+
+        if (requiresRun)
         {
             Run();
         }
@@ -217,6 +265,11 @@ public partial class InstanceEngine: ICatchHandler
         {
             yield return GetTimerDueDate(token, timerCatchEvent);
         }
+
+        foreach (var boundaryTimerEvent in token.ActiveBoundaryEvents.OfType<FlowzerBoundaryTimerEvent>())
+        {
+            yield return GetBoundaryTimerDueDate(token, boundaryTimerEvent);
+        }
     }
 
     private static IEnumerable<TimerSubscriptionDescriptor> GetActiveTimerSubscriptionDescriptors(Token token)
@@ -227,6 +280,15 @@ public partial class InstanceEngine: ICatchHandler
                 GetTimerDueDate(token, timerCatchEvent),
                 timerCatchEvent.Id,
                 TimerSubscriptionKind.IntermediateCatchEvent,
+                token.Id);
+        }
+
+        foreach (var boundaryTimerEvent in token.ActiveBoundaryEvents.OfType<FlowzerBoundaryTimerEvent>())
+        {
+            yield return new TimerSubscriptionDescriptor(
+                GetBoundaryTimerDueDate(token, boundaryTimerEvent),
+                boundaryTimerEvent.Id,
+                TimerSubscriptionKind.BoundaryEvent,
                 token.Id);
         }
     }
@@ -291,6 +353,14 @@ public partial class InstanceEngine: ICatchHandler
             token.LastStateChangeTime,
             timerCatchEvent.TimerDefinition,
             timerCatchEvent);
+    }
+
+    private static DateTime GetBoundaryTimerDueDate(Token token, FlowzerBoundaryTimerEvent boundaryTimerEvent)
+    {
+        return TimerDueDateCalculator.GetDueDate(
+            token.LastStateChangeTime,
+            boundaryTimerEvent.TimerDefinition,
+            boundaryTimerEvent);
     }
 
     public List<Token> ActiveUserTasks()

--- a/src/core-engine/ModelParser.cs
+++ b/src/core-engine/ModelParser.cs
@@ -296,6 +296,19 @@ public static class ModelParser
                 continue;
             }
 
+            if (xmlFlowNode.HasDescendant("timerEventDefinition", out definition))
+            {
+                flowElements.Add(new FlowzerBoundaryTimerEvent
+                {
+                    Id = xmlFlowNode.Attribute("id")!.Value,
+                    Name = xmlFlowNode.Attribute("name")?.Value ?? "",
+                    TimerDefinition = ParseTimerEventDefinition(definition),
+                    AttachedToRef = attachedTo,
+                    CancelActivity = cancelActivity
+                });
+                continue;
+            }
+
             throw new NotSupportedException($"{xmlFlowNode.Name} is not supported at moment.");
         }
 


### PR DESCRIPTION
## Zusammenfassung

Dieses Paket ergänzt **Boundary-Timer** auf dem aktuellen `next`-Pfad in Parser, Engine und Timer-Subscription-Handling.

## Änderungen

- neues Flowzer-Modell `FlowzerBoundaryTimerEvent` ergänzt
- `ModelParser` erkennt `timerEventDefinition` jetzt auch auf `boundaryEvent`
- `InstanceEngine.HandleTime(...)` verarbeitet jetzt auch fällige Boundary-Timer
- aktive Boundary-Timer werden über `ICatchHandler.ActiveTimerSubscriptions` sichtbar
- neuer `TimerSubscriptionKind.BoundaryEvent`
- Boundary-Timer werden genau einmal ausgelöst, indem sie nach dem Trigger aus den aktiven Boundary-Events entfernt werden
- Engine-Regressionstests für interrupting und non-interrupting Boundary-Timer ergänzt
- Runtime-Integrationstest für den persistierten Boundary-Timer-Pfad ergänzt
- Status-/Roadmap-/Runtime-Doku an den neuen Stand angepasst

## Validierung

```bash
dotnet build core-engine.sln --configuration Release --no-restore
dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'
dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'
dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'
```

## Hinweise

- Die Umsetzung hält den Scope bewusst klein und nutzt die bestehende Message-/Signal-Boundary-Logik als Vorlage.
- Weitergehende Recovery- und Wiederholungsstrategien für Timer bleiben weiterhin eigene Folgepakete.

Bezieht sich auf #81.
