### PR TITLE
Auth-/Identity-Grundlage im API-Pfad weiter härten

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Die bisherige Dokumentation klang teilweise deutlich reifer als der aktuelle Sta
 - Es gibt **fachlich wertvolle Tests, BPMN-Beispiele und eine grüne CI-Basis auf `next`**.
 - Zentrale Produktpfade wie Demo, UI-Smokes, API-Fehlerverträge und ein erster Timer-Kernpfad sind inzwischen vorhanden.
 - Timer-Subscriptions werden jetzt auch in Storage/Web-API persistiert, über einen kleinen Scheduler-Polling-Pfad verarbeitet und können wiederkehrende Start-Timer inklusive Restwiederholungen abbilden.
+- Geschützte API-Pfade verlangen inzwischen einen **aufgelösten Benutzerkontext**, statt stillschweigend über einen System-Fallback weiterzulaufen.
 - Es gibt aber weiterhin **offene Restlücken** bei weitergehender Timer-/Boundary-Recovery, Auth/Identity und Betriebsreife.
 - Das Projekt ist **klar revivierbar und aktiv weiterentwickelbar**, wenn die nächsten Schritte weiter fokussiert bleiben.
 
@@ -95,7 +96,7 @@ Diese Punkte sollte man kennen, bevor man loslegt:
    Der Engine-Kern kann fällige Timer jetzt weiterführen, Boundary-Timer im bestehenden Subscription-Pfad verarbeiten, wiederkehrende Start-Timer überfälligkeitstolerant nachziehen und rohe `NotImplementedException`-Abbrüche in mehreren Pfaden vermeiden. Offen bleiben weiterhin speziellere Recovery-Fragen, vollständige Fehler-/Eskalationssemantik und echte Kompensation.
 
 4. **Betrieb und Auth sind noch nicht am Ziel**
-   Lokale Compose- und Runtime-Container sind vorhanden, aber Themen wie Telemetrie, Secrets, TLS, Recovery und eine belastbare Identity-/Auth-Story sind weiterhin Folgepakete.
+   Lokale Compose- und Runtime-Container sind vorhanden, geschützte API-Pfade verlangen jetzt zwar einen aufgelösten Benutzerkontext, aber Themen wie echte Authentifizierung, Rollenmodell, Telemetrie, Secrets, TLS und Recovery sind weiterhin Folgepakete.
 
 ## Dokumentation
 
@@ -113,7 +114,7 @@ Diese Punkte sollte man kennen, bevor man loslegt:
 
 Die sinnvolle Reihenfolge ist aktuell:
 
-1. **Auth-/Identity- und weitergehende Fehlersemantik produktionsnah härten**
+1. **Auth-/Identity-Story über Claim-/Rollenmodell und Betriebssignale weiter ausbauen**
 2. **Betriebsbasis mit Telemetrie, Secrets, TLS und Recovery vertiefen**
 3. **Timer-Recovery nur noch in speziellen Boundary-/Spezialfällen nachziehen**
 4. **Status-, Architektur- und Contributor-Dokumentation laufend nachziehen**

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Die bisherige Dokumentation klang teilweise deutlich reifer als der aktuelle Sta
 - Zentrale Produktpfade wie Demo, UI-Smokes, API-Fehlerverträge und ein erster Timer-Kernpfad sind inzwischen vorhanden.
 - Timer-Subscriptions werden jetzt auch in Storage/Web-API persistiert, über einen kleinen Scheduler-Polling-Pfad verarbeitet und können wiederkehrende Start-Timer inklusive Restwiederholungen abbilden.
 - Geschützte API-Pfade verlangen inzwischen einen **aufgelösten Benutzerkontext**, statt stillschweigend über einen System-Fallback weiterzulaufen.
+- Für lokale Entwicklung und UI-Smokes setzt das Frontend im **Development-Modus** jetzt automatisch einen technischen Benutzerheader, damit die gehärteten API-Pfade lokal weiter reproduzierbar testbar bleiben.
 - Es gibt aber weiterhin **offene Restlücken** bei weitergehender Timer-/Boundary-Recovery, Auth/Identity und Betriebsreife.
 - Das Projekt ist **klar revivierbar und aktiv weiterentwickelbar**, wenn die nächsten Schritte weiter fokussiert bleiben.
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -18,6 +18,8 @@ Aktuell gilt damit bewusst:
 
 Damit lässt sich das Frontend lokal direkt gegen die Web-API starten, ohne dass im Code harte URLs verdrahtet bleiben.
 
+Zusätzlich kann `FlowzerApi:DevelopmentUserId` gesetzt werden. Wenn das Frontend selbst im `Development`-Modus läuft, sendet es diesen Wert automatisch als `X-Flowzer-UserId` an die Web-API. Damit bleiben lokal gehärtete Definition-, User-Task- und Formularpfade testbar, ohne Produktionsumgebungen wieder für freie Header-Impersonation zu öffnen.
+
 ## Lokaler Start
 
 ### Web-API
