### PR TITLE
Repo-Instructions für autonome Git-Writes unterhalb von main/release ergänzen

### DIFF
--- a/.codex-instructions.md
+++ b/.codex-instructions.md
@@ -1,0 +1,18 @@
+# Codex-Projektanweisungen
+
+Zusätzliche repositoryspezifische Regeln für Codex und andere agentische Werkzeuge.
+
+## Git-Write-Regel für dieses Repository
+
+- Für dieses Repository dürfen **Commits und Pushes ohne weitere Rückfrage** erfolgen, **solange** auf einem Arbeits- oder Integrationszweig gearbeitet wird.
+- Diese Freigabe gilt ausdrücklich für Branches wie `codex/*`, `next` und vergleichbare Nicht-Release-Zweige.
+- **Nicht** erlaubt ohne explizite Freigabe bleiben direkte Git-Write-Aktionen auf:
+  - `main`
+  - `release`
+  - `release/*`
+- Merges und PRs sollen weiterhin **nach `next`** erfolgen, solange nicht ausdrücklich etwas anderes verlangt wird.
+
+## GitHub-Kommunikation
+
+- GitHub-Issues, PRs und Kommentare bitte weiterhin **auf Deutsch** und in **Markdown** verfassen.
+- Neue Issues und PRs bitte **`ChrMaass`** zuweisen.

--- a/.codex-instructions.md
+++ b/.codex-instructions.md
@@ -11,8 +11,3 @@ Zusätzliche repositoryspezifische Regeln für Codex und andere agentische Werkz
   - `release`
   - `release/*`
 - Merges und PRs sollen weiterhin **nach `next`** erfolgen, solange nicht ausdrücklich etwas anderes verlangt wird.
-
-## GitHub-Kommunikation
-
-- GitHub-Issues, PRs und Kommentare bitte weiterhin **auf Deutsch** und in **Markdown** verfassen.
-- Neue Issues und PRs bitte **`ChrMaass`** zuweisen.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,6 +48,16 @@ Wenn Architektur, Setup oder bekannte Einschränkungen verändert werden, sollen
 - **Code auf Englisch**
 - **Erklärende Kommentare und Doku bevorzugt auf Deutsch**
 
+### 5. Git-Write-Regel im Repository
+
+- Auf Arbeits- und Integrationszweigen dieses Repositories darf GitHub Copilot bzw. ein agentischer Workflow **ohne weitere Rückfrage committen und pushen**.
+- Diese Freigabe gilt für Branches wie `codex/*`, `next` und vergleichbare Nicht-Release-Zweige.
+- **Nicht** erlaubt ohne explizite Freigabe bleiben direkte Git-Write-Aktionen auf:
+  - `main`
+  - `release`
+  - `release/*`
+- Solange nichts anderes verlangt wird, sollen PRs weiterhin **nach `next`** erstellt werden.
+
 ## Bekannte Fallstricke
 
 ### Build, Tests und CI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Dieses Repository enthält eine BPMN-Engine mit Parser, Laufzeit, API, Frontend 
 3. [docs/ROADMAP.md](docs/ROADMAP.md)
 4. [DEVELOPMENT-GUIDELINES.md](DEVELOPMENT-GUIDELINES.md)
 5. [.github/copilot-instructions.md](.github/copilot-instructions.md)
+6. [.codex-instructions.md](.codex-instructions.md)
 
 ## Wichtige Bereiche
 
@@ -30,6 +31,17 @@ Dieses Repository enthält eine BPMN-Engine mit Parser, Laufzeit, API, Frontend 
 - **Engine-Änderungen möglichst mit Tests absichern.**
 - **Doku aktualisieren, wenn sich Architektur oder Setup ändern.**
 - **Code auf Englisch, erklärende Kommentare/Dokumentation bevorzugt auf Deutsch.**
+
+## Git-Write-Regel für dieses Repository
+
+- Auf Arbeits- und Integrationszweigen dürfen agentische Werkzeuge in diesem Repository **ohne weitere Rückfrage committen und pushen**.
+- Diese Freigabe gilt insbesondere für Branches wie `codex/*`, `next` und vergleichbare Nicht-Release-Zweige.
+- **Nicht** darunter fallen direkte Git-Write-Aktionen auf:
+  - `main`
+  - `release`
+  - `release/*`
+- Solche Writes auf `main` oder `release` bleiben weiterhin nur mit expliziter Freigabe erlaubt.
+- Solange nichts anderes gefordert ist, sollen PRs und Merges weiterhin **nach `next`** gehen.
 
 ## Bekannte Fallstricke
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Dieses Repository enthält eine BPMN-Engine mit Parser, Laufzeit, API, Frontend 
   - `main`
   - `release`
   - `release/*`
-- Solche Writes auf `main` oder `release` bleiben weiterhin nur mit expliziter Freigabe erlaubt.
+- Solche Writes auf `main`, `release` oder `release/*` bleiben weiterhin nur mit expliziter Freigabe erlaubt.
 - Solange nichts anderes gefordert ist, sollen PRs und Merges weiterhin **nach `next`** gehen.
 
 ## Bekannte Fallstricke


### PR DESCRIPTION
## Zusammenfassung

Dieses Paket dokumentiert die projektweite Git-Write-Regel jetzt direkt im Repository:

- automatische Commits/Pushes auf Arbeits- und Integrationszweigen sind erlaubt
- `main` und `release` bleiben davon ausdrücklich ausgenommen
- PRs sollen weiterhin standardmäßig nach `next` gehen

## Änderungen

- neue Datei `/Users/christian/Projekte/BPMN/flowzer-bpmn-core-engine/.codex-instructions.md`
- `AGENTS.md` um die Git-Write-Regel ergänzt
- `.github/copilot-instructions.md` um dieselbe Regel ergänzt

## Validierung

- `git diff --check`

Bezieht sich auf #83.
