### PR TITLE
Operations-Basis um Diagnose, Metrics-Namen und Recovery-Hinweise erweitern

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Die bisherige Dokumentation klang teilweise deutlich reifer als der aktuelle Sta
 - Timer-Subscriptions werden jetzt auch in Storage/Web-API persistiert, über einen kleinen Scheduler-Polling-Pfad verarbeitet und können wiederkehrende Start-Timer inklusive Restwiederholungen abbilden.
 - Geschützte API-Pfade verlangen inzwischen einen **aufgelösten Benutzerkontext**, statt stillschweigend über einen System-Fallback weiterzulaufen.
 - Für lokale Entwicklung und UI-Smokes setzt das Frontend im **Development-Modus** jetzt automatisch einen technischen Benutzerheader, damit die gehärteten API-Pfade lokal weiter reproduzierbar testbar bleiben.
+- Zusätzlich gibt es jetzt einen kleinen **Operations-/Diagnose-Endpunkt** sowie lokale Metrics-/Tracing-Namen, damit Scheduler- und Storage-Zustand nicht nur über reine Healthchecks sichtbar werden.
 - Es gibt aber weiterhin **offene Restlücken** bei weitergehender Timer-/Boundary-Recovery, Auth/Identity und Betriebsreife.
 - Das Projekt ist **klar revivierbar und aktiv weiterentwickelbar**, wenn die nächsten Schritte weiter fokussiert bleiben.
 
@@ -97,7 +98,7 @@ Diese Punkte sollte man kennen, bevor man loslegt:
    Der Engine-Kern kann fällige Timer jetzt weiterführen, Boundary-Timer im bestehenden Subscription-Pfad verarbeiten, wiederkehrende Start-Timer überfälligkeitstolerant nachziehen und rohe `NotImplementedException`-Abbrüche in mehreren Pfaden vermeiden. Offen bleiben weiterhin speziellere Recovery-Fragen, vollständige Fehler-/Eskalationssemantik und echte Kompensation.
 
 4. **Betrieb und Auth sind noch nicht am Ziel**
-   Lokale Compose- und Runtime-Container sind vorhanden, geschützte API-Pfade verlangen jetzt zwar einen aufgelösten Benutzerkontext, aber Themen wie echte Authentifizierung, Rollenmodell, Telemetrie, Secrets, TLS und Recovery sind weiterhin Folgepakete.
+   Lokale Compose- und Runtime-Container sind vorhanden, geschützte API-Pfade verlangen jetzt zwar einen aufgelösten Benutzerkontext und die Web-API liefert erste Operations-Diagnose-Informationen, aber Themen wie echte Authentifizierung, Rollenmodell, externe Telemetrie-Backends, Secrets, TLS und Recovery-Automatisierung sind weiterhin Folgepakete.
 
 ## Dokumentation
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -2,18 +2,20 @@
 
 **Stand:** 12. April 2026
 
-Dieses Dokument beschreibt den derzeit realistischen Betriebsrahmen für `next`: lokale Starts, Health-Signale, Compose-Setup und sinnvolle Prüfpfade.
+Dieses Dokument beschreibt den derzeit realistischen Betriebsrahmen für `next`: lokale Starts, Health-Signale, einfache Diagnose-Endpunkte, Compose-Setup und sinnvolle Prüfpfade.
 
 > Wichtig: Das ist **noch keine produktionsfertige Deployment-Story**. Ziel dieses Pakets ist ein reproduzierbarer, dokumentierter Start- und Prüfpfad für API und Frontend.
 
 ## Enthaltene Bausteine
 
 - dokumentierte Health-Endpunkte der Web-API
+- dokumentierter Operations-/Diagnose-Endpunkt der Web-API
 - lokaler Startpfad per `dotnet run`
 - lokaler Startpfad per Docker Compose
 - runtime-nahe Release-Container für API + Frontend + Gateway
 - kleine Shell-Skripte zum Starten, Stoppen und Prüfen des lokalen Stacks
 - definierter Storage-Pfad für dateibasierte Persistenz
+- kleine Metrics-/Tracing-Grundlage über `Meter` und `ActivitySource`
 
 ## Health-Signale
 
@@ -21,11 +23,20 @@ Die Web-API stellt aktuell folgende Endpunkte bereit:
 
 - `GET /health` – Liveness
 - `GET /health/ready` – Readiness inkl. Storage-Prüfung