@@ -98,6 +100,7 @@ Bei Bedarf kann das Verhalten angepasst werden:
 
 - `PLAYWRIGHT_SKIP_PROCESS_GUARD=1` deaktiviert den Wächter
 - `PLAYWRIGHT_PROCESS_STALE_THRESHOLD_SECONDS=<sekunden>` steuert, ab wann alte Browser-Prozesse als verwaist gelten
+- `FLOWZER_DEVELOPMENT_USER_ID=<guid>` überschreibt den technischen Development-Benutzer für API-Seed- und Runtime-Hilfsaufrufe der UI-Smokes
 
 ## Diagramm- und Modeler-Prüfpfade
 

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -56,6 +56,7 @@ Unter anderem bereits umgesetzt:
 - Startup-Recovery für überfällige Start-Timer auf Basis persistierter Timer-Subscriptions
 - konsistentere Form-/Message-Fehlerverträge in Web-API und Business-Logic
 - geschützte Definition-, User-Task- und Form-Ergebnispfade verlangen jetzt einen aufgelösten Benutzerkontext statt stillen System-Fallback
+- lokaler Development- und UI-Smoke-Pfad sendet für diese geschützten Routen nun automatisch einen technischen Benutzerheader, ohne die strengeren Produktionspfade wieder aufzuweichen
 - Nullability- und Guard-Härtung in zentralen Frontend-Seiten
 - lokale Runtime-Containerbasis für API, Frontend und Gateway
 

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -55,6 +55,7 @@ Unter anderem bereits umgesetzt:
 - wiederkehrende Start-Timer mit Restwiederholungen und Catch-up-Verhalten im Runtime-Pfad
 - Startup-Recovery für überfällige Start-Timer auf Basis persistierter Timer-Subscriptions
 - konsistentere Form-/Message-Fehlerverträge in Web-API und Business-Logic
+- geschützte Definition-, User-Task- und Form-Ergebnispfade verlangen jetzt einen aufgelösten Benutzerkontext statt stillen System-Fallback
 - Nullability- und Guard-Härtung in zentralen Frontend-Seiten
 - lokale Runtime-Containerbasis für API, Frontend und Gateway
 
@@ -66,7 +67,7 @@ Besonders relevant sind noch:
 
 - weiter ausgebautes Playwright-/E2E-Smoke-Set
 - Restlücken bei spezieller Boundary-/Spezialtimer-Recovery und weitergehender Scheduler-Semantik
-- weitere Auth-/Identity- und Fehlerpfade
+- weitere Auth-/Identity- und Fehlerpfade jenseits des aktuellen Benutzerkontext-Guards
 - Release-/Telemetrie-/Secret-/Recovery-Story über die lokale Basis hinaus
 
 ### 2. Es gibt noch Restlücken im Codebestand
@@ -74,7 +75,7 @@ Besonders relevant sind noch:
 Noch offen sind unter anderem:
 
 - Restlücken in Timer-, Boundary- und Kompensationssemantik
-- provisorische Auth-/Identity-Platzhalter
+- provisorische Auth-/Identity-Platzhalter oberhalb des aktuellen Benutzerkontext-Guards
 - Betriebs- und Deployment-Themen wie Reverse Proxy, TLS, Logging-/Telemetry und Recovery
 - Altlasten und Doppelstrukturen im Repository
 
@@ -96,7 +97,7 @@ Die Basisdokumentation ist deutlich besser als zuvor, aber für die nächste Rei
 Die erste große Revitalisierungs- und Stabilisierungswelle ist inzwischen weitgehend abgearbeitet. Der nächste sinnvolle Backlog ergibt sich aktuell weniger aus alten Sammel-Issues, sondern aus den noch verbleibenden Produktlücken:
 
 - weitergehende Boundary-/Spezialtimer-Recovery sowie BPMN-Fehler-/Eskalationssemantik
-- Auth-/Identity-Härtung
+- Auth-/Identity-Härtung über Claim-, Rollen- und Betriebsmodell
 - Telemetrie, Secrets, Recovery und operationsnahe Doku
 - weitere Architektur- und Repo-Hygiene
 
@@ -106,7 +107,7 @@ Das Projekt sollte jetzt **nicht mehr primär gerettet**, sondern gezielt **zur 
 
 Die sinnvolle Reihenfolge ist aus heutiger Sicht:
 
-1. Auth-/Identity- und API-Verträge weiter schärfen
+1. Auth-/Identity- und API-Verträge über Claim-/Rollenmodell weiter schärfen
 2. Betriebsbasis um Telemetrie, Secrets, TLS und Recovery erweitern
 3. Timer-Recovery nur noch in verbleibenden Spezialfällen weiter vertiefen
 4. E2E-, Architektur- und Operations-Dokumentation weiter vertiefen

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -52,7 +52,7 @@ Die Roadmap startet also **nicht mehr bei Null**, sondern baut auf einer funktio
 
 ### 2.2 Auth-/Identity-Pfade weiter absichern
 
