### PR TITLE
Wiederkehrende Start-Timer und Timer-Recovery im Runtime-Pfad härten

### DIFF
--- a/Model/TimerSubscription.cs
+++ b/Model/TimerSubscription.cs
@@ -14,4 +14,5 @@ public class TimerSubscription
     public required Guid DefinitionId { get; init; }
     public Guid? ProcessInstanceId { get; init; }
     public Guid? TokenId { get; init; }
+    public int? RemainingOccurrences { get; init; }
 }

--- a/Model/TimerSubscriptionDescriptor.cs
+++ b/Model/TimerSubscriptionDescriptor.cs
@@ -7,4 +7,5 @@ public record TimerSubscriptionDescriptor(
     DateTime DueAt,
     string FlowNodeId,
     TimerSubscriptionKind Kind,
-    Guid? TokenId = null);
+    Guid? TokenId = null,
+    int? RemainingOccurrences = null);

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Die bisherige Dokumentation klang teilweise deutlich reifer als der aktuelle Sta
 - Es gibt bereits eine **brauchbare Kernarchitektur**.
 - Es gibt **fachlich wertvolle Tests, BPMN-Beispiele und eine grüne CI-Basis auf `next`**.
 - Zentrale Produktpfade wie Demo, UI-Smokes, API-Fehlerverträge und ein erster Timer-Kernpfad sind inzwischen vorhanden.
-- Timer-Subscriptions werden jetzt auch in Storage/Web-API persistiert und über einen kleinen Scheduler-Polling-Pfad verarbeitet.
-- Es gibt aber weiterhin **offene Restlücken** bei weitergehender Timer-/Recovery-Semantik, Auth/Identity und Betriebsreife.
+- Timer-Subscriptions werden jetzt auch in Storage/Web-API persistiert, über einen kleinen Scheduler-Polling-Pfad verarbeitet und können wiederkehrende Start-Timer inklusive Restwiederholungen abbilden.
+- Es gibt aber weiterhin **offene Restlücken** bei weitergehender Timer-/Boundary-Recovery, Auth/Identity und Betriebsreife.
 - Das Projekt ist **klar revivierbar und aktiv weiterentwickelbar**, wenn die nächsten Schritte weiter fokussiert bleiben.
 
 Mehr Details: [docs/PROJECT-STATUS.md](docs/PROJECT-STATUS.md)
@@ -92,7 +92,7 @@ Diese Punkte sollte man kennen, bevor man loslegt:
    Test- und CI-Umgebungen laufen inzwischen auch ohne native V8-Abhängigkeit stabiler. Die vollständige FEEL-/V8-Strategie der Engine ist fachlich aber weiterhin ein eigener Architekturstrang.
 
 3. **Timer-, Fehler- und Abbruchpfade sind verbessert, aber noch nicht vollständig**
-   Der Engine-Kern kann fällige Timer jetzt weiterführen, Boundary-Timer im bestehenden Subscription-Pfad verarbeiten und rohe `NotImplementedException`-Abbrüche in mehreren Pfaden vermeiden. Offen bleiben weiterhin wiederkehrende Start-Timer, weitergehende Recovery-Fragen, vollständige Fehler-/Eskalationssemantik und echte Kompensation.
+   Der Engine-Kern kann fällige Timer jetzt weiterführen, Boundary-Timer im bestehenden Subscription-Pfad verarbeiten, wiederkehrende Start-Timer überfälligkeitstolerant nachziehen und rohe `NotImplementedException`-Abbrüche in mehreren Pfaden vermeiden. Offen bleiben weiterhin speziellere Recovery-Fragen, vollständige Fehler-/Eskalationssemantik und echte Kompensation.
 
 4. **Betrieb und Auth sind noch nicht am Ziel**
    Lokale Compose- und Runtime-Container sind vorhanden, aber Themen wie Telemetrie, Secrets, TLS, Recovery und eine belastbare Identity-/Auth-Story sind weiterhin Folgepakete.
@@ -113,9 +113,9 @@ Diese Punkte sollte man kennen, bevor man loslegt:
 
 Die sinnvolle Reihenfolge ist aktuell:
 
-1. **Timer-Recovery, wiederkehrende Start-Timer und weitergehende Fehlersemantik sauber nachziehen**
-2. **Auth-/Identity- und Fehlerpfade weiter produktionsnah härten**
-3. **Betriebsbasis mit Telemetrie, Secrets und Recovery vertiefen**
+1. **Auth-/Identity- und weitergehende Fehlersemantik produktionsnah härten**
+2. **Betriebsbasis mit Telemetrie, Secrets, TLS und Recovery vertiefen**
+3. **Timer-Recovery nur noch in speziellen Boundary-/Spezialfällen nachziehen**
 4. **Status-, Architektur- und Contributor-Dokumentation laufend nachziehen**
 
 Details dazu stehen in [docs/ROADMAP.md](docs/ROADMAP.md).