+- `GET /operations/diagnostics` – Scheduler-Status, Storage-Snapshot und lokale Instrumentierungsnamen
 
 Typische URLs lokal:
 
 - [http://localhost:5182/health](http://localhost:5182/health)
 - [http://localhost:5182/health/ready](http://localhost:5182/health/ready)
+- [http://localhost:5182/operations/diagnostics](http://localhost:5182/operations/diagnostics)
+
+Der Diagnose-Endpunkt ist bewusst **pragmatisch statt vollständig**. Er liefert aktuell:
+
+- aktuellen Environment- und Zeitstempel
+- Storage-Snapshot mit Definitionen, Formularen, Instanzen und offenen Subscriptions
+- Timer-Scheduler-Status inkl. letztem Tick, Fehlerstatus und verarbeiteter Timerzahl
+- Namen des lokalen `Meter`- und `ActivitySource`-Setups für spätere Exporter-Anbindung
 
 ## Lokaler Start ohne Docker
 
@@ -103,6 +114,7 @@ Typische URLs:
 - [http://localhost:5288](http://localhost:5288)
 - [http://localhost:5288/health](http://localhost:5288/health)
 - [http://localhost:5288/health/ready](http://localhost:5288/health/ready)
+- [http://localhost:5288/operations/diagnostics](http://localhost:5288/operations/diagnostics)
 
 Bei Portkonflikten kann der Host-Port über `FLOWZER_RUNTIME_PORT` überschrieben werden.
 
@@ -131,6 +143,23 @@ Der runtime-nahe Stack nutzt bewusst einen separaten Pfad:
 Damit bleiben lokale Dev-Daten und runtime-nahe Containerdaten getrennt.
 
 ## Logs und Diagnose
+
+### Request- und Scheduler-Diagnose
+
+Die Web-API protokolliert zentrale Request- und Scheduler-Signale jetzt strukturierter:
+
+- mutierende Requests sowie langsame oder fehlerhafte API-Aufrufe werden mit Statuscode, Dauer und `TraceId` geloggt
+- der Timer-Scheduler meldet Start, Tick-Erfolg, Tick-Fehler und zuletzt verarbeitete Timer
+- Health-Aufrufe bleiben bewusst aus dieser zusätzlichen Request-Protokollierung ausgenommen, damit die Logs nicht mit Probe-Traffic überlaufen
+
+### Meter- und Activity-Namen
+
+Für spätere Exporter- oder OpenTelemetry-Anbindung sind jetzt stabile lokale Namen vorhanden:
+
+- `Meter`: `Flowzer.WebApi`
+- `ActivitySource`: `Flowzer.WebApi`
+
+Dieses Paket führt **noch keinen externen Exporter** ein, damit der lokale Betriebsweg klein und reproduzierbar bleibt.
 
 ### Container-Logs
 
@@ -165,18 +194,67 @@ FLOWZER_FRONTEND_URL=http://localhost:5288 \
 npm --prefix tests/ui-smoke run test
 ```
 
+## Recovery- und Backup-Hinweise für die dateibasierte Persistenz
+
+Die dateibasierte Persistenz ist aktuell weiterhin die maßgebliche lokale Betriebsquelle. Für Diagnose, Backup und Restore gelten deshalb ein paar einfache Regeln:
+
+### Relevante Verzeichnisse
+
+- lokale Dev-/Compose-Daten: `.data/flowzer-storage`
+- runtime-nahe Containerdaten: `.data/runtime-storage`
+
+### Sicheres Backup
+
+Am zuverlässigsten ist ein Backup bei gestopptem Stack oder zumindest ohne parallele Schreiblast:
+
+```bash
+./scripts/local/stop-stack.sh
+tar -czf flowzer-storage-backup.tgz .data/flowzer-storage
+```
+
+Für den runtime-nahen Stack entsprechend:
+
+```bash
+./scripts/runtime/stop-runtime-stack.sh
+tar -czf flowzer-runtime-storage-backup.tgz .data/runtime-storage
+```
+
+### Restore
+
+1. Stack stoppen
+2. Zielverzeichnis leeren oder ersetzen
+3. Backup entpacken
+4. Stack neu starten
+5. `/health/ready` und `/operations/diagnostics` prüfen
+
+Beispiel lokal:
+
+```bash
+rm -rf .data/flowzer-storage
+mkdir -p .data
+tar -xzf flowzer-storage-backup.tgz -C .data
+./scripts/local/start-stack.sh
+```
+
+### Sinnvolle Recovery-Checks nach einem Restore
+
+- `/health/ready` liefert `Healthy`
+- `/operations/diagnostics` zeigt plausible Definitionen-, Instanz- und Timer-Zahlen
+- UI-Smokes gegen den laufenden Stack laufen ohne fatale Requests
+- Timer-Scheduler steht nicht dauerhaft auf `Faulted`
+
 ## Bewusst noch offen
 
 Folgende Betriebsaspekte sind mit diesem Paket **noch nicht abgeschlossen**:
 
 - strukturierte Produktions-Logformate über die Standard-Konsole hinaus
-- Metrics/Tracing
+- externe Metrics-/Tracing-Exporter oder Dashboards
 - produktionsnahe Reverse-Proxy- oder TLS-Story
 - Secret-/Configuration-Story jenseits lokaler Entwicklungswerte
 
 ## Sinnvolle nächste Ausbauschritte
 
 1. Reverse-Proxy-/Gateway-Konfiguration für echte Zielumgebungen weiter härten
-2. Metrics/Tracing einführen
-3. Recovery-/Backup-Hinweise für dateibasierte Persistenz dokumentieren
-4. Secret-/Konfigurationsstory für Nicht-Entwicklungsumgebungen schärfen
+2. externe Metrics-/Tracing-Exporter und Dashboards anbinden
+3. Secret-/Konfigurationsstory für Nicht-Entwicklungsumgebungen schärfen
+4. Reverse-Proxy-/TLS-Härtung und Backup-Automatisierung vertiefen

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -72,7 +72,7 @@ Besonders relevant sind noch:
 - weiter ausgebautes Playwright-/E2E-Smoke-Set
 - Restlücken bei spezieller Boundary-/Spezialtimer-Recovery und weitergehender Scheduler-Semantik
 - weitere Auth-/Identity- und Fehlerpfade jenseits des aktuellen Benutzerkontext-Guards
-- Release-/Telemetry-/Secret-/Recovery-Story über die lokale Basis hinaus
+- Release-/Telemetrie-/Secret-/Recovery-Story über die lokale Basis hinaus
 
 ### 2. Es gibt noch Restlücken im Codebestand
 
@@ -80,7 +80,7 @@ Noch offen sind unter anderem:
 
 - Restlücken in Timer-, Boundary- und Kompensationssemantik
 - provisorische Auth-/Identity-Platzhalter oberhalb des aktuellen Benutzerkontext-Guards
-- Betriebs- und Deployment-Themen wie Reverse Proxy, TLS, externe Logging-/Telemetry-Backends und Recovery-Automatisierung
+- Betriebs- und Deployment-Themen wie Reverse Proxy, TLS, externe Logging-/Telemetrie-Backends und Recovery-Automatisierung
 - Altlasten und Doppelstrukturen im Repository
 
 Für die inzwischen vorhandene lokale Start- und Diagnosebasis siehe zusätzlich [`docs/OPERATIONS.md`](./OPERATIONS.md).

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -59,6 +59,9 @@ Unter anderem bereits umgesetzt:
 - lokaler Development- und UI-Smoke-Pfad sendet für diese geschützten Routen nun automatisch einen technischen Benutzerheader, ohne die strengeren Produktionspfade wieder aufzuweichen
 - Nullability- und Guard-Härtung in zentralen Frontend-Seiten
 - lokale Runtime-Containerbasis für API, Frontend und Gateway
+- Operations-/Diagnose-Endpunkt mit Scheduler-Status, Storage-Snapshot und lokalen Metrics-/Tracing-Namen
+- Request- und Timer-Scheduler-Diagnosepfad mit Dauer-, Status- und Tick-Signalen
+- dokumentierte Recovery-/Backup-Hinweise für die dateibasierte Persistenz
 
 ## Was weiterhin bremst
 
@@ -69,7 +72,7 @@ Besonders relevant sind noch:
 - weiter ausgebautes Playwright-/E2E-Smoke-Set
 - Restlücken bei spezieller Boundary-/Spezialtimer-Recovery und weitergehender Scheduler-Semantik
 - weitere Auth-/Identity- und Fehlerpfade jenseits des aktuellen Benutzerkontext-Guards
-- Release-/Telemetrie-/Secret-/Recovery-Story über die lokale Basis hinaus
+- Release-/Telemetry-/Secret-/Recovery-Story über die lokale Basis hinaus
 
 ### 2. Es gibt noch Restlücken im Codebestand
 
@@ -77,7 +80,7 @@ Noch offen sind unter anderem:
 
 - Restlücken in Timer-, Boundary- und Kompensationssemantik
 - provisorische Auth-/Identity-Platzhalter oberhalb des aktuellen Benutzerkontext-Guards
-- Betriebs- und Deployment-Themen wie Reverse Proxy, TLS, Logging-/Telemetry und Recovery
+- Betriebs- und Deployment-Themen wie Reverse Proxy, TLS, externe Logging-/Telemetry-Backends und Recovery-Automatisierung
 - Altlasten und Doppelstrukturen im Repository
 
 Für die inzwischen vorhandene lokale Start- und Diagnosebasis siehe zusätzlich [`docs/OPERATIONS.md`](./OPERATIONS.md).
@@ -99,7 +102,7 @@ Die erste große Revitalisierungs- und Stabilisierungswelle ist inzwischen weitg
 
 - weitergehende Boundary-/Spezialtimer-Recovery sowie BPMN-Fehler-/Eskalationssemantik
 - Auth-/Identity-Härtung über Claim-, Rollen- und Betriebsmodell
-- Telemetrie, Secrets, Recovery und operationsnahe Doku
+- externe Telemetrie-Backends, Secrets, Recovery-Automatisierung und operationsnahe Doku
 - weitere Architektur- und Repo-Hygiene
 
 ## Aktuelle Gesamtempfehlung
@@ -109,7 +112,7 @@ Das Projekt sollte jetzt **nicht mehr primär gerettet**, sondern gezielt **zur 
 Die sinnvolle Reihenfolge ist aus heutiger Sicht:
 
 1. Auth-/Identity- und API-Verträge über Claim-/Rollenmodell weiter schärfen
-2. Betriebsbasis um Telemetrie, Secrets, TLS und Recovery erweitern
+2. Betriebsbasis um externe Telemetrie-Backends, Secrets, TLS und Recovery-Automatisierung erweitern
 3. Timer-Recovery nur noch in verbleibenden Spezialfällen weiter vertiefen
 4. E2E-, Architektur- und Operations-Dokumentation weiter vertiefen
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,7 +45,7 @@ Die Roadmap startet also **nicht mehr bei Null**, sondern baut auf einer funktio
 
 ### 2.1 Operations-Basis über die lokale Compose-Story hinaus vertiefen
 
-- Metrics/Tracing
+- externe Metrics-/Tracing-Exporter und Dashboards
 - Secret-/Konfigurationsstory
 - Recovery-/Backup-Hinweise
 - Reverse-Proxy-/TLS-Härtung für echte Zielumgebungen
@@ -80,7 +80,7 @@ Die Roadmap startet also **nicht mehr bei Null**, sondern baut auf einer funktio
 
 ### Sprint B – Betrieb und Auth
 
-- Telemetrie/Secrets/Recovery
+- externe Telemetrie/Secrets/Recovery
 - Claim-/Rollenmodell und Auth-/Identity-Härtung
 
 ### Sprint C – E2E und Dokumentation

--- a/scripts/local/check-stack.sh
+++ b/scripts/local/check-stack.sh
@@ -5,6 +5,7 @@ api_url="${FLOWZER_API_URL:-http://localhost:5182}"
 frontend_url="${FLOWZER_FRONTEND_URL:-http://localhost:5269}"
 health_file="$(mktemp /tmp/flowzer-health.XXXXXX.json)"
 ready_file="$(mktemp /tmp/flowzer-ready.XXXXXX.json)"
+diagnostics_file="$(mktemp /tmp/flowzer-ops.XXXXXX.json)"
 frontend_file="$(mktemp /tmp/flowzer-frontend.XXXXXX.html)"
 curl_opts=(
   --fail
@@ -18,7 +19,7 @@ curl_opts=(
   --retry-connrefused
 )
 
-trap 'rm -f "$health_file" "$ready_file" "$frontend_file"' EXIT
+trap 'rm -f "$health_file" "$ready_file" "$diagnostics_file" "$frontend_file"' EXIT
 
 echo "Checking API liveness: ${api_url}/health"
 curl "${curl_opts[@]}" "${api_url}/health" >"$health_file"
@@ -28,6 +29,12 @@ echo
 echo "Checking API readiness: ${api_url}/health/ready"
 curl "${curl_opts[@]}" "${api_url}/health/ready" >"$ready_file"
 cat "$ready_file"
+echo
+
+echo "Checking API operations diagnostics: ${api_url}/operations/diagnostics"
+curl "${curl_opts[@]}" "${api_url}/operations/diagnostics" >"$diagnostics_file"
+grep -q '"Successful"[[:space:]]*:[[:space:]]*true' "$diagnostics_file"
+cat "$diagnostics_file"
 echo
 
 echo "Checking frontend root: ${frontend_url}"

--- a/scripts/local/check-stack.sh
+++ b/scripts/local/check-stack.sh
@@ -33,7 +33,7 @@ echo
 
 echo "Checking API operations diagnostics: ${api_url}/operations/diagnostics"
 curl "${curl_opts[@]}" "${api_url}/operations/diagnostics" >"$diagnostics_file"
-grep -q '"Successful"[[:space:]]*:[[:space:]]*true' "$diagnostics_file"
+grep -Eqi '"(successful|Successful)"[[:space:]]*:[[:space:]]*true' "$diagnostics_file"
 cat "$diagnostics_file"
 echo
 

--- a/scripts/runtime/check-runtime-stack.sh
+++ b/scripts/runtime/check-runtime-stack.sh
@@ -33,7 +33,7 @@ echo
 
 echo "Checking runtime operations diagnostics: ${gateway_url}/operations/diagnostics"
 curl "${curl_opts[@]}" "${gateway_url}/operations/diagnostics" >"$diagnostics_file"
-grep -q '"Successful"[[:space:]]*:[[:space:]]*true' "$diagnostics_file"
+grep -Eqi '"(successful|Successful)"[[:space:]]*:[[:space:]]*true' "$diagnostics_file"
 cat "$diagnostics_file"
 echo
 

--- a/scripts/runtime/check-runtime-stack.sh
+++ b/scripts/runtime/check-runtime-stack.sh
@@ -5,6 +5,7 @@ runtime_port="${FLOWZER_RUNTIME_PORT:-5288}"
 gateway_url="${FLOWZER_GATEWAY_URL:-http://localhost:${runtime_port}}"
 health_file="$(mktemp /tmp/flowzer-runtime-health.XXXXXX.json)"
 ready_file="$(mktemp /tmp/flowzer-runtime-ready.XXXXXX.json)"
+diagnostics_file="$(mktemp /tmp/flowzer-runtime-ops.XXXXXX.json)"
 frontend_file="$(mktemp /tmp/flowzer-runtime-frontend.XXXXXX.html)"
 curl_opts=(
   --fail
@@ -18,7 +19,7 @@ curl_opts=(
   --retry-connrefused
 )
 
-trap 'rm -f "$health_file" "$ready_file" "$frontend_file"' EXIT
+trap 'rm -f "$health_file" "$ready_file" "$diagnostics_file" "$frontend_file"' EXIT
 
 echo "Checking runtime gateway liveness: ${gateway_url}/health"
 curl "${curl_opts[@]}" "${gateway_url}/health" >"$health_file"
@@ -28,6 +29,12 @@ echo
 echo "Checking runtime gateway readiness: ${gateway_url}/health/ready"
 curl "${curl_opts[@]}" "${gateway_url}/health/ready" >"$ready_file"
 cat "$ready_file"
+echo
+
+echo "Checking runtime operations diagnostics: ${gateway_url}/operations/diagnostics"
+curl "${curl_opts[@]}" "${gateway_url}/operations/diagnostics" >"$diagnostics_file"
+grep -q '"Successful"[[:space:]]*:[[:space:]]*true' "$diagnostics_file"
+cat "$diagnostics_file"
 echo
 
 echo "Checking runtime frontend root: ${gateway_url}"

--- a/src/WebApiEngine.Shared/OperationsDiagnosticsDto.cs
+++ b/src/WebApiEngine.Shared/OperationsDiagnosticsDto.cs
@@ -1,0 +1,53 @@
+namespace WebApiEngine.Shared;
+
+public class OperationsDiagnosticsDto
+{
+    public required DateTime CheckedAtUtc { get; set; }
+    public required string Environment { get; set; }
+    public required OperationsStorageSnapshotDto Storage { get; set; }
+    public required TimerSchedulerDiagnosticsDto TimerScheduler { get; set; }
+    public required OperationsInstrumentationDto Instrumentation { get; set; }
+}
+
+public class OperationsStorageSnapshotDto
+{
+    public required string StorageRootHint { get; set; }
+    public required int TotalDefinitions { get; set; }
+    public required int ActiveDefinitions { get; set; }
+    public required int DefinitionMetadataEntries { get; set; }
+    public required int FormMetadataEntries { get; set; }
+    public required int TotalInstances { get; set; }
+    public required int ActiveInstances { get; set; }
+    public required int CompletedInstances { get; set; }
+    public required int FailedInstances { get; set; }
+    public required int PendingMessages { get; set; }
+    public required int PendingTimers { get; set; }
+    public required int OpenUserTasks { get; set; }
+    public required int PendingSignals { get; set; }
+    public required int PendingServices { get; set; }
+}
+
+public class TimerSchedulerDiagnosticsDto
+{
+    public required bool Enabled { get; set; }
+    public required int PollIntervalSeconds { get; set; }
+    public required string Status { get; set; }
+    public DateTime? ServiceStartedAtUtc { get; set; }
+    public DateTime? LastTickStartedAtUtc { get; set; }
+    public DateTime? LastTickCompletedAtUtc { get; set; }
+    public DateTime? LastSuccessfulTickAtUtc { get; set; }
+    public DateTime? LastFailedTickAtUtc { get; set; }
+    public double? LastTickDurationMs { get; set; }
+    public int LastProcessedTimers { get; set; }
+    public long SuccessfulTickCount { get; set; }
+    public long FailedTickCount { get; set; }
+    public long TotalProcessedTimers { get; set; }
+    public string? LastErrorMessage { get; set; }
+}
+
+public class OperationsInstrumentationDto
+{
+    public required string MeterName { get; set; }
+    public required string ActivitySourceName { get; set; }
+    public required string Notes { get; set; }
+}

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -182,6 +182,7 @@ public class ApiHardeningIntegrationTest
         payload.Result.TimerScheduler.Status.Should().Be("Disabled");
         payload.Result.Instrumentation.MeterName.Should().Be("Flowzer.WebApi");
         payload.Result.Instrumentation.ActivitySourceName.Should().Be("Flowzer.WebApi");
+        storage.GetAllActiveInstancesCallCount.Should().Be(0);
     }
 
     [Test]
@@ -202,6 +203,38 @@ public class ApiHardeningIntegrationTest
         payload.Should().NotBeNull();
         payload!.Successful.Should().BeFalse();
         payload.ErrorMessage.Should().Be("Operations diagnostics are currently unavailable.");
+    }
+
+    [Test]
+    public async Task OperationsDiagnostics_ShouldRedactCustomStorageRootOutsideDevelopment()
+    {
+        var storage = new TestStorage();
+        var previousStorageRoot = Environment.GetEnvironmentVariable(FilesystemStorageSystem.Storage.StorageRootEnvironmentVariableName);
+        var configuredStorageRoot = Path.Combine(Path.GetTempPath(), "flowzer-observability-root", Guid.NewGuid().ToString("N"), "custom-store");
+
+        Environment.SetEnvironmentVariable(FilesystemStorageSystem.Storage.StorageRootEnvironmentVariableName, configuredStorageRoot);
+
+        try
+        {
+            await using var factory = new TestWebApplicationFactory(
+                storage,
+                new TestFactoryOptions { EnvironmentName = "Production" });
+            using var client = factory.CreateClient();
+
+            var response = await client.GetAsync("/operations/diagnostics");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<OperationsDiagnosticsDto>>();
+            payload.Should().NotBeNull();
+            payload!.Successful.Should().BeTrue();
+            payload.Result.Should().NotBeNull();
+            payload.Result!.Storage.StorageRootHint.Should().Be("(custom FLOWZER_STORAGE_ROOT configured: custom-store)");
+            payload.Result.Storage.StorageRootHint.Should().NotContain(configuredStorageRoot);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(FilesystemStorageSystem.Storage.StorageRootEnvironmentVariableName, previousStorageRoot);
+        }
     }
 
     [Test]
@@ -646,6 +679,7 @@ public class ApiHardeningIntegrationTest
     {
         public bool ThrowOnGetAllDefinitions { get; set; }
         public bool ThrowOnGetFormMetadata { get; set; }
+        public int GetAllActiveInstancesCallCount { get; set; }
         public Guid? LastRequestedExtendedUserTaskUserId { get; set; }
         public List<BpmnDefinition> StoredDefinitions { get; } = [];
         public List<ExtendedBpmnMetaDefinition> MetaDefinitions { get; } = [];
@@ -904,6 +938,7 @@ public class ApiHardeningIntegrationTest
 
         public Task<IEnumerable<ProcessInstanceInfo>> GetAllActiveInstances()
         {
+            storage.GetAllActiveInstancesCallCount++;
             return Task.FromResult(storage.Instances.Where(instance => !instance.IsFinished));
         }
 

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -65,6 +65,146 @@ public class ApiHardeningIntegrationTest
     }
 
     [Test]
+    public async Task OperationsDiagnostics_ShouldReturnSchedulerAndStorageSnapshot()
+    {
+        var storage = new TestStorage();
+        storage.StoredDefinitions.AddRange(
+        [
+            new BpmnDefinition
+            {
+                Id = Guid.NewGuid(),
+                DefinitionId = "definition-active",
+                Hash = "hash-active",
+                SavedByUser = Guid.NewGuid(),
+                SavedOn = DateTime.UtcNow,
+                Version = new Model.Version(1, 0),
+                IsActive = true
+            },
+            new BpmnDefinition
+            {
+                Id = Guid.NewGuid(),
+                DefinitionId = "definition-inactive",
+                Hash = "hash-inactive",
+                SavedByUser = Guid.NewGuid(),
+                SavedOn = DateTime.UtcNow,
+                Version = new Model.Version(1, 0),
+                IsActive = false
+            }
+        ]);
+        storage.MetaDefinitions.Add(new ExtendedBpmnMetaDefinition
+        {
+            DefinitionId = "definition-active",
+            Name = "Active Definition",
+            LatestVersion = new Model.Version(1, 0),
+            LatestVersionDateTime = DateTime.UtcNow
+        });
+        storage.FormMetadatas.Add(new FormMetadata
+        {
+            FormId = Guid.NewGuid(),
+            Name = "Approval Form"
+        });
+        storage.MessageSubscriptions.Add(new MessageSubscription(
+            new MessageDefinition
+            {
+                Name = "InvoiceReceived",
+                FlowzerCorrelationKey = "invoiceId"
+            },
+            "Process_Invoice",
+            "definition-active",
+            storage.StoredDefinitions[0].Id,
+            null));
+        storage.TimerSubscriptions.Add(new TimerSubscription
+        {
+            DueAt = DateTime.UtcNow.AddMinutes(5),
+            FlowNodeId = "StartEvent_Timer",
+            Kind = TimerSubscriptionKind.ProcessStartEvent,
+            ProcessId = "Process_Invoice",
+            RelatedDefinitionId = "definition-active",
+            DefinitionId = storage.StoredDefinitions[0].Id
+        });
+        storage.Instances.AddRange(
+        [
+            new ProcessInstanceInfo
+            {
+                InstanceId = Guid.NewGuid(),
+                metaDefinitionId = "definition-active",
+                DefinitionId = storage.StoredDefinitions[0].Id,
+                ProcessId = "Process_Invoice",
+                Tokens = [],
+                IsFinished = false,
+                State = ProcessInstanceState.Waiting,
+                MessageSubscriptionCount = 1,
+                SignalSubscriptionCount = 2,
+                UserTaskSubscriptionCount = 3,
+                ServiceSubscriptionCount = 1
+            },
+            new ProcessInstanceInfo
+            {
+                InstanceId = Guid.NewGuid(),
+                metaDefinitionId = "definition-active",
+                DefinitionId = storage.StoredDefinitions[0].Id,
+                ProcessId = "Process_Invoice",
+                Tokens = [],
+                IsFinished = true,
+                State = ProcessInstanceState.Completed,
+                MessageSubscriptionCount = 0,
+                SignalSubscriptionCount = 0,
+                UserTaskSubscriptionCount = 0,
+                ServiceSubscriptionCount = 0
+            }
+        ]);
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/operations/diagnostics");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<OperationsDiagnosticsDto>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeTrue();
+        payload.Result.Should().NotBeNull();
+        payload.Result!.Environment.Should().Be("Development");
+        payload.Result.Storage.TotalDefinitions.Should().Be(2);
+        payload.Result.Storage.ActiveDefinitions.Should().Be(1);
+        payload.Result.Storage.DefinitionMetadataEntries.Should().Be(1);
+        payload.Result.Storage.FormMetadataEntries.Should().Be(1);
+        payload.Result.Storage.TotalInstances.Should().Be(2);
+        payload.Result.Storage.ActiveInstances.Should().Be(1);
+        payload.Result.Storage.CompletedInstances.Should().Be(1);
+        payload.Result.Storage.FailedInstances.Should().Be(0);
+        payload.Result.Storage.PendingMessages.Should().Be(1);
+        payload.Result.Storage.PendingTimers.Should().Be(1);
+        payload.Result.Storage.OpenUserTasks.Should().Be(3);
+        payload.Result.Storage.PendingSignals.Should().Be(2);
+        payload.Result.Storage.PendingServices.Should().Be(1);
+        payload.Result.TimerScheduler.Enabled.Should().BeFalse();
+        payload.Result.TimerScheduler.Status.Should().Be("Disabled");
+        payload.Result.Instrumentation.MeterName.Should().Be("Flowzer.WebApi");
+        payload.Result.Instrumentation.ActivitySourceName.Should().Be("Flowzer.WebApi");
+    }
+
+    [Test]
+    public async Task OperationsDiagnostics_ShouldReturnServiceUnavailable_WhenStorageSnapshotFails()
+    {
+        var storage = new TestStorage
+        {
+            ThrowOnGetAllDefinitions = true
+        };
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/operations/diagnostics");
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<OperationsDiagnosticsDto>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeFalse();
+        payload.ErrorMessage.Should().Be("Operations diagnostics are currently unavailable.");
+    }
+
+    [Test]
     public async Task UploadDefinition_ShouldUseTechnicalUserHeader_WhenNoAuthenticationExistsYet()
     {
         var storage = new TestStorage();
@@ -508,12 +648,16 @@ public class ApiHardeningIntegrationTest
         public bool ThrowOnGetFormMetadata { get; set; }
         public Guid? LastRequestedExtendedUserTaskUserId { get; set; }
         public List<BpmnDefinition> StoredDefinitions { get; } = [];
+        public List<ExtendedBpmnMetaDefinition> MetaDefinitions { get; } = [];
         public Dictionary<Guid, string> StoredBinaries { get; } = [];
+        public List<FormMetadata> FormMetadatas { get; } = [];
         public List<MessageSubscription> MessageSubscriptions { get; } = [];
+        public List<TimerSubscription> TimerSubscriptions { get; } = [];
+        public List<ProcessInstanceInfo> Instances { get; } = [];
 
         public IDefinitionStorage DefinitionStorage => new TestDefinitionStorage(this);
         public IMessageSubscriptionStorage SubscriptionStorage => new TestSubscriptionStorage(this);
-        public IInstanceStorage InstanceStorage { get; } = new TestInstanceStorage();
+        public IInstanceStorage InstanceStorage => new TestInstanceStorage(this);
         public IFormStorage FormStorage => new TestFormStorage(this);
 
         public void CommitChanges()
@@ -610,16 +754,30 @@ public class ApiHardeningIntegrationTest
 
         public Task<ExtendedBpmnMetaDefinition[]> GetAllMetaDefinitions()
         {
-            return Task.FromResult(Array.Empty<ExtendedBpmnMetaDefinition>());
+            return Task.FromResult(storage.MetaDefinitions.ToArray());
         }
 
         public Task StoreMetaDefinition(BpmnMetaDefinition metaDefinition)
         {
+            storage.MetaDefinitions.RemoveAll(existing => existing.DefinitionId == metaDefinition.DefinitionId);
+            storage.MetaDefinitions.Add(new ExtendedBpmnMetaDefinition
+            {
+                DefinitionId = metaDefinition.DefinitionId,
+                Name = metaDefinition.Name,
+                Description = metaDefinition.Description
+            });
             return Task.CompletedTask;
         }
 
         public Task UpdateMetaDefinition(BpmnMetaDefinition metaDefinition)
         {
+            storage.MetaDefinitions.RemoveAll(existing => existing.DefinitionId == metaDefinition.DefinitionId);
+            storage.MetaDefinitions.Add(new ExtendedBpmnMetaDefinition
+            {
+                DefinitionId = metaDefinition.DefinitionId,
+                Name = metaDefinition.Name,
+                Description = metaDefinition.Description
+            });
             return Task.CompletedTask;
         }
 
@@ -696,40 +854,62 @@ public class ApiHardeningIntegrationTest
         public Task RemoveAllUserTaskSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
 
         public Task<IEnumerable<TimerSubscription>> GetAllTimerSubscriptions() =>
-            Task.FromResult(Enumerable.Empty<TimerSubscription>());
+            Task.FromResult(storage.TimerSubscriptions.AsEnumerable());
 
         public Task<IEnumerable<TimerSubscription>> GetTimerSubscriptions(Guid instanceId) =>
-            Task.FromResult(Enumerable.Empty<TimerSubscription>());
+            Task.FromResult(storage.TimerSubscriptions.Where(subscription => subscription.ProcessInstanceId == instanceId));
 
-        public Task AddTimerSubscription(TimerSubscription timerSubscription) => Task.CompletedTask;
+        public Task AddTimerSubscription(TimerSubscription timerSubscription)
+        {
+            storage.TimerSubscriptions.RemoveAll(existing => existing.Id == timerSubscription.Id);
+            storage.TimerSubscriptions.Add(timerSubscription);
+            return Task.CompletedTask;
+        }
 
-        public Task RemoveTimerSubscription(Guid timerSubscriptionId) => Task.CompletedTask;
+        public Task RemoveTimerSubscription(Guid timerSubscriptionId)
+        {
+            storage.TimerSubscriptions.RemoveAll(existing => existing.Id == timerSubscriptionId);
+            return Task.CompletedTask;
+        }
 
-        public Task RemoveProcessTimerSubscriptionsByProcessInstanceId(Guid instanceId) => Task.CompletedTask;
+        public Task RemoveProcessTimerSubscriptionsByProcessInstanceId(Guid instanceId)
+        {
+            storage.TimerSubscriptions.RemoveAll(existing => existing.ProcessInstanceId == instanceId);
+            return Task.CompletedTask;
+        }
 
-        public Task RemoveAllProcessTimerSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
+        public Task RemoveAllProcessTimerSubscriptionsWithNoInstanceId(string relatedDefinitionId)
+        {
+            storage.TimerSubscriptions.RemoveAll(existing =>
+                existing.RelatedDefinitionId == relatedDefinitionId && existing.ProcessInstanceId == null);
+            return Task.CompletedTask;
+        }
     }
 
-    private sealed class TestInstanceStorage : IInstanceStorage
+    private sealed class TestInstanceStorage(TestStorage storage) : IInstanceStorage
     {
         public Task<ProcessInstanceInfo> GetProcessInstance(Guid processInstanceId)
         {
-            throw new FileNotFoundException($"Process instance {processInstanceId} was not found.");
+            var instance = storage.Instances.SingleOrDefault(existing => existing.InstanceId == processInstanceId)
+                           ?? throw new FileNotFoundException($"Process instance {processInstanceId} was not found.");
+            return Task.FromResult(instance);
         }
 
         public Task AddOrUpdateInstance(ProcessInstanceInfo processInstanceInfo)
         {
+            storage.Instances.RemoveAll(existing => existing.InstanceId == processInstanceInfo.InstanceId);
+            storage.Instances.Add(processInstanceInfo);
             return Task.CompletedTask;
         }
 
         public Task<IEnumerable<ProcessInstanceInfo>> GetAllActiveInstances()
         {
-            return Task.FromResult(Enumerable.Empty<ProcessInstanceInfo>());
+            return Task.FromResult(storage.Instances.Where(instance => !instance.IsFinished));
         }
 
         public Task<IEnumerable<ProcessInstanceInfo>> GetAllInstances()
         {
-            return Task.FromResult(Enumerable.Empty<ProcessInstanceInfo>());
+            return Task.FromResult(storage.Instances.AsEnumerable());
         }
     }
 
@@ -749,7 +929,7 @@ public class ApiHardeningIntegrationTest
 
         public Task<IEnumerable<FormMetadata>> GetFormMetadatas()
         {
-            return Task.FromResult(Enumerable.Empty<FormMetadata>());
+            return Task.FromResult(storage.FormMetadatas.AsEnumerable());
         }
 
         public Task UpdateFormMetaData(FormMetadata formMetaData) => Task.CompletedTask;

--- a/src/WebApiEngine/Background/TimerSchedulerBackgroundService.cs
+++ b/src/WebApiEngine/Background/TimerSchedulerBackgroundService.cs
@@ -1,23 +1,33 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Options;
 using WebApiEngine.BusinessLogic;
+using WebApiEngine.Diagnostics;
 
 namespace WebApiEngine.Background;
 
 public class TimerSchedulerBackgroundService(
     BpmnBusinessLogic bpmnBusinessLogic,
     IOptions<TimerSchedulerOptions> options,
+    TimerSchedulerDiagnosticsState diagnosticsState,
     ILogger<TimerSchedulerBackgroundService> logger) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         var schedulerOptions = options.Value;
+        var pollIntervalSeconds = Math.Max(1, schedulerOptions.PollIntervalSeconds);
+        diagnosticsState.MarkConfigured(schedulerOptions.Enabled, pollIntervalSeconds);
         if (!schedulerOptions.Enabled)
         {
             logger.LogInformation("Timer scheduler is disabled.");
             return;
         }
 
-        var pollInterval = TimeSpan.FromSeconds(Math.Max(1, schedulerOptions.PollIntervalSeconds));
+        diagnosticsState.MarkStarted(DateTime.UtcNow);
+        logger.LogInformation(
+            "Timer scheduler is enabled with a poll interval of {PollIntervalSeconds} second(s).",
+            pollIntervalSeconds);
+
+        var pollInterval = TimeSpan.FromSeconds(pollIntervalSeconds);
 
         await RunTimerTick(stoppingToken);
 
@@ -30,9 +40,19 @@ public class TimerSchedulerBackgroundService(
 
     private async Task RunTimerTick(CancellationToken stoppingToken)
     {
+        using var activity = FlowzerDiagnostics.ActivitySource.StartActivity("timer.scheduler.tick", ActivityKind.Internal);
+        var startedAtUtc = DateTime.UtcNow;
+        diagnosticsState.MarkTickStarted(startedAtUtc);
+        var stopwatch = Stopwatch.StartNew();
+
         try
         {
             var processedTimers = await bpmnBusinessLogic.HandleTime(DateTime.UtcNow);
+            stopwatch.Stop();
+            diagnosticsState.MarkTickSucceeded(DateTime.UtcNow, stopwatch.Elapsed, processedTimers);
+            FlowzerDiagnostics.RecordTimerSchedulerSuccess(processedTimers, stopwatch.Elapsed);
+            activity?.SetTag("flowzer.processed_timers", processedTimers);
+            activity?.SetTag("flowzer.tick.duration_ms", stopwatch.Elapsed.TotalMilliseconds);
             if (processedTimers > 0)
             {
                 logger.LogInformation("Processed {ProcessedTimers} due timer subscriptions.", processedTimers);
@@ -44,6 +64,10 @@ public class TimerSchedulerBackgroundService(
         }
         catch (Exception exception)
         {
+            stopwatch.Stop();
+            diagnosticsState.MarkTickFailed(DateTime.UtcNow, stopwatch.Elapsed, exception);
+            FlowzerDiagnostics.RecordTimerSchedulerFailure(stopwatch.Elapsed);
+            activity?.SetTag("flowzer.tick.duration_ms", stopwatch.Elapsed.TotalMilliseconds);
             logger.LogError(exception, "Timer scheduler tick failed.");
         }
     }

--- a/src/WebApiEngine/Controller/OperationsController.cs
+++ b/src/WebApiEngine/Controller/OperationsController.cs
@@ -23,7 +23,9 @@ public class OperationsController(
             var metaDefinitions = (await storageSystem.DefinitionStorage.GetAllMetaDefinitions()).ToArray();
             var forms = (await storageSystem.FormStorage.GetFormMetadatas()).ToArray();
             var instances = (await storageSystem.InstanceStorage.GetAllInstances()).ToArray();
-            var activeInstances = (await storageSystem.InstanceStorage.GetAllActiveInstances()).ToArray();
+            var activeInstances = instances
+                .Where(instance => instance.State is not (ProcessInstanceState.Completed or ProcessInstanceState.Compensated or ProcessInstanceState.Failed or ProcessInstanceState.Terminated))
+                .ToArray();
             var messages = (await storageSystem.SubscriptionStorage.GetAllMessageSubscriptions()).ToArray();
             var timers = (await storageSystem.SubscriptionStorage.GetAllTimerSubscriptions()).ToArray();
 
@@ -33,7 +35,7 @@ public class OperationsController(
                 Environment = environment.EnvironmentName,
                 Storage = new OperationsStorageSnapshotDto
                 {
-                    StorageRootHint = ResolveStorageRootHint(),
+                    StorageRootHint = ResolveStorageRootHint(environment),
                     TotalDefinitions = definitions.Length,
                     ActiveDefinitions = definitions.Count(definition => definition.IsActive),
                     DefinitionMetadataEntries = metaDefinitions.Length,
@@ -77,11 +79,23 @@ public class OperationsController(
         }
     }
 
-    private static string ResolveStorageRootHint()
+    private static string ResolveStorageRootHint(IHostEnvironment environment)
     {
         var configuredStorageRoot = Environment.GetEnvironmentVariable(FilesystemStorageSystem.Storage.StorageRootEnvironmentVariableName);
-        return string.IsNullOrWhiteSpace(configuredStorageRoot)
-            ? "(default under FilesystemStorageSystem build output)"
-            : Path.GetFullPath(configuredStorageRoot);
+        if (string.IsNullOrWhiteSpace(configuredStorageRoot))
+        {
+            return "(default under FilesystemStorageSystem build output)";
+        }
+
+        var normalizedStorageRoot = Path.GetFullPath(configuredStorageRoot);
+        if (environment.IsDevelopment())
+        {
+            return normalizedStorageRoot;
+        }
+
+        var leafName = Path.GetFileName(normalizedStorageRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        return string.IsNullOrWhiteSpace(leafName)
+            ? "(custom FLOWZER_STORAGE_ROOT configured)"
+            : $"(custom FLOWZER_STORAGE_ROOT configured: {leafName})";
     }
 }

--- a/src/WebApiEngine/Controller/OperationsController.cs
+++ b/src/WebApiEngine/Controller/OperationsController.cs
@@ -1,0 +1,87 @@
+using System.Diagnostics;
+using Model;
+using WebApiEngine.Diagnostics;
+using WebApiEngine.Shared;
+
+namespace WebApiEngine.Controller;
+
+[ApiController, Route("operations")]
+public class OperationsController(
+    IStorageSystem storageSystem,
+    IHostEnvironment environment,
+    TimerSchedulerDiagnosticsState timerSchedulerDiagnosticsState,
+    ILogger<OperationsController> logger) : ControllerBase
+{
+    [HttpGet("diagnostics")]
+    public async Task<ActionResult<ApiStatusResult<OperationsDiagnosticsDto>>> GetDiagnostics()
+    {
+        using var activity = FlowzerDiagnostics.ActivitySource.StartActivity("operations.diagnostics", ActivityKind.Internal);
+
+        try
+        {
+            var definitions = (await storageSystem.DefinitionStorage.GetAllDefinitions()).ToArray();
+            var metaDefinitions = (await storageSystem.DefinitionStorage.GetAllMetaDefinitions()).ToArray();
+            var forms = (await storageSystem.FormStorage.GetFormMetadatas()).ToArray();
+            var instances = (await storageSystem.InstanceStorage.GetAllInstances()).ToArray();
+            var activeInstances = (await storageSystem.InstanceStorage.GetAllActiveInstances()).ToArray();
+            var messages = (await storageSystem.SubscriptionStorage.GetAllMessageSubscriptions()).ToArray();
+            var timers = (await storageSystem.SubscriptionStorage.GetAllTimerSubscriptions()).ToArray();
+
+            var payload = new OperationsDiagnosticsDto
+            {
+                CheckedAtUtc = DateTime.UtcNow,
+                Environment = environment.EnvironmentName,
+                Storage = new OperationsStorageSnapshotDto
+                {
+                    StorageRootHint = ResolveStorageRootHint(),
+                    TotalDefinitions = definitions.Length,
+                    ActiveDefinitions = definitions.Count(definition => definition.IsActive),
+                    DefinitionMetadataEntries = metaDefinitions.Length,
+                    FormMetadataEntries = forms.Length,
+                    TotalInstances = instances.Length,
+                    ActiveInstances = activeInstances.Length,
+                    CompletedInstances = instances.Count(instance =>
+                        instance.State is ProcessInstanceState.Completed or ProcessInstanceState.Compensated),
+                    FailedInstances = instances.Count(instance =>
+                        instance.State is ProcessInstanceState.Failed or ProcessInstanceState.Terminated),
+                    PendingMessages = messages.Length,
+                    PendingTimers = timers.Length,
+                    OpenUserTasks = activeInstances.Sum(instance => instance.UserTaskSubscriptionCount),
+                    PendingSignals = activeInstances.Sum(instance => instance.SignalSubscriptionCount),
+                    PendingServices = activeInstances.Sum(instance => instance.ServiceSubscriptionCount)
+                },
+                TimerScheduler = timerSchedulerDiagnosticsState.GetSnapshot(),
+                Instrumentation = new OperationsInstrumentationDto
+                {
+                    MeterName = FlowzerDiagnostics.MeterName,
+                    ActivitySourceName = FlowzerDiagnostics.ActivitySourceName,
+                    Notes =
+                        "Dieses Paket liefert bewusst nur die lokale Metrics-/Tracing-Grundlage. Exporter und externe Observability-Backends bleiben Folgearbeit."
+                }
+            };
+
+            activity?.SetTag("flowzer.instances.total", payload.Storage.TotalInstances);
+            activity?.SetTag("flowzer.subscriptions.timers", payload.Storage.PendingTimers);
+
+            return Ok(new ApiStatusResult<OperationsDiagnosticsDto>(payload));
+        }
+        catch (Exception exception)
+        {
+            logger.LogWarning(exception, "Could not build operations diagnostics snapshot.");
+
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new ApiStatusResult<OperationsDiagnosticsDto>
+            {
+                Successful = false,
+                ErrorMessage = "Operations diagnostics are currently unavailable."
+            });
+        }
+    }
+
+    private static string ResolveStorageRootHint()
+    {
+        var configuredStorageRoot = Environment.GetEnvironmentVariable(FilesystemStorageSystem.Storage.StorageRootEnvironmentVariableName);
+        return string.IsNullOrWhiteSpace(configuredStorageRoot)
+            ? "(default under FilesystemStorageSystem build output)"
+            : Path.GetFullPath(configuredStorageRoot);
+    }
+}

--- a/src/WebApiEngine/Diagnostics/FlowzerDiagnostics.cs
+++ b/src/WebApiEngine/Diagnostics/FlowzerDiagnostics.cs
@@ -34,12 +34,12 @@ public static class FlowzerDiagnostics
     private static readonly Histogram<int> TimerSchedulerProcessedTimers =
         Meter.CreateHistogram<int>("flowzer.timer.scheduler.processed_timers");
 
-    public static void RecordHttpRequest(string method, string path, int statusCode, TimeSpan duration)
+    public static void RecordHttpRequest(string method, string routeName, int statusCode, TimeSpan duration)
     {
         var tags = new TagList
         {
             { "http.method", method },
-            { "url.path", path },
+            { "http.route", routeName },
             { "http.status_code", statusCode }
         };
 

--- a/src/WebApiEngine/Diagnostics/FlowzerDiagnostics.cs
+++ b/src/WebApiEngine/Diagnostics/FlowzerDiagnostics.cs
@@ -1,0 +1,63 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace WebApiEngine.Diagnostics;
+
+/// <summary>
+/// Kapselt die kleinen, lokal nutzbaren Metrics-/Tracing-Namen für die Web-API.
+/// Die eigentliche Export-Story bleibt bewusst ein Folgepaket; dieses Paket liefert
+/// zuerst stabile Signalnamen und einfache Messpunkte.
+/// </summary>
+public static class FlowzerDiagnostics
+{
+    public const string MeterName = "Flowzer.WebApi";
+    public const string ActivitySourceName = "Flowzer.WebApi";
+
+    public static readonly Meter Meter = new(MeterName);
+    public static readonly ActivitySource ActivitySource = new(ActivitySourceName);
+
+    private static readonly Counter<long> HttpRequestCounter =
+        Meter.CreateCounter<long>("flowzer.http.requests");
+
+    private static readonly Histogram<double> HttpRequestDurationMilliseconds =
+        Meter.CreateHistogram<double>("flowzer.http.request.duration", "ms");
+
+    private static readonly Counter<long> TimerSchedulerTickCounter =
+        Meter.CreateCounter<long>("flowzer.timer.scheduler.ticks");
+
+    private static readonly Counter<long> TimerSchedulerFailureCounter =
+        Meter.CreateCounter<long>("flowzer.timer.scheduler.failures");
+
+    private static readonly Histogram<double> TimerSchedulerTickDurationMilliseconds =
+        Meter.CreateHistogram<double>("flowzer.timer.scheduler.tick.duration", "ms");
+
+    private static readonly Histogram<int> TimerSchedulerProcessedTimers =
+        Meter.CreateHistogram<int>("flowzer.timer.scheduler.processed_timers");
+
+    public static void RecordHttpRequest(string method, string path, int statusCode, TimeSpan duration)
+    {
+        var tags = new TagList
+        {
+            { "http.method", method },
+            { "url.path", path },
+            { "http.status_code", statusCode }
+        };
+
+        HttpRequestCounter.Add(1, tags);
+        HttpRequestDurationMilliseconds.Record(duration.TotalMilliseconds, tags);
+    }
+
+    public static void RecordTimerSchedulerSuccess(int processedTimers, TimeSpan duration)
+    {
+        TimerSchedulerTickCounter.Add(1);
+        TimerSchedulerTickDurationMilliseconds.Record(duration.TotalMilliseconds);
+        TimerSchedulerProcessedTimers.Record(processedTimers);
+    }
+
+    public static void RecordTimerSchedulerFailure(TimeSpan duration)
+    {
+        TimerSchedulerTickCounter.Add(1);
+        TimerSchedulerFailureCounter.Add(1);
+        TimerSchedulerTickDurationMilliseconds.Record(duration.TotalMilliseconds);
+    }
+}

--- a/src/WebApiEngine/Diagnostics/TimerSchedulerDiagnosticsState.cs
+++ b/src/WebApiEngine/Diagnostics/TimerSchedulerDiagnosticsState.cs
@@ -1,0 +1,119 @@
+using WebApiEngine.Shared;
+
+namespace WebApiEngine.Diagnostics;
+
+/// <summary>
+/// Hält den letzten bekannten Zustand des Timer-Schedulers für die Diagnose-API.
+/// </summary>
+public sealed class TimerSchedulerDiagnosticsState
+{
+    private readonly object _sync = new();
+    private TimerSchedulerSnapshot _snapshot = new()
+    {
+        Status = "NotStarted"
+    };
+
+    public void MarkConfigured(bool enabled, int pollIntervalSeconds)
+    {
+        lock (_sync)
+        {
+            _snapshot.Enabled = enabled;
+            _snapshot.PollIntervalSeconds = pollIntervalSeconds;
+            if (!enabled)
+            {
+                _snapshot.Status = "Disabled";
+            }
+        }
+    }
+
+    public void MarkStarted(DateTime startedAtUtc)
+    {
+        lock (_sync)
+        {
+            _snapshot.ServiceStartedAtUtc = startedAtUtc;
+            _snapshot.Status = _snapshot.Enabled ? "Starting" : "Disabled";
+        }
+    }
+
+    public void MarkTickStarted(DateTime startedAtUtc)
+    {
+        lock (_sync)
+        {
+            _snapshot.LastTickStartedAtUtc = startedAtUtc;
+            if (_snapshot.Enabled)
+            {
+                _snapshot.Status = "Running";
+            }
+        }
+    }
+
+    public void MarkTickSucceeded(DateTime completedAtUtc, TimeSpan duration, int processedTimers)
+    {
+        lock (_sync)
+        {
+            _snapshot.LastTickCompletedAtUtc = completedAtUtc;
+            _snapshot.LastSuccessfulTickAtUtc = completedAtUtc;
+            _snapshot.LastTickDurationMs = duration.TotalMilliseconds;
+            _snapshot.LastProcessedTimers = processedTimers;
+            _snapshot.SuccessfulTickCount++;
+            _snapshot.TotalProcessedTimers += processedTimers;
+            _snapshot.LastErrorMessage = null;
+            _snapshot.Status = "Healthy";
+        }
+    }
+
+    public void MarkTickFailed(DateTime completedAtUtc, TimeSpan duration, Exception exception)
+    {
+        lock (_sync)
+        {
+            _snapshot.LastTickCompletedAtUtc = completedAtUtc;
+            _snapshot.LastFailedTickAtUtc = completedAtUtc;
+            _snapshot.LastTickDurationMs = duration.TotalMilliseconds;
+            _snapshot.FailedTickCount++;
+            _snapshot.LastErrorMessage = exception.Message;
+            _snapshot.Status = "Faulted";
+        }
+    }
+
+    public TimerSchedulerDiagnosticsDto GetSnapshot()
+    {
+        lock (_sync)
+        {
+            return new TimerSchedulerDiagnosticsDto
+            {
+                Enabled = _snapshot.Enabled,
+                PollIntervalSeconds = _snapshot.PollIntervalSeconds,
+                Status = _snapshot.Status,
+                ServiceStartedAtUtc = _snapshot.ServiceStartedAtUtc,
+                LastTickStartedAtUtc = _snapshot.LastTickStartedAtUtc,
+                LastTickCompletedAtUtc = _snapshot.LastTickCompletedAtUtc,
+                LastSuccessfulTickAtUtc = _snapshot.LastSuccessfulTickAtUtc,
+                LastFailedTickAtUtc = _snapshot.LastFailedTickAtUtc,
+                LastTickDurationMs = _snapshot.LastTickDurationMs,
+                LastProcessedTimers = _snapshot.LastProcessedTimers,
+                SuccessfulTickCount = _snapshot.SuccessfulTickCount,
+                FailedTickCount = _snapshot.FailedTickCount,
+                TotalProcessedTimers = _snapshot.TotalProcessedTimers,
+                LastErrorMessage = _snapshot.LastErrorMessage
+            };
+        }
+    }
+
+    private sealed class TimerSchedulerSnapshot
+    {
+        public bool Enabled { get; set; }
+        public int PollIntervalSeconds { get; set; } = 5;
+        public required string Status { get; set; }
+        public DateTime? ServiceStartedAtUtc { get; set; }
+        public DateTime? LastTickStartedAtUtc { get; set; }
+        public DateTime? LastTickCompletedAtUtc { get; set; }
+        public DateTime? LastSuccessfulTickAtUtc { get; set; }
+        public DateTime? LastFailedTickAtUtc { get; set; }
+        public double? LastTickDurationMs { get; set; }
+        public int LastProcessedTimers { get; set; }
+        public long SuccessfulTickCount { get; set; }
+        public long FailedTickCount { get; set; }
+        public long TotalProcessedTimers { get; set; }
+        public string? LastErrorMessage { get; set; }
+    }
+}

--- a/src/WebApiEngine/Middleware/FlowzerRequestDiagnosticsMiddleware.cs
+++ b/src/WebApiEngine/Middleware/FlowzerRequestDiagnosticsMiddleware.cs
@@ -1,0 +1,85 @@
+using System.Diagnostics;
+using WebApiEngine.Diagnostics;
+
+namespace WebApiEngine.Middleware;
+
+/// <summary>
+/// Ergänzt kleine, fokussierte Diagnoseinformationen für zentrale API-Pfade,
+/// ohne eine komplette Observability-Plattform vorauszusetzen.
+/// </summary>
+public sealed class FlowzerRequestDiagnosticsMiddleware(
+    RequestDelegate next,
+    ILogger<FlowzerRequestDiagnosticsMiddleware> logger)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var path = context.Request.Path.HasValue ? context.Request.Path.Value! : "/";
+        var method = context.Request.Method;
+        var routeName = context.GetEndpoint()?.DisplayName ?? path;
+
+        using var activity = FlowzerDiagnostics.ActivitySource.StartActivity("flowzer.request", ActivityKind.Server);
+        activity?.SetTag("http.method", method);
+        activity?.SetTag("url.path", path);
+        activity?.SetTag("flowzer.route_name", routeName);
+
+        var stopwatch = Stopwatch.StartNew();
+
+        await next(context);
+
+        stopwatch.Stop();
+
+        var statusCode = context.Response.StatusCode;
+        FlowzerDiagnostics.RecordHttpRequest(method, path, statusCode, stopwatch.Elapsed);
+
+        activity?.SetTag("http.status_code", statusCode);
+        activity?.SetTag("flowzer.duration_ms", stopwatch.Elapsed.TotalMilliseconds);
+
+        if (!ShouldLog(path, method, statusCode, stopwatch.Elapsed))
+        {
+            return;
+        }
+
+        var logLevel = statusCode >= StatusCodes.Status500InternalServerError
+            ? LogLevel.Error
+            : statusCode >= StatusCodes.Status400BadRequest || stopwatch.Elapsed >= TimeSpan.FromSeconds(1)
+                ? LogLevel.Warning
+                : LogLevel.Information;
+
+        logger.Log(
+            logLevel,
+            "Handled {Method} {Path} with status {StatusCode} in {DurationMs:0.0} ms (TraceId: {TraceId}).",
+            method,
+            path,
+            statusCode,
+            stopwatch.Elapsed.TotalMilliseconds,
+            context.TraceIdentifier);
+    }
+
+    private static bool ShouldLog(string path, string method, int statusCode, TimeSpan duration)
+    {
+        if (path.StartsWith("/health", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (statusCode >= StatusCodes.Status400BadRequest)
+        {
+            return true;
+        }
+
+        if (!HttpMethods.IsGet(method))
+        {
+            return true;
+        }
+
+        return duration >= TimeSpan.FromSeconds(1);
+    }
+}
+
+public static class FlowzerRequestDiagnosticsExtensions
+{
+    public static IApplicationBuilder UseFlowzerRequestDiagnostics(this IApplicationBuilder app)
+    {
+        return app.UseMiddleware<FlowzerRequestDiagnosticsMiddleware>();
+    }
+}

--- a/src/WebApiEngine/Middleware/FlowzerRequestDiagnosticsMiddleware.cs
+++ b/src/WebApiEngine/Middleware/FlowzerRequestDiagnosticsMiddleware.cs
@@ -29,7 +29,7 @@ public sealed class FlowzerRequestDiagnosticsMiddleware(
         stopwatch.Stop();
 
         var statusCode = context.Response.StatusCode;
-        FlowzerDiagnostics.RecordHttpRequest(method, path, statusCode, stopwatch.Elapsed);
+        FlowzerDiagnostics.RecordHttpRequest(method, routeName, statusCode, stopwatch.Elapsed);
 
         activity?.SetTag("http.status_code", statusCode);
         activity?.SetTag("flowzer.duration_ms", stopwatch.Elapsed.TotalMilliseconds);
@@ -45,14 +45,19 @@ public sealed class FlowzerRequestDiagnosticsMiddleware(
                 ? LogLevel.Warning
                 : LogLevel.Information;
 
+        var activityTraceId = activity?.TraceId.ToString();
+        var activitySpanId = activity?.SpanId.ToString();
+
         logger.Log(
             logLevel,
-            "Handled {Method} {Path} with status {StatusCode} in {DurationMs:0.0} ms (TraceId: {TraceId}).",
+            "Handled {Method} {Path} with status {StatusCode} in {DurationMs:0.0} ms (RequestId: {RequestId}, ActivityTraceId: {ActivityTraceId}, ActivitySpanId: {ActivitySpanId}).",
             method,
             path,
             statusCode,
             stopwatch.Elapsed.TotalMilliseconds,
-            context.TraceIdentifier);
+            context.TraceIdentifier,
+            activityTraceId,
+            activitySpanId);
     }
 
     private static bool ShouldLog(string path, string method, int statusCode, TimeSpan duration)

--- a/src/WebApiEngine/Program.cs
+++ b/src/WebApiEngine/Program.cs
@@ -2,6 +2,7 @@ using WebApiEngine;
 using WebApiEngine.Auth;
 using WebApiEngine.Background;
 using WebApiEngine.BusinessLogic;
+using WebApiEngine.Diagnostics;
 using WebApiEngine.Middleware;
 using Microsoft.Extensions.Options;
 
@@ -23,6 +24,7 @@ builder.Services.AddHttpContextAccessor();
 builder.Services.AddSingleton<ITransactionalStorageProvider, FilesystemStorageSystem.FileSystemTransactionalStorageProvider>();
 builder.Services.AddSingleton<IStorageSystem, FilesystemStorageSystem.Storage>();
 builder.Services.AddSingleton<ICurrentUserContextAccessor, HttpContextCurrentUserContextAccessor>();
+builder.Services.AddSingleton<TimerSchedulerDiagnosticsState>();
 builder.Services.AddSingleton<FormBusinessLogic>();
 builder.Services.AddSingleton<DefinitionBusinessLogic>();
 builder.Services.AddSingleton<BpmnBusinessLogic>();
@@ -41,6 +43,7 @@ builder.Services.AddCors(options =>
 
 var app = builder.Build();
 
+app.UseFlowzerRequestDiagnostics();
 app.UseFlowzerApiExceptionHandling();
 
 // Configure the HTTP request pipeline.


### PR DESCRIPTION
## Zusammenfassung

Dieses PR erweitert die lokale Operations-Basis auf `next` gezielt um **sichtbarere Diagnoseinformationen**, ohne schon eine vollständige Observability-Plattform einzuführen.

## Umgesetzt

- neuer API-Endpunkt `GET /operations/diagnostics`
- Storage-Snapshot mit Definitionen, Formularen, Instanzen und offenen Subscriptions
- Timer-Scheduler-Zustand mit letztem Tick, Fehlerstatus und verarbeiteten Timern
- kleine Metrics-/Tracing-Grundlage über `Meter` und `ActivitySource` (`Flowzer.WebApi`)
- fokussierte Request-Diagnose für langsame, fehlerhafte und mutierende API-Aufrufe
- lokale und runtime-nahe Check-Skripte prüfen jetzt zusätzlich den Diagnose-Endpunkt
- `docs/OPERATIONS.md` dokumentiert Backup-/Restore-/Recovery-Hinweise für die dateibasierte Persistenz
- Status- und Roadmap-Doku an den neuen Stand angepasst
- zusätzliche Integrationstests für den Diagnose-Endpunkt

## Validierung

- `dotnet build core-engine.sln --configuration Release`
- `dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-build`
- `dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-build`
- `dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-build`
- `bash -n scripts/local/check-stack.sh scripts/runtime/check-runtime-stack.sh scripts/local/start-stack.sh scripts/local/stop-stack.sh scripts/runtime/start-runtime-stack.sh scripts/runtime/stop-runtime-stack.sh`
- `npm --prefix tests/ui-smoke ci`
- `npm --prefix tests/ui-smoke test`

## Scope-Hinweis

Bewusst **nicht** Teil dieses PRs:

- externe OpenTelemetry-/OTLP-Exporter
- Dashboards oder externe Observability-Backends
- vollständige Secret-/TLS-/Cloud-Story

Schließt #89