-- Fallback-/Development-Pfade weiter reduzieren
+- Claim-basierte Authentifizierung entlang echter Betriebsumgebungen verdrahten
 - Nutzer- und Rollenmodell klarer kapseln
 - API-Verträge und Betriebssignale entlang der Auth-Story ergänzen
 
@@ -81,7 +81,7 @@ Die Roadmap startet also **nicht mehr bei Null**, sondern baut auf einer funktio
 ### Sprint B – Betrieb und Auth
 
 - Telemetrie/Secrets/Recovery
-- Auth-/Identity-Härtung
+- Claim-/Rollenmodell und Auth-/Identity-Härtung
 
 ### Sprint C – E2E und Dokumentation
 

--- a/src/FlowzerFrontend.Tests/FlowzerApiOptionsTest.cs
+++ b/src/FlowzerFrontend.Tests/FlowzerApiOptionsTest.cs
@@ -45,6 +45,69 @@ public class FlowzerApiOptionsTest
     }
 
     [Test]
+    public void ResolveDevelopmentUserId_ShouldReturnConfiguredUser_WhenFrontendRunsInDevelopment()
+    {
+        var developmentUserId = Guid.NewGuid();
+        var options = new FlowzerApiOptions
+        {
+            DevelopmentUserId = developmentUserId.ToString()
+        };
+
+        var result = options.ResolveDevelopmentUserId(isDevelopment: true);
+
+        result.Should().Be(developmentUserId);
+    }
+
+    [Test]
+    public void ResolveDevelopmentUserId_ShouldReturnNull_WhenFrontendDoesNotRunInDevelopment()
+    {
+        var options = new FlowzerApiOptions
+        {
+            DevelopmentUserId = Guid.NewGuid().ToString()
+        };
+
+        var result = options.ResolveDevelopmentUserId(isDevelopment: false);
+
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public void ApplyDefaultHeaders_ShouldAddTechnicalUserHeader_WhenDevelopmentUserIsConfigured()
+    {
+        var developmentUserId = Guid.NewGuid();
+        var options = new FlowzerApiOptions
+        {
+            DevelopmentUserId = developmentUserId.ToString()
+        };
+        using var httpClient = new HttpClient();
+
+        options.ApplyDefaultHeaders(httpClient, isDevelopment: true);
+
+        httpClient.DefaultRequestHeaders.Contains(FlowzerApiOptions.DevelopmentUserIdHeaderName).Should().BeTrue();
+        httpClient.DefaultRequestHeaders
+            .GetValues(FlowzerApiOptions.DevelopmentUserIdHeaderName)
+            .Should()
+            .ContainSingle()
+            .Which
+            .Should()
+            .Be(developmentUserId.ToString());
+    }
+
+    [Test]
+    public void ApplyDefaultHeaders_ShouldNotAddTechnicalUserHeader_OutsideDevelopment()
+    {
+        var options = new FlowzerApiOptions
+        {
+            DevelopmentUserId = Guid.NewGuid().ToString()
+        };
+        using var httpClient = new HttpClient();
+
+        options.ApplyDefaultHeaders(httpClient, isDevelopment: false);
+
+        httpClient.DefaultRequestHeaders.Contains(FlowzerApiOptions.DevelopmentUserIdHeaderName).Should().BeFalse();
+    }
+
+    [Test]
     public async Task GetJsonRequest_ShouldUseConfiguredHttpMethod_AndJsonPayload()
     {
         var handler = new RecordingHttpMessageHandler();

--- a/src/FlowzerFrontend/FlowzerApiOptions.cs
+++ b/src/FlowzerFrontend/FlowzerApiOptions.cs
@@ -6,12 +6,19 @@ namespace FlowzerFrontend;
 public sealed class FlowzerApiOptions
 {
     public const string SectionName = "FlowzerApi";
+    public const string DevelopmentUserIdHeaderName = "X-Flowzer-UserId";
 
     /// <summary>
     /// Optionale Zieladresse der Web-API. Leere Werte fallen auf die Host-Basisadresse
     /// des Frontends zurück und unterstützen damit Reverse-Proxy- oder Same-Origin-Setups.
     /// </summary>
     public string? BaseUrl { get; set; }
+
+    /// <summary>
+    /// Optionaler technischer Benutzer für lokale Development-Umgebungen. Wird nur dann als
+    /// Request-Header gesetzt, wenn das Frontend selbst im Development-Modus läuft.
+    /// </summary>
+    public string? DevelopmentUserId { get; set; }
 
     /// <summary>
     /// Ermittelt die effektive API-Basisadresse aus Host-URL und optionaler Konfiguration.
@@ -40,6 +47,40 @@ public sealed class FlowzerApiOptions
                 new Uri(
                     normalizedHostBaseAddress,
                     new Uri(normalizedRelativeBaseAddress, UriKind.Relative)));
+    }
+
+    /// <summary>
+    /// Liefert den konfigurierten technischen Development-Benutzer nur dann zurück, wenn die
+    /// aktuelle Frontend-Instanz tatsächlich im Development-Modus läuft.
+    /// </summary>
+    public Guid? ResolveDevelopmentUserId(bool isDevelopment)
+    {
+        if (!isDevelopment || !Guid.TryParse(DevelopmentUserId, out var developmentUserId))
+        {
+            return null;
+        }
+
+        return developmentUserId;
+    }
+
+    /// <summary>
+    /// Ergänzt den technischen Development-Header auf dem HttpClient, falls er für die
+    /// aktuelle Umgebung konfiguriert und erlaubt ist.
+    /// </summary>
+    public void ApplyDefaultHeaders(HttpClient httpClient, bool isDevelopment)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+
+        var developmentUserId = ResolveDevelopmentUserId(isDevelopment);
+        if (developmentUserId is null)
+        {
+            return;
+        }
+
+        httpClient.DefaultRequestHeaders.Remove(DevelopmentUserIdHeaderName);
+        httpClient.DefaultRequestHeaders.Add(
+            DevelopmentUserIdHeaderName,
+            developmentUserId.Value.ToString());
     }
 
     private static Uri EnsureTrailingSlash(Uri uri)