@@ -173,6 +173,8 @@ Weitere Betriebs- und Diagnosehinweise stehen in [docs/OPERATIONS.md](docs/OPERA
 
 Die Web-API enthält jetzt zusätzlich einen kleinen Hintergrund-Poller für fällige Timer-Subscriptions.
 
+Persistierte wiederkehrende Start-Timer werden dabei inklusive verbleibender Wiederholungen nachgezogen und nach einem Neustart wieder sauber auf den nächsten Fälligkeitszeitpunkt vorgeschoben.
+
 Relevante Konfiguration:
 
 ```json
@@ -186,6 +188,8 @@ Zusätzlich sichtbar sind Timer-Subscriptions jetzt über:
 
 - `GET /timer`
 - `GET /instance/{instanceId}/subscription/timers`
+
+Die API-DTOs für Timer enthalten dabei jetzt auch `RemainingOccurrences`, wenn ein Start-Timer über ein BPMN-`timeCycle` mit begrenzter Wiederholung definiert wurde.
 
 ## Runtime-Container für lokale Release-Checks
 

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -52,6 +52,8 @@ Unter anderem bereits umgesetzt:
 - Boundary-Timer im Parser, in der Runtime und im persistierten Timer-Subscription-Pfad
 - persistierte Timer-Subscriptions in Storage und Web-API
 - kleiner Scheduler-/Polling-Pfad im Web-API-Host für fällige Timer
+- wiederkehrende Start-Timer mit Restwiederholungen und Catch-up-Verhalten im Runtime-Pfad
+- Startup-Recovery für überfällige Start-Timer auf Basis persistierter Timer-Subscriptions
 - konsistentere Form-/Message-Fehlerverträge in Web-API und Business-Logic
 - Nullability- und Guard-Härtung in zentralen Frontend-Seiten
 - lokale Runtime-Containerbasis für API, Frontend und Gateway
@@ -63,7 +65,7 @@ Unter anderem bereits umgesetzt:
 Besonders relevant sind noch:
 
 - weiter ausgebautes Playwright-/E2E-Smoke-Set
-- Restlücken bei wiederkehrenden Timer-Strategien und weitergehender Scheduler-/Recovery-Semantik
+- Restlücken bei spezieller Boundary-/Spezialtimer-Recovery und weitergehender Scheduler-Semantik
 - weitere Auth-/Identity- und Fehlerpfade
 - Release-/Telemetrie-/Secret-/Recovery-Story über die lokale Basis hinaus
 
@@ -93,7 +95,7 @@ Die Basisdokumentation ist deutlich besser als zuvor, aber für die nächste Rei
 
 Die erste große Revitalisierungs- und Stabilisierungswelle ist inzwischen weitgehend abgearbeitet. Der nächste sinnvolle Backlog ergibt sich aktuell weniger aus alten Sammel-Issues, sondern aus den noch verbleibenden Produktlücken:
 
-- weitergehende Timer-Recovery sowie BPMN-Fehler-/Eskalationssemantik
+- weitergehende Boundary-/Spezialtimer-Recovery sowie BPMN-Fehler-/Eskalationssemantik
 - Auth-/Identity-Härtung
 - Telemetrie, Secrets, Recovery und operationsnahe Doku
 - weitere Architektur- und Repo-Hygiene
@@ -104,9 +106,9 @@ Das Projekt sollte jetzt **nicht mehr primär gerettet**, sondern gezielt **zur 
 
 Die sinnvolle Reihenfolge ist aus heutiger Sicht:
 
-1. Timer-Recovery und wiederkehrende Start-Timer weiter abbauen
-2. Auth-/Identity- und API-Verträge weiter schärfen
-3. Betriebsbasis um Telemetrie, Secrets, TLS und Recovery erweitern
+1. Auth-/Identity- und API-Verträge weiter schärfen
+2. Betriebsbasis um Telemetrie, Secrets, TLS und Recovery erweitern
+3. Timer-Recovery nur noch in verbleibenden Spezialfällen weiter vertiefen
 4. E2E-, Architektur- und Operations-Dokumentation weiter vertiefen
 
 ## Gesamturteil

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,6 +17,8 @@ Die erste große Stabilisierungsrunde ist bereits erfolgt:
 - Boundary-Timer im Parser, in der Runtime und im persistierten Subscription-Pfad ergänzt
 - persistierte Timer-Subscriptions in Storage/Web-API ergänzt
 - Scheduler-/Polling-Pfad für fällige Timer im Web-API-Host ergänzt
+- wiederkehrende Start-Timer inklusive Restwiederholungen und Catch-up-Verhalten ergänzt
+- Startup-Recovery für überfällige Start-Timer über persistierte Timer-Subscriptions ergänzt
 - Form-/Message-Fehlerverträge in der Web-API weiter geschärft
 - lokale und CI-nahe Testpfade wieder grün gemacht
 - lokale Runtime-Containerbasis für Release-nahe Prüfpfade ergänzt
@@ -35,8 +37,8 @@ Die Roadmap startet also **nicht mehr bei Null**, sondern baut auf einer funktio
 
 ### 1.3 Timer-Recovery und wiederkehrende Strategien vertiefen
 
-- Recovery-Verhalten für bereits persistierte Timer nach Neustarts weiter härten
-- wiederkehrende Start-Timer über den ersten Due-Zeitpunkt hinaus sauber modellieren
+- Recovery-Verhalten für bereits persistierte Boundary- und Spezialtimer nach Neustarts weiter härten
+- wiederkehrende Start-Timer nur noch bei komplexeren Spezialfällen vertiefen
 - wiederkehrende Boundary- oder Spezialtimer nur dann ergänzen, wenn sie fachlich wirklich benötigt werden
 
 ## Priorität 2: Betriebs- und Auth-Reife erhöhen
@@ -72,8 +74,8 @@ Die Roadmap startet also **nicht mehr bei Null**, sondern baut auf einer funktio
 
 ### Sprint A – Timer-Runtime vertiefen
 
-- Timer-Recovery
-- wiederkehrende Timer-Strategien
+- Boundary-/Spezialtimer-Recovery
+- verbleibende wiederkehrende Spezialtimer
 - verbleibende Boundary-Timer-Randfälle
 
 ### Sprint B – Betrieb und Auth

--- a/docs/RUNTIME-GAPS.md
+++ b/docs/RUNTIME-GAPS.md
@@ -37,13 +37,20 @@ Dieses Dokument hält die aktuell noch offenen Laufzeit- und Engine-Lücken fest
 - fällige Boundary-Timer werden im `HandleTime(...)`-Pfad genau einmal ausgelöst.
 - interrupting Boundary-Timer ziehen die Aktivität zurück, non-interrupting Boundary-Timer starten einen parallelen Pfad.
 
-### 6. User-Task-Ergebnisse haben einen stabileren Laufzeitvertrag
+### 6. Wiederkehrende Start-Timer und Start-Timer-Recovery sind jetzt als Runtime-Pfad vorhanden
+
+- begrenzte `timeCycle`-Definitionen wie `R3/PT2S` werden jetzt mit `RemainingOccurrences` als Teil der Timer-Subscription persistiert.
+- `ProcessEngine.HandleTime(...)` zieht überfällige Start-Timer jetzt mehrfach nach, bis wieder ein zukünftiger Fälligkeitszeitpunkt erreicht ist.
+- `BpmnBusinessLogic.HandleTime(...)` reschedult wiederkehrende Start-Timer im Storage-Pfad konsistent weiter.
+- `BpmnBusinessLogic.Load()` kann überfällige Start-Timer nach einem Neustart direkt wieder anstoßen und auf den nächsten Due-Zeitpunkt vorschieben.
+
+### 7. User-Task-Ergebnisse haben einen stabileren Laufzeitvertrag
 
 - User-Task-Ergebnisse ohne `ProcessInstanceId` laufen nicht mehr in eine rohe `NotImplementedException`.
 - Stattdessen kommt ein valider `400 Bad Request` mit einem klaren API-Fehlervertrag zurück.
 - Zusätzlich wird jetzt geprüft, ob das übergebene `TokenId` wirklich noch aktiv ist und zum erwarteten `FlowNodeId` gehört.
 
-### 7. Instanzabbruch ist als Best-Effort-Pfad verfügbar
+### 8. Instanzabbruch ist als Best-Effort-Pfad verfügbar
 
 - `InstanceEngine.Cancel()` terminiert jetzt aktive/wartende Tokens der Instanz konsistent.
 - Das ersetzt noch **keine vollständige BPMN-Kompensation**, verhindert aber, dass der API-/Runtime-Pfad an einer nackten `NotImplementedException` scheitert.
@@ -59,11 +66,13 @@ Aktuell vorhanden:
 - einmaliger Engine-Kernpfad für fällige Timer-Starts und Intermediate-Timer
 - persistierte Timer-Subscriptions in Storage und Web-API
 - kleiner Scheduler-/Polling-Pfad rund um `HandleTime(...)`
+- wiederkehrende Start-Timer mit Catch-up und verbleibenden Wiederholungen
+- Startup-Recovery für überfällige Start-Timer
 
 Weiterhin offen:
 
-- Recovery-Strategie für bereits persistierte Start-Timer über harte Neustarts hinweg weiter schärfen
-- vollständige Wiederholungsstrategie für zyklische Start-Timer über den ersten Due-Zeitpunkt hinaus
+- Recovery-Strategie für bereits persistierte Boundary- oder Spezialtimer über harte Neustarts hinweg weiter schärfen
+- weitergehende Wiederholungsstrategie für Spezialfälle jenseits des aktuellen Start-Timer-Pfads
 - Sonderfälle wie konkurrierende Timer oder weitergehende Boundary-Timer-Recovery nur bei echtem Bedarf vertiefen
 
 ### 2. Fehler- und Eskalationspfade
@@ -95,7 +104,7 @@ Nicht enthalten:
 
 ## Empfohlene nächste Runtime-Schritte
 
-1. Recovery- und Wiederholungsstrategie für Start-Timer weiter härten
+1. Recovery- und Wiederholungsstrategie nur noch für Boundary- und Spezialtimer weiter härten
 2. Error-/Escalation-Semantik gezielt modellieren und testen
 3. `Cancel()` später um echte Kompensationsstrategien erweitern
 4. Boundary-Timer nur noch bei echten Randfällen weiter vertiefen

--- a/src/WebApiEngine.Shared/TimerSubscriptionDto.cs
+++ b/src/WebApiEngine.Shared/TimerSubscriptionDto.cs
@@ -10,5 +10,6 @@ public class TimerSubscriptionDto
     public Guid DefinitionId { get; set; }
     public Guid? ProcessInstanceId { get; set; }
     public Guid? TokenId { get; set; }
+    public int? RemainingOccurrences { get; set; }
     public string Kind { get; set; } = string.Empty;
 }

--- a/src/WebApiEngine.Tests/TimerControllerIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/TimerControllerIntegrationTest.cs
@@ -30,7 +30,8 @@ public class TimerControllerIntegrationTest
                 Kind = TimerSubscriptionKind.ProcessStartEvent,
                 ProcessId = "Process_Start",
                 RelatedDefinitionId = "definition-start",
-                DefinitionId = definitionId
+                DefinitionId = definitionId,
+                RemainingOccurrences = 3
             },
             new TimerSubscription
             {
@@ -56,6 +57,7 @@ public class TimerControllerIntegrationTest
         payload!.Successful.Should().BeTrue();
         payload.Result.Should().HaveCount(2);
         payload.Result!.Should().Contain(subscription => subscription.Kind == nameof(TimerSubscriptionKind.ProcessStartEvent));
+        payload.Result.Should().Contain(subscription => subscription.RemainingOccurrences == 3);
         payload.Result.Should().Contain(subscription => subscription.ProcessInstanceId == instanceId);
     }
 

--- a/src/WebApiEngine.Tests/TimerRuntimeIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/TimerRuntimeIntegrationTest.cs
@@ -169,6 +169,44 @@ public class TimerRuntimeIntegrationTest
     }
 
     [Test]
+    public async Task HandleTime_ShouldRecoverLegacyRecurringDefinitionTimer_WhenRemainingOccurrencesWereNotPersistedYet()
+    {
+        var definition = CreateDefinition();
+        var storage = new TimerRuntimeTestStorage();
+        storage.Definitions[definition.Id] = definition;
+        storage.Binaries[definition.Id] = CreateRecurringTimerStartXml("R3");
+
+        var businessLogic = new BpmnBusinessLogic(new TestTransactionalStorageProvider(storage));
+        await businessLogic.DeployDefinition(definition);
+
+        var persistedSubscription = storage.TimerSubscriptions.Should().ContainSingle().Subject;
+        storage.TimerSubscriptions[0] = new TimerSubscription
+        {
+            Id = persistedSubscription.Id,
+            DueAt = persistedSubscription.DueAt,
+            FlowNodeId = persistedSubscription.FlowNodeId,
+            Kind = persistedSubscription.Kind,
+            ProcessId = persistedSubscription.ProcessId,
+            RelatedDefinitionId = persistedSubscription.RelatedDefinitionId,
+            DefinitionId = persistedSubscription.DefinitionId,
+            ProcessInstanceId = persistedSubscription.ProcessInstanceId,
+            TokenId = persistedSubscription.TokenId,
+            RemainingOccurrences = null
+        };
+
+        var processedTimers = await businessLogic.HandleTime(persistedSubscription.DueAt.AddMilliseconds(50));
+
+        var nextSubscription = storage.TimerSubscriptions.Should().ContainSingle().Subject;
+        using (new AssertionScope())
+        {
+            processedTimers.Should().Be(1);
+            storage.Instances.Should().ContainSingle();
+            nextSubscription.RemainingOccurrences.Should().Be(2);
+            nextSubscription.DueAt.Should().BeCloseTo(persistedSubscription.DueAt.AddSeconds(2), TimeSpan.FromMilliseconds(250));
+        }
+    }
+
+    [Test]
     public async Task HandleTime_ShouldAdvanceDueInstanceTimer_AndClearPersistedInstanceTimer()
     {
         var definitionId = Guid.NewGuid();

--- a/src/WebApiEngine.Tests/TimerRuntimeIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/TimerRuntimeIntegrationTest.cs
@@ -2,6 +2,7 @@ using BPMN.Process;
 using core_engine;
 using core_engine.Extensions;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Model;
 using StorageSystem;
 using WebApiEngine.BusinessLogic;
@@ -41,6 +42,23 @@ public class TimerRuntimeIntegrationTest
     }
 
     [Test]
+    public async Task DeployDefinition_ShouldPersistRecurringProcessStartTimerSubscriptionWithRemainingOccurrences()
+    {
+        var definition = CreateDefinition();
+        var storage = new TimerRuntimeTestStorage();
+        storage.Definitions[definition.Id] = definition;
+        storage.Binaries[definition.Id] = CreateRecurringTimerStartXml("R3");
+
+        var businessLogic = new BpmnBusinessLogic(new TestTransactionalStorageProvider(storage));
+
+        await businessLogic.DeployDefinition(definition);
+
+        var timerSubscription = storage.TimerSubscriptions.Should().ContainSingle().Subject;
+        timerSubscription.Kind.Should().Be(TimerSubscriptionKind.ProcessStartEvent);
+        timerSubscription.RemainingOccurrences.Should().Be(3);
+    }
+
+    [Test]
     public async Task HandleTime_ShouldStartDueDefinitionTimer_AndRemoveStartSubscription()
     {
         var definition = CreateDefinition();
@@ -58,6 +76,96 @@ public class TimerRuntimeIntegrationTest
         storage.Instances.Should().ContainSingle();
         storage.Instances.Values.Single().State.Should().Be(ProcessInstanceState.Completed);
         storage.Instances.Values.Single().IsFinished.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task HandleTime_ShouldRescheduleRecurringDefinitionTimer_AfterFirstTrigger()
+    {
+        var definition = CreateDefinition();
+        var storage = new TimerRuntimeTestStorage();
+        storage.Definitions[definition.Id] = definition;
+        storage.Binaries[definition.Id] = CreateRecurringTimerStartXml("R3");
+
+        var businessLogic = new BpmnBusinessLogic(new TestTransactionalStorageProvider(storage));
+        await businessLogic.DeployDefinition(definition);
+
+        var initialSubscription = storage.TimerSubscriptions.Should().ContainSingle().Subject;
+
+        var processedTimers = await businessLogic.HandleTime(initialSubscription.DueAt.AddMilliseconds(50));
+
+        var nextSubscription = storage.TimerSubscriptions.Should().ContainSingle().Subject;
+        using (new AssertionScope())
+        {
+            processedTimers.Should().Be(1);
+            storage.Instances.Should().ContainSingle();
+            nextSubscription.RemainingOccurrences.Should().Be(2);
+            nextSubscription.DueAt.Should().BeCloseTo(initialSubscription.DueAt.AddSeconds(2), TimeSpan.FromMilliseconds(250));
+        }
+    }
+
+    [Test]
+    public async Task HandleTime_ShouldCatchUpRecurringDefinitionTimer_AndKeepNextDueSubscription()
+    {
+        var definition = CreateDefinition();
+        var storage = new TimerRuntimeTestStorage();
+        storage.Definitions[definition.Id] = definition;
+        storage.Binaries[definition.Id] = CreateRecurringTimerStartXml("R3");
+
+        var businessLogic = new BpmnBusinessLogic(new TestTransactionalStorageProvider(storage));
+        await businessLogic.DeployDefinition(definition);
+
+        var initialSubscription = storage.TimerSubscriptions.Should().ContainSingle().Subject;
+        var catchUpTime = initialSubscription.DueAt.AddSeconds(2).AddMilliseconds(50);
+
+        var processedTimers = await businessLogic.HandleTime(catchUpTime);
+
+        var nextSubscription = storage.TimerSubscriptions.Should().ContainSingle().Subject;
+        using (new AssertionScope())
+        {
+            processedTimers.Should().Be(2);
+            storage.Instances.Should().HaveCount(2);
+            nextSubscription.RemainingOccurrences.Should().Be(1);
+            nextSubscription.DueAt.Should().BeCloseTo(initialSubscription.DueAt.AddSeconds(4), TimeSpan.FromMilliseconds(250));
+        }
+    }
+
+    [Test]
+    public async Task Load_ShouldRecoverOverdueRecurringDefinitionTimer_AndKeepNextDueSubscription()
+    {
+        var definition = CreateDefinition();
+        var storage = new TimerRuntimeTestStorage();
+        storage.Definitions[definition.Id] = definition;
+        storage.Binaries[definition.Id] = CreateRecurringTimerStartXml("R5");
+
+        var deployBusinessLogic = new BpmnBusinessLogic(new TestTransactionalStorageProvider(storage));
+        await deployBusinessLogic.DeployDefinition(definition);
+
+        var persistedSubscription = storage.TimerSubscriptions.Should().ContainSingle().Subject;
+        var recoveredDueAt = DateTime.UtcNow.AddSeconds(-5);
+        storage.TimerSubscriptions[0] = new TimerSubscription
+        {
+            Id = persistedSubscription.Id,
+            DueAt = recoveredDueAt,
+            FlowNodeId = persistedSubscription.FlowNodeId,
+            Kind = persistedSubscription.Kind,
+            ProcessId = persistedSubscription.ProcessId,
+            RelatedDefinitionId = persistedSubscription.RelatedDefinitionId,
+            DefinitionId = persistedSubscription.DefinitionId,
+            ProcessInstanceId = persistedSubscription.ProcessInstanceId,
+            TokenId = persistedSubscription.TokenId,
+            RemainingOccurrences = persistedSubscription.RemainingOccurrences
+        };
+
+        var recoveredBusinessLogic = new BpmnBusinessLogic(new TestTransactionalStorageProvider(storage));
+        recoveredBusinessLogic.Load();
+
+        var nextSubscription = storage.TimerSubscriptions.Should().ContainSingle().Subject;
+        using (new AssertionScope())
+        {
+            storage.Instances.Should().HaveCount(3);
+            nextSubscription.RemainingOccurrences.Should().Be(2);
+            nextSubscription.DueAt.Should().BeCloseTo(recoveredDueAt.AddSeconds(6), TimeSpan.FromMilliseconds(500));
+        }
     }
 
     [Test]
@@ -212,6 +320,31 @@ public class TimerRuntimeIntegrationTest
                      <bpmn:outgoing>Flow_1</bpmn:outgoing>
                      <bpmn:timerEventDefinition id="TimerDefinition_1">
                        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">PT2S</bpmn:timeDuration>
+                     </bpmn:timerEventDefinition>
+                   </bpmn:startEvent>
+                   <bpmn:endEvent id="EndEvent_1">
+                     <bpmn:incoming>Flow_1</bpmn:incoming>
+                   </bpmn:endEvent>
+                   <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_Timer" targetRef="EndEvent_1" />
+                 </bpmn:process>
+               </bpmn:definitions>
+               """;
+    }
+
+    private static string CreateRecurringTimerStartXml(string repetitionToken)
+    {
+        return $$"""
+               <?xml version="1.0" encoding="UTF-8"?>
+               <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                 xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                 id="Definitions_RecurringTimerStart"
+                                 targetNamespace="http://bpmn.io/schema/bpmn">
+                 <bpmn:process id="Process_RecurringTimerStart" isExecutable="true">
+                   <bpmn:startEvent id="StartEvent_Timer">
+                     <bpmn:outgoing>Flow_1</bpmn:outgoing>
+                     <bpmn:timerEventDefinition id="TimerDefinition_1">
+                       <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">{{repetitionToken}}/PT2S</bpmn:timeCycle>
                      </bpmn:timerEventDefinition>
                    </bpmn:startEvent>
                    <bpmn:endEvent id="EndEvent_1">

--- a/src/WebApiEngine.Tests/TimerSubscriptionStorageTest.cs
+++ b/src/WebApiEngine.Tests/TimerSubscriptionStorageTest.cs
@@ -17,7 +17,8 @@ public class TimerSubscriptionStorageTest
             TimerSubscriptionKind.ProcessStartEvent,
             processInstanceId: null,
             tokenId: null,
-            flowNodeId: "StartEvent_Timer");
+            flowNodeId: "StartEvent_Timer",
+            remainingOccurrences: 3);
         var instanceTimer = context.CreateTimerSubscription(
             TimerSubscriptionKind.IntermediateCatchEvent,
             processInstanceId: instanceId,
@@ -33,6 +34,7 @@ public class TimerSubscriptionStorageTest
         allTimers.Should().HaveCount(2);
         allTimers.Should().Contain(subscription => subscription.Id == definitionTimer.Id);
         allTimers.Should().Contain(subscription => subscription.Id == instanceTimer.Id);
+        allTimers.Should().Contain(subscription => subscription.RemainingOccurrences == 3);
         instanceTimers.Should().ContainSingle(subscription => subscription.Id == instanceTimer.Id);
     }
 
@@ -100,7 +102,8 @@ public class TimerSubscriptionStorageTest
             TimerSubscriptionKind kind,
             Guid? processInstanceId,
             Guid? tokenId,
-            string flowNodeId)
+            string flowNodeId,
+            int? remainingOccurrences = null)
         {
             return new TimerSubscription
             {
@@ -111,7 +114,8 @@ public class TimerSubscriptionStorageTest
                 RelatedDefinitionId = RelatedDefinitionId,
                 DefinitionId = DefinitionId,
                 ProcessInstanceId = processInstanceId,
-                TokenId = tokenId
+                TokenId = tokenId,
+                RemainingOccurrences = remainingOccurrences
             };
         }
 

--- a/src/WebApiEngine/BusinessLogic/BpmnBusinessLogic.cs
+++ b/src/WebApiEngine/BusinessLogic/BpmnBusinessLogic.cs
@@ -1,5 +1,6 @@
 using BPMN.HumanInteraction;
 using BPMN.Process;
+using BPMN.Flowzer.Events;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace WebApiEngine.BusinessLogic;
@@ -155,7 +156,8 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider, IL
                 RelatedDefinitionId = relatedDefinitionId,
                 DefinitionId = definitionId,
                 ProcessInstanceId = processInstanceId,
-                TokenId = activeTimer.TokenId
+                TokenId = activeTimer.TokenId,
+                RemainingOccurrences = activeTimer.RemainingOccurrences
             });
         }
     }
@@ -175,8 +177,7 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider, IL
         {
             try
             {
-                await HandleStartTimer(storageSystem, dueStartTimer);
-                processedTimers++;
+                processedTimers += await HandleStartTimer(storageSystem, dueStartTimer, time);
             }
             catch (Exception exception)
             {
@@ -369,7 +370,10 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider, IL
         storageSystem.CommitChanges();
     }
 
-    private async Task HandleStartTimer(ITransactionalStorage storageSystem, TimerSubscription timerSubscription)
+    private async Task<int> HandleStartTimer(
+        ITransactionalStorage storageSystem,
+        TimerSubscription timerSubscription,
+        DateTime time)
     {
         var xmlData = await storageSystem.DefinitionStorage.GetBinary(timerSubscription.DefinitionId);
         var model = ModelParser.ParseModel(xmlData);
@@ -380,15 +384,42 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider, IL
                 $"No process with the id \"{timerSubscription.ProcessId}\" was found in the definition with the id \"{timerSubscription.DefinitionId}\".");
         }
 
-        var processEngine = new ProcessEngine(process);
-        var instance = processEngine.StartProcessByTimerStartEvent(timerSubscription.FlowNodeId);
-        await SaveInstance(
-            storageSystem,
-            instance,
-            timerSubscription.RelatedDefinitionId,
-            timerSubscription.DefinitionId,
-            timerSubscription.ProcessId);
+        var startEvent = process.FlowElements
+            .OfType<FlowzerTimerStartEvent>()
+            .SingleOrDefault(candidate => string.Equals(candidate.Id, timerSubscription.FlowNodeId, StringComparison.Ordinal))
+            ?? throw new FileNotFoundException(
+                $"No timer start event with the id \"{timerSubscription.FlowNodeId}\" was found in the process \"{timerSubscription.ProcessId}\".");
+
+        var processedTimers = 0;
+        TimerSubscription? currentTimerSubscription = timerSubscription;
+
+        while (currentTimerSubscription != null && currentTimerSubscription.DueAt <= time)
+        {
+            var processEngine = new ProcessEngine(process);
+            var instance = processEngine.StartProcessByTimerStartEvent(currentTimerSubscription.FlowNodeId);
+            await SaveInstance(
+                storageSystem,
+                instance,
+                currentTimerSubscription.RelatedDefinitionId,
+                currentTimerSubscription.DefinitionId,
+                currentTimerSubscription.ProcessId);
+            processedTimers++;
+
+            if (!TryAdvanceStartTimerSubscription(startEvent, currentTimerSubscription, out currentTimerSubscription))
+            {
+                currentTimerSubscription = null;
+                break;
+            }
+        }
+
         await storageSystem.SubscriptionStorage.RemoveTimerSubscription(timerSubscription.Id);
+
+        if (currentTimerSubscription != null)
+        {
+            await storageSystem.SubscriptionStorage.AddTimerSubscription(currentTimerSubscription);
+        }
+
+        return processedTimers;
     }
 
     private async Task HandleInstanceTimers(ITransactionalStorage storageSystem, Guid instanceId, DateTime time)
@@ -404,7 +435,41 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider, IL
     {
         return processInstance.Tokens.Count(token => token.ParentTokenId == null) == 1;
     }
-    
+
+    private static bool TryAdvanceStartTimerSubscription(
+        FlowzerTimerStartEvent startEvent,
+        TimerSubscription timerSubscription,
+        out TimerSubscription? nextTimerSubscription)
+    {
+        var currentSchedule = new TimerSchedule(
+            timerSubscription.DueAt,
+            TimerScheduleCalculator.CreateInitialSchedule(
+                timerSubscription.DueAt,
+                startEvent.TimerDefinition,
+                startEvent).RepeatInterval,
+            timerSubscription.RemainingOccurrences);
+
+        if (!TimerScheduleCalculator.TryAdvanceSchedule(currentSchedule, out var nextSchedule))
+        {
+            nextTimerSubscription = null;
+            return false;
+        }
+
+        nextTimerSubscription = new TimerSubscription
+        {
+            Id = timerSubscription.Id,
+            DueAt = nextSchedule.DueAt,
+            FlowNodeId = timerSubscription.FlowNodeId,
+            Kind = timerSubscription.Kind,
+            ProcessId = timerSubscription.ProcessId,
+            RelatedDefinitionId = timerSubscription.RelatedDefinitionId,
+            DefinitionId = timerSubscription.DefinitionId,
+            ProcessInstanceId = timerSubscription.ProcessInstanceId,
+            TokenId = timerSubscription.TokenId,
+            RemainingOccurrences = nextSchedule.RemainingOccurrences
+        };
+        return true;
+    }
 
 
 }

--- a/src/WebApiEngine/BusinessLogic/BpmnBusinessLogic.cs
+++ b/src/WebApiEngine/BusinessLogic/BpmnBusinessLogic.cs
@@ -387,7 +387,7 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider, IL
         var startEvent = process.FlowElements
             .OfType<FlowzerTimerStartEvent>()
             .SingleOrDefault(candidate => string.Equals(candidate.Id, timerSubscription.FlowNodeId, StringComparison.Ordinal))
-            ?? throw new FileNotFoundException(
+            ?? throw new InvalidOperationException(
                 $"No timer start event with the id \"{timerSubscription.FlowNodeId}\" was found in the process \"{timerSubscription.ProcessId}\".");
 
         var processedTimers = 0;
@@ -441,13 +441,15 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider, IL
         TimerSubscription timerSubscription,
         out TimerSubscription? nextTimerSubscription)
     {
+        var initialSchedule = TimerScheduleCalculator.CreateInitialSchedule(
+            timerSubscription.DueAt,
+            startEvent.TimerDefinition,
+            startEvent);
+
         var currentSchedule = new TimerSchedule(
             timerSubscription.DueAt,
-            TimerScheduleCalculator.CreateInitialSchedule(
-                timerSubscription.DueAt,
-                startEvent.TimerDefinition,
-                startEvent).RepeatInterval,
-            timerSubscription.RemainingOccurrences);
+            initialSchedule.RepeatInterval,
+            timerSubscription.RemainingOccurrences ?? initialSchedule.RemainingOccurrences);
 
         if (!TimerScheduleCalculator.TryAdvanceSchedule(currentSchedule, out var nextSchedule))
         {

--- a/src/WebApiEngine/Mappers/InteractionMappingExtensions.cs
+++ b/src/WebApiEngine/Mappers/InteractionMappingExtensions.cs
@@ -107,6 +107,7 @@ public static class InteractionMappingExtensions
             DefinitionId = timerSubscription.DefinitionId,
             ProcessInstanceId = timerSubscription.ProcessInstanceId,
             TokenId = timerSubscription.TokenId,
+            RemainingOccurrences = timerSubscription.RemainingOccurrences,
             Kind = timerSubscription.Kind.ToString()
         };
     }

--- a/src/core-engine-tests/EngineTest.cs
+++ b/src/core-engine-tests/EngineTest.cs
@@ -438,11 +438,16 @@ public class EngineTest
         var process = model.GetProcesses();
         var processEngine = Helper.CreateProcessEngine(process.First());
         var activeTimers = processEngine.ActiveTimers.ToArray();
+        var timerSubscription = processEngine.ActiveTimerSubscriptions.Should().ContainSingle().Subject;
         activeTimers.Should().HaveCount(1);
         var dueDate = activeTimers.Single();
         var remainingTime = dueDate - DateTime.UtcNow;
-        remainingTime.Should().BeGreaterOrEqualTo(TimeSpan.FromSeconds(1));
-        remainingTime.Should().BeLessOrEqualTo(TimeSpan.FromSeconds(2.5));
+        using (new AssertionScope())
+        {
+            remainingTime.Should().BeGreaterOrEqualTo(TimeSpan.FromSeconds(1));
+            remainingTime.Should().BeLessOrEqualTo(TimeSpan.FromSeconds(2.5));
+            timerSubscription.RemainingOccurrences.Should().Be(10);
+        }
     }
 
     [Test]
@@ -490,6 +495,44 @@ public class EngineTest
                 .Should()
                 .ContainSingle("timer-start-step");
             processEngine.ActiveTimers.Should().BeEmpty();
+        }
+    }
+
+    [Test]
+    public void RecurringTimerStartEvent_ShouldRescheduleAfterFirstTrigger()
+    {
+        var processEngine = CreateProcessEngineFromXml(CreateRecurringTimerStartXml(repetitionToken: "R3"));
+
+        var initialSubscription = processEngine.ActiveTimerSubscriptions.Should().ContainSingle().Subject;
+
+        var instances = processEngine.HandleTime(initialSubscription.DueAt.AddMilliseconds(50));
+
+        var nextSubscription = processEngine.ActiveTimerSubscriptions.Should().ContainSingle().Subject;
+        using (new AssertionScope())
+        {
+            instances.Should().ContainSingle();
+            initialSubscription.RemainingOccurrences.Should().Be(3);
+            nextSubscription.RemainingOccurrences.Should().Be(2);
+            nextSubscription.DueAt.Should().BeCloseTo(initialSubscription.DueAt.AddSeconds(2), TimeSpan.FromMilliseconds(250));
+        }
+    }
+
+    [Test]
+    public void RecurringTimerStartEvent_ShouldCatchUpMissedOccurrencesAndKeepNextDueDate()
+    {
+        var processEngine = CreateProcessEngineFromXml(CreateRecurringTimerStartXml(repetitionToken: "R3"));
+
+        var initialSubscription = processEngine.ActiveTimerSubscriptions.Should().ContainSingle().Subject;
+        var catchUpTime = initialSubscription.DueAt.AddSeconds(2).AddMilliseconds(50);
+
+        var instances = processEngine.HandleTime(catchUpTime);
+
+        var nextSubscription = processEngine.ActiveTimerSubscriptions.Should().ContainSingle().Subject;
+        using (new AssertionScope())
+        {
+            instances.Should().HaveCount(2);
+            nextSubscription.RemainingOccurrences.Should().Be(1);
+            nextSubscription.DueAt.Should().BeCloseTo(initialSubscription.DueAt.AddSeconds(4), TimeSpan.FromMilliseconds(250));
         }
     }
 
@@ -798,6 +841,39 @@ public class EngineTest
                      <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="ServiceTask_1" />
                      <bpmn:sequenceFlow id="Flow_2" sourceRef="ServiceTask_1" targetRef="EndEvent_Main" />
                      <bpmn:sequenceFlow id="Flow_3" sourceRef="BoundaryTimer_1" targetRef="{{boundaryTarget}}" />
+                   </bpmn:process>
+                 </bpmn:definitions>
+                 """;
+    }
+
+    private static string CreateRecurringTimerStartXml(string repetitionToken)
+    {
+        return $$"""
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                   xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                   id="Definitions_RecurringTimerStart"
+                                   targetNamespace="http://bpmn.io/schema/bpmn">
+                   <bpmn:process id="Process_RecurringTimerStart" isExecutable="true">
+                     <bpmn:startEvent id="StartEvent_Recurring">
+                       <bpmn:outgoing>Flow_1</bpmn:outgoing>
+                       <bpmn:timerEventDefinition id="TimerDefinition_1">
+                         <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">{{repetitionToken}}/PT2S</bpmn:timeCycle>
+                       </bpmn:timerEventDefinition>
+                     </bpmn:startEvent>
+                     <bpmn:serviceTask id="ServiceTask_1" name="Wait for worker">
+                       <bpmn:extensionElements>
+                         <zeebe:taskDefinition type="recurring-timer-step" />
+                       </bpmn:extensionElements>
+                       <bpmn:incoming>Flow_1</bpmn:incoming>
+                       <bpmn:outgoing>Flow_2</bpmn:outgoing>
+                     </bpmn:serviceTask>
+                     <bpmn:endEvent id="EndEvent_1">
+                       <bpmn:incoming>Flow_2</bpmn:incoming>
+                     </bpmn:endEvent>
+                     <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_Recurring" targetRef="ServiceTask_1" />
+                     <bpmn:sequenceFlow id="Flow_2" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
                    </bpmn:process>
                  </bpmn:definitions>
                  """;

--- a/src/core-engine-tests/EngineTest.cs
+++ b/src/core-engine-tests/EngineTest.cs
@@ -5,6 +5,7 @@ using Flowzer.Shared;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Model;
+using core_engine.Exceptions;
 using Task = System.Threading.Tasks.Task;
 
 namespace core_engine_tests;
@@ -534,6 +535,35 @@ public class EngineTest
             nextSubscription.RemainingOccurrences.Should().Be(1);
             nextSubscription.DueAt.Should().BeCloseTo(initialSubscription.DueAt.AddSeconds(4), TimeSpan.FromMilliseconds(250));
         }
+    }
+
+    [Test]
+    public void RecurringTimerStartEvent_ShouldRejectNonPositiveRepeatIntervals()
+    {
+        Action act = () => CreateProcessEngineFromXml("""
+                                                      <?xml version="1.0" encoding="UTF-8"?>
+                                                      <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                                                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                                                        id="Definitions_InvalidRecurringTimerStart"
+                                                                        targetNamespace="http://bpmn.io/schema/bpmn">
+                                                        <bpmn:process id="Process_InvalidRecurringTimerStart" isExecutable="true">
+                                                          <bpmn:startEvent id="StartEvent_Timer">
+                                                            <bpmn:outgoing>Flow_1</bpmn:outgoing>
+                                                            <bpmn:timerEventDefinition id="TimerDefinition_1">
+                                                              <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R3/PT0S</bpmn:timeCycle>
+                                                            </bpmn:timerEventDefinition>
+                                                          </bpmn:startEvent>
+                                                          <bpmn:endEvent id="EndEvent_1">
+                                                            <bpmn:incoming>Flow_1</bpmn:incoming>
+                                                          </bpmn:endEvent>
+                                                          <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_Timer" targetRef="EndEvent_1" />
+                                                        </bpmn:process>
+                                                      </bpmn:definitions>
+                                                      """);
+
+        act.Should()
+            .Throw<ModelValidationException>()
+            .WithMessage("*positive ISO-8601 duration interval*");
     }
 
     [Test]

--- a/src/core-engine/ProcessEngine.cs
+++ b/src/core-engine/ProcessEngine.cs
@@ -3,13 +3,24 @@ using Newtonsoft.Json;
 
 namespace core_engine;
 
-public class ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null) : ICatchHandler
+public class ProcessEngine : ICatchHandler
 {
+    private readonly Dictionary<string, TimerStartState> _timerStartStates;
     private readonly DateTime _timerReferenceTime = DateTime.UtcNow;
-    private readonly HashSet<string> _triggeredTimerStartEventIds = [];
-    
-    public Process Process { get; set; } = process;
-    public FlowzerConfig FlowzerConfig { get; } = flowzerConfig ?? FlowzerConfig.Default;
+
+    public ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null)
+    {
+        Process = process;
+        FlowzerConfig = flowzerConfig ?? FlowzerConfig.Default;
+        _timerStartStates = Process.FlowElements
+            .OfType<FlowzerTimerStartEvent>()
+            .Select(startEvent => TimerStartState.Create(startEvent, _timerReferenceTime))
+            .Where(state => state.HasPendingOccurrence)
+            .ToDictionary(state => state.StartEvent.Id, StringComparer.Ordinal);
+    }
+
+    public Process Process { get; set; }
+    public FlowzerConfig FlowzerConfig { get; }
 
     public InstanceEngine StartProcess(Variables? data = null)
     {
@@ -22,34 +33,27 @@ public class ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(flowNodeId);
 
-        var startEvent = Process.FlowElements
-            .OfType<FlowzerTimerStartEvent>()
-            .SingleOrDefault(element => string.Equals(element.Id, flowNodeId, StringComparison.Ordinal))
-            ?? throw new ArgumentException(
+        if (!_timerStartStates.TryGetValue(flowNodeId, out var timerStartState))
+        {
+            throw new ArgumentException(
                 $"No timer start event with the id \"{flowNodeId}\" exists in process \"{Process.Id}\".",
                 nameof(flowNodeId));
+        }
 
         var instance = CreateInstanceEngine();
-        instance.HandleTime(DateTime.UtcNow, startEvent);
-        _triggeredTimerStartEventIds.Add(startEvent.Id);
+        instance.HandleTime(DateTime.UtcNow, timerStartState.StartEvent);
+
+        AdvanceOrRemoveTimerStartState(timerStartState);
+
         return instance;
     }
-
-    // public async Task<InstanceEngine> HandleTime(DateTime time)
-    // {
-    //     var processInstance = new ProcessInstance
-    //     {
-    //         ProcessModel = Process
-    //     };
-    //     return  new InstanceEngine(processInstance);
-    // }
 
     public InstanceEngine HandleMessage(Message message)
     {
         var instanceEngine = CreateInstanceEngine();
 
         instanceEngine.HandleMessage(message);
-        
+
         return instanceEngine;
     }
 
@@ -59,53 +63,59 @@ public class ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null)
             .OfType<FlowzerSignalStartEvent>()
             .Where(e => e.Signal.Name == signalName)
             .Select(startEvent =>
-        {
-            var instanceEngine = CreateInstanceEngine();
+            {
+                var instanceEngine = CreateInstanceEngine();
 
-            instanceEngine.HandleSignal(signalName, JsonConvert.SerializeObject(signalData), startEvent);
+                instanceEngine.HandleSignal(signalName, JsonConvert.SerializeObject(signalData), startEvent);
 
-            return instanceEngine;
-        }).ToArray();
+                return instanceEngine;
+            }).ToArray();
     }
 
     /// <summary>
-    /// Führt fällige Timer-Start-Events einmalig aus und startet dafür neue Instanzen.
-    /// Die Persistenz bzw. echte Wiederholungslogik bleibt weiterhin ein separates Folgethema.
+    /// Führt fällige Timer-Start-Events aus und plant wiederkehrende Start-Timer auf Basis derselben Definition neu ein.
     /// </summary>
     public InstanceEngine[] HandleTime(DateTime time)
     {
-        var dueStartEvents = GetPendingTimerStartEvents()
-            .Where(startEvent => GetStartTimerDueDate(startEvent) <= time)
+        var dueStates = _timerStartStates.Values
+            .Where(state => state.DueAt <= time)
+            .OrderBy(state => state.DueAt)
             .ToArray();
 
         var instances = new List<InstanceEngine>();
 
-        foreach (var startEvent in dueStartEvents)
+        foreach (var dueState in dueStates)
         {
-            var instanceEngine = CreateInstanceEngine();
-            instanceEngine.HandleTime(time, startEvent);
-            _triggeredTimerStartEventIds.Add(startEvent.Id);
-            instances.Add(instanceEngine);
+            var currentState = dueState;
+            while (currentState.DueAt <= time)
+            {
+                var instanceEngine = CreateInstanceEngine();
+                instanceEngine.HandleTime(time, currentState.StartEvent);
+                instances.Add(instanceEngine);
+
+                if (!TryAdvanceTimerStartState(currentState, out currentState))
+                {
+                    _timerStartStates.Remove(dueState.StartEvent.Id);
+                    break;
+                }
+
+                _timerStartStates[dueState.StartEvent.Id] = currentState;
+            }
         }
 
         return instances.ToArray();
     }
 
-    public List<DateTime> ActiveTimers
-    {
-        get
-        {
-            return GetPendingTimerStartEvents()
-                .Select(GetStartTimerDueDate)
-                .ToList();
-        }
-    }
+    public List<DateTime> ActiveTimers => _timerStartStates.Values
+        .Select(state => state.DueAt)
+        .ToList();
 
-    public List<TimerSubscriptionDescriptor> ActiveTimerSubscriptions => GetPendingTimerStartEvents()
-        .Select(startEvent => new TimerSubscriptionDescriptor(
-            GetStartTimerDueDate(startEvent),
-            startEvent.Id,
-            TimerSubscriptionKind.ProcessStartEvent))
+    public List<TimerSubscriptionDescriptor> ActiveTimerSubscriptions => _timerStartStates.Values
+        .Select(state => new TimerSubscriptionDescriptor(
+            state.DueAt,
+            state.StartEvent.Id,
+            TimerSubscriptionKind.ProcessStartEvent,
+            RemainingOccurrences: state.RemainingOccurrences))
         .ToList();
 
     public List<MessageDefinition> ActiveCatchMessages
@@ -114,7 +124,7 @@ public class ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null)
         {
             return Process.FlowElements
                 .OfType<FlowzerMessageStartEvent>()
-                .Select(e => new MessageDefinition() { Name = e.MessageDefinition.Name })
+                .Select(e => new MessageDefinition { Name = e.MessageDefinition.Name })
                 .ToList();
         }
     }
@@ -125,26 +135,47 @@ public class ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null)
         {
             return Process.FlowElements
                 .OfType<FlowzerSignalStartEvent>()
-                .Select(e => e.Signal.Name).ToList();
+                .Select(e => e.Signal.Name)
+                .ToList();
         }
     }
 
     public List<Token> ActiveUserTasks()
     {
         //TODO: implement to support userasks as initialisation of a instancde
-        return new List<Token>();
+        return [];
     }
 
-    private IEnumerable<FlowzerTimerStartEvent> GetPendingTimerStartEvents()
+    private static bool TryAdvanceTimerStartState(TimerStartState currentState, out TimerStartState nextState)
     {
-        return Process.FlowElements
-            .OfType<FlowzerTimerStartEvent>()
-            .Where(startEvent => !_triggeredTimerStartEventIds.Contains(startEvent.Id));
+        var currentSchedule = new TimerSchedule(
+            currentState.DueAt,
+            currentState.RepeatInterval,
+            currentState.RemainingOccurrences);
+
+        if (!TimerScheduleCalculator.TryAdvanceSchedule(currentSchedule, out var nextSchedule))
+        {
+            nextState = default;
+            return false;
+        }
+
+        nextState = currentState with
+        {
+            DueAt = nextSchedule.DueAt,
+            RemainingOccurrences = nextSchedule.RemainingOccurrences
+        };
+        return true;
     }
 
-    private DateTime GetStartTimerDueDate(FlowzerTimerStartEvent startEvent)
+    private void AdvanceOrRemoveTimerStartState(TimerStartState timerStartState)
     {
-        return TimerDueDateCalculator.GetDueDate(_timerReferenceTime, startEvent.TimerDefinition, startEvent);
+        if (TryAdvanceTimerStartState(timerStartState, out var nextState))
+        {
+            _timerStartStates[timerStartState.StartEvent.Id] = nextState;
+            return;
+        }
+
+        _timerStartStates.Remove(timerStartState.StartEvent.Id);
     }
 
     private InstanceEngine CreateInstanceEngine()
@@ -160,5 +191,28 @@ public class ProcessEngine(Process process, FlowzerConfig? flowzerConfig = null)
         };
 
         return new InstanceEngine([masterToken], FlowzerConfig);
+    }
+
+    private readonly record struct TimerStartState(
+        FlowzerTimerStartEvent StartEvent,
+        DateTime DueAt,
+        TimeSpan? RepeatInterval,
+        int? RemainingOccurrences)
+    {
+        public bool HasPendingOccurrence => RemainingOccurrences == null || RemainingOccurrences > 0;
+
+        public static TimerStartState Create(FlowzerTimerStartEvent startEvent, DateTime referenceTime)
+        {
+            var schedule = TimerScheduleCalculator.CreateInitialSchedule(
+                referenceTime,
+                startEvent.TimerDefinition,
+                startEvent);
+
+            return new TimerStartState(
+                startEvent,
+                schedule.DueAt,
+                schedule.RepeatInterval,
+                schedule.RemainingOccurrences);
+        }
     }
 }

--- a/src/core-engine/TimerScheduleCalculator.cs
+++ b/src/core-engine/TimerScheduleCalculator.cs
@@ -1,0 +1,107 @@
+using System.Globalization;
+using core_engine.ISO8601Date;
+
+namespace core_engine;
+
+public readonly record struct TimerSchedule(
+    DateTime DueAt,
+    TimeSpan? RepeatInterval,
+    int? RemainingOccurrences);
+
+public static class TimerScheduleCalculator
+{
+    public static TimerSchedule CreateInitialSchedule(
+        DateTime referenceTime,
+        TimerEventDefinition timerDefinition,
+        FlowNode flowNode)
+    {
+        ArgumentNullException.ThrowIfNull(timerDefinition);
+        ArgumentNullException.ThrowIfNull(flowNode);
+
+        if (timerDefinition.TimeCycle != null &&
+            TryParseRepeatingCycle(timerDefinition.TimeCycle.Body, out var repeatingCycle))
+        {
+            return new TimerSchedule(
+                referenceTime.Add(repeatingCycle.Interval),
+                repeatingCycle.Interval,
+                repeatingCycle.RemainingOccurrences);
+        }
+
+        return new TimerSchedule(
+            TimerDueDateCalculator.GetDueDate(referenceTime, timerDefinition, flowNode),
+            null,
+            1);
+    }
+
+    public static bool TryAdvanceSchedule(TimerSchedule currentSchedule, out TimerSchedule nextSchedule)
+    {
+        if (currentSchedule.RepeatInterval == null)
+        {
+            nextSchedule = default;
+            return false;
+        }
+
+        if (currentSchedule.RemainingOccurrences is int remainingOccurrences)
+        {
+            var nextRemainingOccurrences = remainingOccurrences - 1;
+            if (nextRemainingOccurrences <= 0)
+            {
+                nextSchedule = default;
+                return false;
+            }
+
+            nextSchedule = currentSchedule with
+            {
+                DueAt = currentSchedule.DueAt.Add(currentSchedule.RepeatInterval.Value),
+                RemainingOccurrences = nextRemainingOccurrences
+            };
+            return true;
+        }
+
+        nextSchedule = currentSchedule with
+        {
+            DueAt = currentSchedule.DueAt.Add(currentSchedule.RepeatInterval.Value)
+        };
+        return true;
+    }
+
+    private static bool TryParseRepeatingCycle(
+        string expression,
+        out RepeatingCycleDefinition repeatingCycleDefinition)
+    {
+        repeatingCycleDefinition = default;
+
+        if (string.IsNullOrWhiteSpace(expression) ||
+            !expression.StartsWith("R", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var parts = expression.Split('/', 2, StringSplitOptions.TrimEntries);
+        if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[1]))
+        {
+            return false;
+        }
+
+        int? remainingOccurrences = null;
+        var repetitionToken = parts[0][1..];
+        if (!string.IsNullOrWhiteSpace(repetitionToken))
+        {
+            if (!int.TryParse(repetitionToken, NumberStyles.None, CultureInfo.InvariantCulture, out var parsedCount))
+            {
+                return false;
+            }
+
+            remainingOccurrences = parsedCount;
+        }
+
+        repeatingCycleDefinition = new RepeatingCycleDefinition(
+            DateExtensions.ParseIso8601Duration(parts[1]),
+            remainingOccurrences);
+        return true;
+    }
+
+    private readonly record struct RepeatingCycleDefinition(
+        TimeSpan Interval,
+        int? RemainingOccurrences);
+}

--- a/src/core-engine/TimerScheduleCalculator.cs
+++ b/src/core-engine/TimerScheduleCalculator.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using core_engine.Exceptions;
 using core_engine.ISO8601Date;
 
 namespace core_engine;
@@ -27,10 +28,17 @@ public static class TimerScheduleCalculator
                 repeatingCycle.RemainingOccurrences);
         }
 
+        if (timerDefinition.TimeCycle != null &&
+            timerDefinition.TimeCycle.Body.StartsWith("R", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ModelValidationException(
+                "Repeating timer cycles require a positive ISO-8601 duration interval.");
+        }
+
         return new TimerSchedule(
             TimerDueDateCalculator.GetDueDate(referenceTime, timerDefinition, flowNode),
             null,
-            1);
+            null);
     }
 
     public static bool TryAdvanceSchedule(TimerSchedule currentSchedule, out TimerSchedule nextSchedule)
@@ -95,8 +103,14 @@ public static class TimerScheduleCalculator
             remainingOccurrences = parsedCount;
         }
 
+        var interval = DateExtensions.ParseIso8601Duration(parts[1]);
+        if (interval <= TimeSpan.Zero)
+        {
+            return false;
+        }
+
         repeatingCycleDefinition = new RepeatingCycleDefinition(
-            DateExtensions.ParseIso8601Duration(parts[1]),
+            interval,
             remainingOccurrences);
         return true;
     }


### PR DESCRIPTION
## Zusammenfassung

Dieses PR härtet den Runtime-Pfad für **wiederkehrende Start-Timer**.

Konkret werden `timeCycle`-basierte Start-Timer jetzt nicht mehr nur einmalig verarbeitet, sondern inklusive verbleibender Wiederholungen persistiert, bei Überfälligkeit nachgezogen und auf den nächsten Fälligkeitszeitpunkt weitergeplant.

## Änderungen

- `TimerScheduleCalculator` für wiederverwendbare Timer-Schedule-Berechnung ergänzt
- `ProcessEngine` auf wiederkehrende Start-Timer mit Catch-up-Logik umgestellt
- `RemainingOccurrences` als Teil des Timer-Subscription-Vertrags in Model, DTOs und Mapping ergänzt
- `BpmnBusinessLogic.HandleTime(...)` für wiederkehrende Start-Timer und Rescheduling gehärtet
- Startup-Recovery über `BpmnBusinessLogic.Load()` mit überfälligen Start-Timern abgesichert
- Engine-, Storage- und Web-API-Regressionstests für Rescheduling und Recovery ergänzt
- Status-, Roadmap- und Runtime-Dokumentation an den neuen Stand angepasst

## Tests

Lokal erfolgreich ausgeführt:

- `dotnet build core-engine.sln --configuration Release --no-restore`
- `dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'`
- `dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'`
- `dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'`

## Bezug

- Bezieht sich auf #85