--- a/src/FlowzerFrontend/Program.cs
+++ b/src/FlowzerFrontend/Program.cs
@@ -14,15 +14,20 @@ var flowzerApiOptions =
 
 builder.Services.AddSingleton<ExampleRestRequestBuilder>();
 builder.Services.AddSingleton(flowzerApiOptions);
-builder.Services.AddScoped(sp => new HttpClient
+builder.Services.AddScoped(_ =>
 {
-    BaseAddress = flowzerApiOptions.ResolveBaseAddress(builder.HostEnvironment.BaseAddress)
+    var httpClient = new HttpClient
+    {
+        BaseAddress = flowzerApiOptions.ResolveBaseAddress(builder.HostEnvironment.BaseAddress)
+    };
+
+    flowzerApiOptions.ApplyDefaultHeaders(httpClient, builder.HostEnvironment.IsDevelopment());
+    return httpClient;
 });
 builder.Services.AddScoped<FlowzerApi>();
 builder.Services.AddFluentUIComponents();
 
 await builder.Build().RunAsync();
-
 
 
 

--- a/src/FlowzerFrontend/wwwroot/appsettings.Development.json
+++ b/src/FlowzerFrontend/wwwroot/appsettings.Development.json
@@ -1,5 +1,6 @@
 {
   "FlowzerApi": {
-    "BaseUrl": "http://localhost:5182/"
+    "BaseUrl": "http://localhost:5182/",
+    "DevelopmentUserId": "F70DD76D-D4A3-44D2-8A28-7547E84B7A91"
   }
 }

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -120,6 +120,33 @@ public class ApiHardeningIntegrationTest
     }
 
     [Test]
+    public async Task DeployDefinition_ShouldReturnUnauthorized_WhenNoAuthenticationDataIsPresentOutsideDevelopment()
+    {
+        var storage = new TestStorage();
+
+        await using var factory = new TestWebApplicationFactory(
+            storage,
+            new TestFactoryOptions { EnvironmentName = "Production" });
+        using var client = factory.CreateClient();
+
+        var xml = """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+                    <bpmn:process id="Process_Invoice" isExecutable="true" />
+                  </bpmn:definitions>
+                  """;
+
+        var response = await client.PostAsync("/definition/deploy", new StringContent(xml));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeFalse();
+        payload.ErrorMessage.Should().Contain("resolved user context");
+        storage.StoredDefinitions.Should().BeEmpty();
+    }
+
+    [Test]
     public async Task GetAllUserTasks_ShouldReturnUnauthorized_WhenNoAuthenticationDataIsPresentOutsideDevelopment()
     {
         var storage = new TestStorage();

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -93,17 +93,70 @@ public class ApiHardeningIntegrationTest
     }
 
     [Test]
-    public async Task GetAllUserTasks_ShouldUseFallbackUserId_WhenNoAuthenticationDataIsPresent()
+    public async Task UploadDefinition_ShouldReturnUnauthorized_WhenNoAuthenticationDataIsPresentOutsideDevelopment()
     {
         var storage = new TestStorage();
 
-        await using var factory = new TestWebApplicationFactory(storage);
+        await using var factory = new TestWebApplicationFactory(
+            storage,
+            new TestFactoryOptions { EnvironmentName = "Production" });
+        using var client = factory.CreateClient();
+
+        var xml = """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+                    <bpmn:process id="Process_Invoice" isExecutable="true" />
+                  </bpmn:definitions>
+                  """;
+
+        var response = await client.PostAsync("/definition", new StringContent(xml));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeFalse();
+        payload.ErrorMessage.Should().Contain("resolved user context");
+        storage.StoredDefinitions.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task GetAllUserTasks_ShouldReturnUnauthorized_WhenNoAuthenticationDataIsPresentOutsideDevelopment()
+    {
+        var storage = new TestStorage();
+
+        await using var factory = new TestWebApplicationFactory(
+            storage,
+            new TestFactoryOptions { EnvironmentName = "Production" });
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/usertask");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        storage.LastRequestedExtendedUserTaskUserId.Should().BeNull();
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<ExtendedUserTaskSubscriptionDto[]>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeFalse();
+        payload.ErrorMessage.Should().Contain("resolved user context");
+    }
+
+    [Test]
+    public async Task GetAllUserTasks_ShouldUseResolvedUserContext_WhenAccessorProvidesAuthenticatedUser()
+    {
+        var storage = new TestStorage();
+        var expectedUserId = Guid.NewGuid();
+
+        await using var factory = new TestWebApplicationFactory(
+            storage,
+            new TestFactoryOptions
+            {
+                CurrentUserContext = new CurrentUserContext(expectedUserId, "test:claims", false)
+            });
         using var client = factory.CreateClient();
 
         var response = await client.GetAsync("/usertask");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        storage.LastRequestedExtendedUserTaskUserId.Should().Be(HttpContextCurrentUserContextAccessor.FallbackUserId);
+        storage.LastRequestedExtendedUserTaskUserId.Should().Be(expectedUserId);
         var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<ExtendedUserTaskSubscriptionDto[]>>();
         payload.Should().NotBeNull();
         payload!.Successful.Should().BeTrue();
@@ -115,8 +168,15 @@ public class ApiHardeningIntegrationTest
     public async Task UserTaskEndpoint_ShouldReturnBadRequest_WhenProcessInstanceIdIsMissing()
     {
         var storage = new TestStorage();
+        var expectedUserId = Guid.NewGuid();
 
-        await using var factory = new TestWebApplicationFactory(storage);
+        await using var factory = new TestWebApplicationFactory(
+            storage,
+            new TestFactoryOptions
+            {
+                EnvironmentName = "Production",
+                CurrentUserContext = new CurrentUserContext(expectedUserId, "test:claims", false)
+            });
         using var client = factory.CreateClient();
 
         var response = await client.PostAsJsonAsync("/usertask", new UserTaskResultDto
@@ -133,6 +193,56 @@ public class ApiHardeningIntegrationTest
         payload!.Successful.Should().BeFalse();
         payload.ErrorMessage.Should().Contain("User task results require a ProcessInstanceId.");
         payload.ErrorMessage.Should().Contain("ProcessInstanceId");
+    }
+
+    [Test]
+    public async Task UserTaskEndpoint_ShouldReturnUnauthorized_WhenNoAuthenticationDataIsPresentOutsideDevelopment()
+    {
+        var storage = new TestStorage();
+
+        await using var factory = new TestWebApplicationFactory(
+            storage,
+            new TestFactoryOptions { EnvironmentName = "Production" });
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/usertask", new UserTaskResultDto
+        {
+            FlowNodeId = "UserTask_1",
+            TokenId = Guid.NewGuid(),
+            ProcessInstanceId = Guid.NewGuid(),
+            Data = null
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeFalse();
+        payload.ErrorMessage.Should().Contain("resolved user context");
+    }
+
+    [Test]
+    public async Task FormResult_ShouldReturnUnauthorized_WhenNoAuthenticationDataIsPresentOutsideDevelopment()
+    {
+        var storage = new TestStorage();
+
+        await using var factory = new TestWebApplicationFactory(
+            storage,
+            new TestFactoryOptions { EnvironmentName = "Production" });
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/form/result", new UserTaskResultDto
+        {
+            FlowNodeId = "UserTask_1",
+            TokenId = Guid.NewGuid(),
+            ProcessInstanceId = Guid.NewGuid(),
+            Data = null
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeFalse();
+        payload.ErrorMessage.Should().Contain("resolved user context");
     }
 
     [Test]
@@ -309,11 +419,15 @@ public class ApiHardeningIntegrationTest
         };
     }
 
-    private sealed class TestWebApplicationFactory(TestStorage storage) : WebApplicationFactory<Program>
+    private sealed class TestWebApplicationFactory(
+        TestStorage storage,
+        TestFactoryOptions? options = null) : WebApplicationFactory<Program>
     {
         protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
         {
-            builder.UseSetting(WebHostDefaults.EnvironmentKey, "Development");
+            options ??= new TestFactoryOptions();
+
+            builder.UseSetting(WebHostDefaults.EnvironmentKey, options.EnvironmentName);
             builder.ConfigureAppConfiguration((_, configBuilder) =>
             {
                 configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
@@ -328,8 +442,29 @@ public class ApiHardeningIntegrationTest
 
                 services.AddSingleton<IStorageSystem>(storage);
                 services.AddSingleton<ITransactionalStorageProvider>(new TestTransactionalStorageProvider(storage));
+
+                if (options.CurrentUserContext is not null)
+                {
+                    services.RemoveAll<ICurrentUserContextAccessor>();
+                    services.AddSingleton<ICurrentUserContextAccessor>(
+                        new FixedCurrentUserContextAccessor(options.CurrentUserContext));
+                }
             });
         }
+    }
+
+    private sealed class FixedCurrentUserContextAccessor(CurrentUserContext currentUserContext) : ICurrentUserContextAccessor
+    {
+        public CurrentUserContext GetCurrentUser()
+        {
+            return currentUserContext;
+        }
+    }
+
+    private sealed record TestFactoryOptions
+    {
+        public string EnvironmentName { get; init; } = "Development";
+        public CurrentUserContext? CurrentUserContext { get; init; }
     }
 
     private sealed class TestTransactionalStorageProvider(TestStorage storage) : ITransactionalStorageProvider

--- a/src/WebApiEngine.Tests/HttpContextCurrentUserContextAccessorTest.cs
+++ b/src/WebApiEngine.Tests/HttpContextCurrentUserContextAccessorTest.cs
@@ -1,0 +1,115 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using WebApiEngine.Auth;
+
+namespace WebApiEngine.Tests;
+
+[NonParallelizable]
+public class HttpContextCurrentUserContextAccessorTest
+{
+    [Test]
+    public void GetCurrentUser_ShouldResolveNameIdentifierClaim()
+    {
+        var expectedUserId = Guid.NewGuid();
+        var accessor = CreateAccessor(
+            environmentName: Environments.Production,
+            claims:
+            [
+                new Claim(ClaimTypes.NameIdentifier, expectedUserId.ToString())
+            ]);
+
+        var currentUser = accessor.GetCurrentUser();
+
+        currentUser.UserId.Should().Be(expectedUserId);
+        currentUser.Source.Should().Be("claim:nameidentifier");
+        currentUser.IsFallback.Should().BeFalse();
+    }
+
+    [Test]
+    public void GetCurrentUser_ShouldResolveSubClaim_WhenNameIdentifierIsMissing()
+    {
+        var expectedUserId = Guid.NewGuid();
+        var accessor = CreateAccessor(
+            environmentName: Environments.Production,
+            claims:
+            [
+                new Claim("sub", expectedUserId.ToString())
+            ]);
+
+        var currentUser = accessor.GetCurrentUser();
+
+        currentUser.UserId.Should().Be(expectedUserId);
+        currentUser.Source.Should().Be("claim:sub");
+        currentUser.IsFallback.Should().BeFalse();
+    }
+
+    [Test]
+    public void GetCurrentUser_ShouldUseHeaderInDevelopment()
+    {
+        var expectedUserId = Guid.NewGuid();
+        var accessor = CreateAccessor(
+            environmentName: Environments.Development,
+            headerUserId: expectedUserId);
+
+        var currentUser = accessor.GetCurrentUser();
+
+        currentUser.UserId.Should().Be(expectedUserId);
+        currentUser.Source.Should().Be("header:x-flowzer-userid");
+        currentUser.IsFallback.Should().BeFalse();
+    }
+
+    [Test]
+    public void GetCurrentUser_ShouldIgnoreHeaderOutsideDevelopment()
+    {
+        var expectedUserId = Guid.NewGuid();
+        var accessor = CreateAccessor(
+            environmentName: Environments.Production,
+            headerUserId: expectedUserId);
+
+        var currentUser = accessor.GetCurrentUser();
+
+        currentUser.UserId.Should().Be(HttpContextCurrentUserContextAccessor.FallbackUserId);
+        currentUser.Source.Should().Be("fallback:system-user");
+        currentUser.IsFallback.Should().BeTrue();
+    }
+
+    private static HttpContextCurrentUserContextAccessor CreateAccessor(
+        string environmentName,
+        IEnumerable<Claim>? claims = null,
+        Guid? headerUserId = null)
+    {
+        var httpContext = new DefaultHttpContext();
+
+        if (claims is not null)
+        {
+            httpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(claims, authenticationType: "test"));
+        }
+
+        if (headerUserId.HasValue)
+        {
+            httpContext.Request.Headers[HttpContextCurrentUserContextAccessor.UserIdHeaderName] =
+                headerUserId.Value.ToString();
+        }
+
+        var httpContextAccessor = new HttpContextAccessor
+        {
+            HttpContext = httpContext
+        };
+
+        return new HttpContextCurrentUserContextAccessor(
+            httpContextAccessor,
+            new TestHostEnvironment(environmentName));
+    }
+
+    private sealed class TestHostEnvironment(string environmentName) : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = environmentName;
+        public string ApplicationName { get; set; } = "WebApiEngine.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/src/WebApiEngine/Auth/CurrentUserContextExtensions.cs
+++ b/src/WebApiEngine/Auth/CurrentUserContextExtensions.cs
@@ -1,0 +1,22 @@
+namespace WebApiEngine.Auth;
+
+/// <summary>
+/// Hilfslogik für API-Pfade, die nur mit einem aufgelösten Benutzerkontext
+/// ausgeführt werden dürfen.
+/// </summary>
+public static class CurrentUserContextExtensions
+{
+    public static Guid RequireResolvedUserId(this CurrentUserContext currentUserContext, string operationDescription)
+    {
+        ArgumentNullException.ThrowIfNull(currentUserContext);
+        ArgumentException.ThrowIfNullOrWhiteSpace(operationDescription);
+
+        if (!currentUserContext.IsFallback)
+        {
+            return currentUserContext.UserId;
+        }
+
+        throw new UnauthorizedAccessException(
+            $"A resolved user context is required for {operationDescription}.");
+    }
+}

--- a/src/WebApiEngine/BusinessLogic/DefinitionBusinessLogic.cs
+++ b/src/WebApiEngine/BusinessLogic/DefinitionBusinessLogic.cs
@@ -39,6 +39,7 @@ public class DefinitionBusinessLogic(
         
                 
         var currentUser = currentUserContextAccessor.GetCurrentUser();
+        var resolvedUserId = currentUser.RequireResolvedUserId("definition changes");
 
         var definition = new BpmnDefinition()
         {
@@ -46,7 +47,7 @@ public class DefinitionBusinessLogic(
             DefinitionId = model.Id,
             PreviousGuid = previousGuid,
             Hash = ComputeStableHash(rawContent),
-            SavedByUser = currentUser.UserId,
+            SavedByUser = resolvedUserId,
             SavedOn = DateTime.UtcNow,
             Version = highestVersion,
             IsActive = false

--- a/src/WebApiEngine/Controller/DefinitionController.cs
+++ b/src/WebApiEngine/Controller/DefinitionController.cs
@@ -28,6 +28,10 @@ public class DefinitionController(
             await bpmnBusinessLogic.DeployDefinition(definition);
             return Ok(new ApiStatusResult<BpmnDefinitionDto>(definition.ToDto()));
         }
+        catch (UnauthorizedAccessException)
+        {
+            throw;
+        }
         catch (Exception e)
         {
             return BadRequest(new ApiStatusResult<BpmnDefinitionDto>(e.Message));

--- a/src/WebApiEngine/Controller/FormController.cs
+++ b/src/WebApiEngine/Controller/FormController.cs
@@ -117,7 +117,8 @@ public class FormController(
         {
             var data = formMetadataDto.ToModel();
             var currentUser = currentUserContextAccessor.GetCurrentUser();
-            await bpmnBusinessLogic.HandleUserTask(data, currentUser.UserId);
+            var userId = currentUser.RequireResolvedUserId("submitting form results");
+            await bpmnBusinessLogic.HandleUserTask(data, userId);
             return Ok(new ApiStatusResult() {Successful = true});
         }
         catch (ArgumentException e)

--- a/src/WebApiEngine/Controller/UserTaskController.cs
+++ b/src/WebApiEngine/Controller/UserTaskController.cs
@@ -17,7 +17,8 @@ public class UserTaskController(
     public async Task<ActionResult<ApiStatusResult<ExtendedUserTaskSubscriptionDto[]>>> GetAllUserTasks()
     {
         var currentUser = currentUserContextAccessor.GetCurrentUser();
-        var userTaskSubscriptions = await storageSystem.SubscriptionStorage.GetAllUserTasksExtended(currentUser.UserId);
+        var userId = currentUser.RequireResolvedUserId("reading user tasks");
+        var userTaskSubscriptions = await storageSystem.SubscriptionStorage.GetAllUserTasksExtended(userId);
         var dtos = userTaskSubscriptions.Select(subscription => subscription.ToDto()).ToArray();
         return Ok(new ApiStatusResult<ExtendedUserTaskSubscriptionDto[]>(dtos));
     }
@@ -29,7 +30,8 @@ public class UserTaskController(
     {
         var userTaskResult = messageDto.ToModel();
         var currentUser = currentUserContextAccessor.GetCurrentUser();
-        await bpmnBusinessLogic.HandleUserTask(userTaskResult, currentUser.UserId);
+        var userId = currentUser.RequireResolvedUserId("completing user tasks");
+        await bpmnBusinessLogic.HandleUserTask(userTaskResult, userId);
 
         return Ok(new ApiStatusResult { Successful = true });
     }

--- a/tests/ui-smoke/support/flowzer-api.js
+++ b/tests/ui-smoke/support/flowzer-api.js
@@ -1,9 +1,27 @@
 const { randomUUID } = require('crypto');
 
 const apiUrl = process.env.FLOWZER_API_URL || 'http://localhost:5182';
+const developmentUserIdHeaderName = 'X-Flowzer-UserId';
+const developmentUserId =
+  process.env.FLOWZER_DEVELOPMENT_USER_ID ||
+  'F70DD76D-D4A3-44D2-8A28-7547E84B7A91';
 
 function buildApiUrl(pathname) {
   return new URL(pathname, apiUrl).toString();
+}
+
+function buildRequestOptions(overrides = {}) {
+  const mergedHeaders = {
+    ...(developmentUserId
+      ? { [developmentUserIdHeaderName]: developmentUserId }
+      : {}),
+    ...(overrides.headers || {})
+  };
+
+  return {
+    ...overrides,
+    headers: mergedHeaders
+  };
 }
 
 async function readJson(response, description) {
@@ -111,21 +129,21 @@ function buildMessageStartUserTaskXml({
 }
 
 async function saveForm(request, { formId = randomUUID(), name, schema }) {
-  const metadataResponse = await request.post(buildApiUrl(`/form/meta/${formId}`), {
+  const metadataResponse = await request.post(buildApiUrl(`/form/meta/${formId}`), buildRequestOptions({
     data: {
       formId,
       name
     }
-  });
+  }));
   ensureApiSuccess(await readJson(metadataResponse, 'Saving form metadata'), 'Saving form metadata');
 
-  const formResponse = await request.post(buildApiUrl('/form'), {
+  const formResponse = await request.post(buildApiUrl('/form'), buildRequestOptions({
     data: {
       formId,
       version: { major: 0, minor: 0 },
       formData: schema
     }
-  });
+  }));
 
   const formResult = ensureApiSuccess(await readJson(formResponse, 'Saving form content'), 'Saving form content');
   return {
@@ -136,17 +154,17 @@ async function saveForm(request, { formId = randomUUID(), name, schema }) {
 }
 
 async function createDefinitionMeta(request, { name, description = '' }) {
-  const createResponse = await request.get(buildApiUrl('/definition/new'));
+  const createResponse = await request.get(buildApiUrl('/definition/new'), buildRequestOptions());
   const createdDefinition = await readJson(createResponse, 'Creating definition metadata');
   const definitionId = createdDefinition?.definitionId || createdDefinition?.DefinitionId;
 
-  const updateResponse = await request.put(buildApiUrl('/definition/meta'), {
+  const updateResponse = await request.put(buildApiUrl('/definition/meta'), buildRequestOptions({
     data: {
       definitionId,
       name,
       description
     }
-  });
+  }));
   await readJson(updateResponse, 'Updating definition metadata');
 
   return definitionId;
@@ -154,12 +172,12 @@ async function createDefinitionMeta(request, { name, description = '' }) {
 
 async function deployDefinition(request, { xml }) {
 
-  const definitionResponse = await request.post(buildApiUrl('/definition/deploy'), {
+  const definitionResponse = await request.post(buildApiUrl('/definition/deploy'), buildRequestOptions({
     headers: {
       'content-type': 'text/plain'
     },
     data: xml
-  });
+  }));
 
   const deployedDefinition = ensureApiSuccess(
     await readJson(definitionResponse, 'Deploying definition'),
@@ -172,32 +190,32 @@ async function deployDefinition(request, { xml }) {
 }
 
 async function sendMessage(request, { name, correlationKey = null, variables = {}, instanceId = null }) {
-  const response = await request.post(buildApiUrl('/message'), {
+  const response = await request.post(buildApiUrl('/message'), buildRequestOptions({
     data: {
       name,
       correlationKey,
       variables,
       instanceId
     }
-  });
+  }));
 
   ensureApiSuccess(await readJson(response, 'Sending message'), 'Sending message');
 }
 
 async function getUserTasks(request) {
-  const response = await request.get(buildApiUrl('/usertask'));
+  const response = await request.get(buildApiUrl('/usertask'), buildRequestOptions());
   return ensureApiSuccess(await readJson(response, 'Loading user tasks'), 'Loading user tasks');
 }
 
 async function completeUserTask(request, userTask, data = {}) {
-  const response = await request.post(buildApiUrl('/form/result'), {
+  const response = await request.post(buildApiUrl('/form/result'), buildRequestOptions({
     data: {
       flowNodeId: userTask.token.currentFlowNodeId,
       tokenId: userTask.token.id,
       processInstanceId: userTask.processInstanceId,
       data
     }
-  });
+  }));
 
   ensureApiSuccess(await readJson(response, 'Completing user task'), 'Completing user task');
 }


### PR DESCRIPTION
## Zusammenfassung

Dieses PR härtet den Benutzerkontext für geschützte Web-API-Pfade.

Definition-Uploads sowie benutzergebundene User-Task- und Form-Ergebnis-Endpunkte akzeptieren den stillen System-Fallback jetzt nicht mehr als produktionsnahen Standardpfad, sondern verlangen einen aufgelösten Benutzerkontext. Der Development-Header bleibt für lokale Entwicklungsumgebungen weiterhin nutzbar.

## Änderungen

- `CurrentUserContextExtensions.RequireResolvedUserId(...)` als zentrale Guard-Logik ergänzt
- Definition-Uploads/-Deploys gegen Fallback-Benutzer abgesichert
- `/usertask` sowie User-Task-/Form-Ergebnispfade gegen Fallback-Benutzer abgesichert
- neue Integrationstests für Development-Header, fehlende Authentifizierung und aufgelösten Benutzerkontext ergänzt
- neue Tests für `HttpContextCurrentUserContextAccessor` mit Claim-, Header- und Fallback-Verhalten ergänzt
- Status- und Roadmap-Doku an den neuen Stand angepasst

## Tests

Lokal erfolgreich ausgeführt:

- `dotnet build core-engine.sln --configuration Release`
- `dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'`
- `dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'`
- `dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'`

## Bezug

- Bezieht sich auf #87
