### PR TITLE
Optionale OpenTelemetry-Exporter für die Web-API ergänzen

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Die bisherige Dokumentation klang teilweise deutlich reifer als der aktuelle Sta
 - Geschützte API-Pfade verlangen inzwischen einen **aufgelösten Benutzerkontext**, statt stillschweigend über einen System-Fallback weiterzulaufen.
 - Für lokale Entwicklung und UI-Smokes setzt das Frontend im **Development-Modus** jetzt automatisch einen technischen Benutzerheader, damit die gehärteten API-Pfade lokal weiter reproduzierbar testbar bleiben.
 - Zusätzlich gibt es jetzt einen kleinen **Operations-/Diagnose-Endpunkt** sowie lokale Metrics-/Tracing-Namen, damit Scheduler- und Storage-Zustand nicht nur über reine Healthchecks sichtbar werden.
+- Die Web-API kann diese Signale jetzt optional auch über **OpenTelemetry** an Console- oder OTLP-Exporter weitergeben, ohne den Default-Pfad in Dev/CI zu verschärfen.
 - Es gibt aber weiterhin **offene Restlücken** bei weitergehender Timer-/Boundary-Recovery, Auth/Identity und Betriebsreife.
 - Das Projekt ist **klar revivierbar und aktiv weiterentwickelbar**, wenn die nächsten Schritte weiter fokussiert bleiben.
 
@@ -98,7 +99,7 @@ Diese Punkte sollte man kennen, bevor man loslegt:
    Der Engine-Kern kann fällige Timer jetzt weiterführen, Boundary-Timer im bestehenden Subscription-Pfad verarbeiten, wiederkehrende Start-Timer überfälligkeitstolerant nachziehen und rohe `NotImplementedException`-Abbrüche in mehreren Pfaden vermeiden. Offen bleiben weiterhin speziellere Recovery-Fragen, vollständige Fehler-/Eskalationssemantik und echte Kompensation.
 
 4. **Betrieb und Auth sind noch nicht am Ziel**
-   Lokale Compose- und Runtime-Container sind vorhanden, geschützte API-Pfade verlangen jetzt zwar einen aufgelösten Benutzerkontext und die Web-API liefert erste Operations-Diagnose-Informationen, aber Themen wie echte Authentifizierung, Rollenmodell, externe Telemetrie-Backends, Secrets, TLS und Recovery-Automatisierung sind weiterhin Folgepakete.
+   Lokale Compose- und Runtime-Container sind vorhanden, geschützte API-Pfade verlangen jetzt zwar einen aufgelösten Benutzerkontext und die Web-API liefert erste Operations-Diagnose-Informationen inklusive optionaler OpenTelemetry-Exporter-Konfiguration, aber Themen wie echte Authentifizierung, Rollenmodell, Secrets, TLS und Recovery-Automatisierung bleiben weiterhin Folgepakete.
 
 ## Dokumentation
 
@@ -171,6 +172,24 @@ Für einen reproduzierbaren API-/Frontend-Start gibt es jetzt zusätzlich einen 
 ```
 
 Weitere Betriebs- und Diagnosehinweise stehen in [docs/OPERATIONS.md](docs/OPERATIONS.md).
+
+### Optionale OpenTelemetry-Exporter
+
+Für produktionsnahe Umgebungen kann die Web-API die vorhandenen Signals jetzt optional an Console- oder OTLP-Exporter weiterreichen.
+
+Beispiel:
+
+```bash
+ASPNETCORE_ENVIRONMENT=Development \
+FLOWZER_STORAGE_ROOT="$(pwd)/.data/flowzer-storage" \
+Observability__Enabled=true \
+Observability__UseConsoleExporter=true \
+Observability__OtlpEndpoint=http://localhost:4318 \
+Observability__OtlpProtocol=http/protobuf \
+dotnet run --project src/WebApiEngine/WebApiEngine.csproj --configuration Release
+```
+
+Welche Exporter aktiv sind, zeigt zusätzlich `GET /operations/diagnostics`.
 
 ## Timer-Scheduler im Web-API-Host
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Weitere Betriebs- und Diagnosehinweise stehen in [docs/OPERATIONS.md](docs/OPERA
 
 ### Optionale OpenTelemetry-Exporter
 
-Für produktionsnahe Umgebungen kann die Web-API die vorhandenen Signals jetzt optional an Console- oder OTLP-Exporter weiterreichen.
+Für produktionsnahe Umgebungen kann die Web-API die vorhandenen Signale jetzt optional an Console- oder OTLP-Exporter weiterreichen.
 
 Beispiel:
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -16,6 +16,7 @@ Dieses Dokument beschreibt den derzeit realistischen Betriebsrahmen für `next`:
 - kleine Shell-Skripte zum Starten, Stoppen und Prüfen des lokalen Stacks
 - definierter Storage-Pfad für dateibasierte Persistenz
 - kleine Metrics-/Tracing-Grundlage über `Meter` und `ActivitySource`
+- optionale OpenTelemetry-Exporter für Console und OTLP
 
 ## Health-Signale
 
@@ -23,7 +24,7 @@ Die Web-API stellt aktuell folgende Endpunkte bereit:
 
 - `GET /health` – Liveness
 - `GET /health/ready` – Readiness inkl. Storage-Prüfung
-- `GET /operations/diagnostics` – Scheduler-Status, Storage-Snapshot und lokale Instrumentierungsnamen
+- `GET /operations/diagnostics` – Scheduler-Status, Storage-Snapshot, Instrumentierungsnamen und aktive Observability-Konfiguration
 
 Typische URLs lokal:
 
@@ -36,7 +37,9 @@ Der Diagnose-Endpunkt ist bewusst **pragmatisch statt vollständig**. Er liefert
 - aktuellen Environment- und Zeitstempel
 - Storage-Snapshot mit Definitionen, Formularen, Instanzen und offenen Subscriptions
 - Timer-Scheduler-Status inkl. letztem Tick, Fehlerstatus und verarbeiteter Timerzahl
-- Namen des lokalen `Meter`- und `ActivitySource`-Setups für spätere Exporter-Anbindung
+- Namen des lokalen `Meter`- und `ActivitySource`-Setups
+- Snapshot, ob Console- und/oder OTLP-Exporter aktiviert sind
+- redigierte OTLP-Endpunkt- und Header-Hinweise für Betriebsprüfungen
 
 ## Lokaler Start ohne Docker
 
@@ -152,14 +155,54 @@ Die Web-API protokolliert zentrale Request- und Scheduler-Signale jetzt struktur
 - der Timer-Scheduler meldet Start, Tick-Erfolg, Tick-Fehler und zuletzt verarbeitete Timer
 - Health-Aufrufe bleiben bewusst aus dieser zusätzlichen Request-Protokollierung ausgenommen, damit die Logs nicht mit Probe-Traffic überlaufen
 
-### Meter- und Activity-Namen
+### Meter-, Activity- und Exporter-Namen
 
-Für spätere Exporter- oder OpenTelemetry-Anbindung sind jetzt stabile lokale Namen vorhanden:
+Für die optionale OpenTelemetry-Anbindung sind jetzt stabile lokale Namen vorhanden:
 
 - `Meter`: `Flowzer.WebApi`
 - `ActivitySource`: `Flowzer.WebApi`
 
-Dieses Paket führt **noch keinen externen Exporter** ein, damit der lokale Betriebsweg klein und reproduzierbar bleibt.
+### OpenTelemetry per Konfiguration aktivieren
+
+Die Exporter bleiben standardmäßig bewusst **deaktiviert**, damit lokale Dev- und CI-Pfade unverändert klein bleiben.
+
+Relevante Konfiguration in `src/WebApiEngine/appsettings.json`:
+
+```json
+"Observability": {
+  "Enabled": false,
+  "UseConsoleExporter": false,
+  "OtlpEndpoint": "",
+  "OtlpHeaders": "",
+  "OtlpProtocol": "grpc",
+  "ServiceName": "Flowzer.WebApi"
+}
+```
+
+Typische Overrides per Environment-Variablen:
+
+```bash
+Observability__Enabled=true
+Observability__UseConsoleExporter=true
+Observability__OtlpEndpoint=http://localhost:4318
+Observability__OtlpProtocol=http/protobuf
+```
+
+Optional können zusätzlich Header für OTLP-Backends gesetzt werden:
+
+```bash
+Observability__OtlpHeaders='authorization=Bearer <token>'
+```
+
+`/operations/diagnostics` zeigt dann:
+
+- ob Observability insgesamt aktiv ist
+- ob Console-Exporter aktiv sind
+- ob ein OTLP-Exporter aktiv ist
+- welchen redigierten OTLP-Endpunkt die API nutzt
+- welches Service-Name/-Version-Paar exportiert wird
+
+Die OTLP-Konfiguration redigiert dabei Benutzerinformationen, Query-Parameter und Headerinhalte bewusst, damit der Diagnose-Endpunkt keine Secrets zurückspiegelt.
 
 ### Container-Logs
 
@@ -248,13 +291,13 @@ tar -xzf flowzer-storage-backup.tgz -C .data
 Folgende Betriebsaspekte sind mit diesem Paket **noch nicht abgeschlossen**:
 
 - strukturierte Produktions-Logformate über die Standard-Konsole hinaus
-- externe Metrics-/Tracing-Exporter oder Dashboards
+- vollständige Dashboard-/Collector-Landschaft rund um die jetzt vorhandenen OTLP-Hooks
 - produktionsnahe Reverse-Proxy- oder TLS-Story
 - Secret-/Configuration-Story jenseits lokaler Entwicklungswerte
 
 ## Sinnvolle nächste Ausbauschritte
 
 1. Reverse-Proxy-/Gateway-Konfiguration für echte Zielumgebungen weiter härten
-2. externe Metrics-/Tracing-Exporter und Dashboards anbinden
+2. Collector-, Dashboard- und Alerting-Pfade auf Basis der jetzt vorhandenen Exporter ergänzen
 3. Secret-/Konfigurationsstory für Nicht-Entwicklungsumgebungen schärfen
 4. Reverse-Proxy-/TLS-Härtung und Backup-Automatisierung vertiefen

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -61,6 +61,7 @@ Unter anderem bereits umgesetzt:
 - lokale Runtime-Containerbasis für API, Frontend und Gateway
 - Operations-/Diagnose-Endpunkt mit Scheduler-Status, Storage-Snapshot und lokalen Metrics-/Tracing-Namen
 - Request- und Timer-Scheduler-Diagnosepfad mit Dauer-, Status- und Tick-Signalen
+- optionale OpenTelemetry-Exporter für Console und OTLP inklusive Konfigurations- und Diagnosepfad
 - dokumentierte Recovery-/Backup-Hinweise für die dateibasierte Persistenz
 
 ## Was weiterhin bremst
@@ -72,7 +73,7 @@ Besonders relevant sind noch:
 - weiter ausgebautes Playwright-/E2E-Smoke-Set
 - Restlücken bei spezieller Boundary-/Spezialtimer-Recovery und weitergehender Scheduler-Semantik
 - weitere Auth-/Identity- und Fehlerpfade jenseits des aktuellen Benutzerkontext-Guards
-- Release-/Telemetrie-/Secret-/Recovery-Story über die lokale Basis hinaus
+- Release-/Telemetrie-/Secret-/Recovery-Story über die jetzt vorhandene OTLP-/Console-Basis hinaus
 
 ### 2. Es gibt noch Restlücken im Codebestand
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,7 +45,7 @@ Die Roadmap startet also **nicht mehr bei Null**, sondern baut auf einer funktio
 
 ### 2.1 Operations-Basis über die lokale Compose-Story hinaus vertiefen
 
-- externe Metrics-/Tracing-Exporter und Dashboards
+- Collector-/Dashboard-/Alerting-Pfade auf Basis der jetzt vorhandenen OpenTelemetry-Exporter
 - Secret-/Konfigurationsstory
 - Recovery-/Backup-Hinweise
 - Reverse-Proxy-/TLS-Härtung für echte Zielumgebungen

--- a/src/WebApiEngine.Shared/OperationsDiagnosticsDto.cs
+++ b/src/WebApiEngine.Shared/OperationsDiagnosticsDto.cs
@@ -7,6 +7,7 @@ public class OperationsDiagnosticsDto
     public required OperationsStorageSnapshotDto Storage { get; set; }
     public required TimerSchedulerDiagnosticsDto TimerScheduler { get; set; }
     public required OperationsInstrumentationDto Instrumentation { get; set; }
+    public required OperationsObservabilityDto Observability { get; set; }
 }
 
 public class OperationsStorageSnapshotDto
@@ -50,4 +51,16 @@ public class OperationsInstrumentationDto
     public required string MeterName { get; set; }
     public required string ActivitySourceName { get; set; }
     public required string Notes { get; set; }
+}
+
+public class OperationsObservabilityDto
+{
+    public required bool Enabled { get; set; }
+    public required bool ConsoleExporterEnabled { get; set; }
+    public required bool OtlpExporterEnabled { get; set; }
+    public string? OtlpEndpointHint { get; set; }
+    public string? OtlpProtocol { get; set; }
+    public string? OtlpHeadersHint { get; set; }
+    public required string ServiceName { get; set; }
+    public required string ServiceVersion { get; set; }
 }

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -186,6 +186,9 @@ public class ApiHardeningIntegrationTest
         payload.Result.Observability.Enabled.Should().BeFalse();
         payload.Result.Observability.ConsoleExporterEnabled.Should().BeFalse();
         payload.Result.Observability.OtlpExporterEnabled.Should().BeFalse();
+        payload.Result.Observability.OtlpEndpointHint.Should().BeNull();
+        payload.Result.Observability.OtlpProtocol.Should().BeNull();
+        payload.Result.Observability.OtlpHeadersHint.Should().BeNull();
         payload.Result.Observability.ServiceName.Should().Be("Flowzer.WebApi");
         storage.GetAllActiveInstancesCallCount.Should().Be(0);
     }
@@ -277,6 +280,57 @@ public class ApiHardeningIntegrationTest
         payload.Result.Observability.OtlpProtocol.Should().Be("HttpProtobuf");
         payload.Result.Observability.OtlpHeadersHint.Should().Be("(configured)");
         payload.Result.Observability.ServiceName.Should().Be("Flowzer.WebApi.Test");
+    }
+
+    [Test]
+    public async Task OperationsDiagnostics_ShouldHideConfiguredOtlpHints_WhenObservabilityIsDisabled()
+    {
+        var storage = new TestStorage();
+
+        await using var factory = new TestWebApplicationFactory(
+            storage,
+            new TestFactoryOptions
+            {
+                AdditionalConfiguration = new Dictionary<string, string?>
+                {
+                    [$"{FlowzerObservabilityOptions.SectionName}:Enabled"] = "false",
+                    [$"{FlowzerObservabilityOptions.SectionName}:OtlpEndpoint"] = "http://127.0.0.1:4318/v1/traces",
+                    [$"{FlowzerObservabilityOptions.SectionName}:OtlpHeaders"] = "authorization=Bearer secret"
+                }
+            });
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/operations/diagnostics");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<OperationsDiagnosticsDto>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeTrue();
+        payload.Result.Should().NotBeNull();
+        payload.Result!.Observability.Enabled.Should().BeFalse();
+        payload.Result.Observability.OtlpExporterEnabled.Should().BeFalse();
+        payload.Result.Observability.OtlpEndpointHint.Should().BeNull();
+        payload.Result.Observability.OtlpProtocol.Should().BeNull();
+        payload.Result.Observability.OtlpHeadersHint.Should().BeNull();
+    }
+
+    [Test]
+    public void AddFlowzerObservability_ShouldThrowClearArgumentException_WhenOtlpEndpointIsInvalid()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{FlowzerObservabilityOptions.SectionName}:Enabled"] = "true",
+                [$"{FlowzerObservabilityOptions.SectionName}:OtlpEndpoint"] = "collector:4318"
+            })
+            .Build();
+
+        var act = () => services.AddFlowzerObservability(configuration);
+
+        act.Should()
+            .Throw<ArgumentException>()
+            .WithMessage("*Observability:OtlpEndpoint*absolute http(s) URI*");
     }
 
     [Test]

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -15,6 +15,7 @@ using StorageSystem;
 using WebApiEngine.Auth;
 using WebApiEngine.BusinessLogic;
 using WebApiEngine.Controller;
+using WebApiEngine.Diagnostics;
 using WebApiEngine.Shared;
 
 namespace WebApiEngine.Tests;
@@ -182,6 +183,10 @@ public class ApiHardeningIntegrationTest
         payload.Result.TimerScheduler.Status.Should().Be("Disabled");
         payload.Result.Instrumentation.MeterName.Should().Be("Flowzer.WebApi");
         payload.Result.Instrumentation.ActivitySourceName.Should().Be("Flowzer.WebApi");
+        payload.Result.Observability.Enabled.Should().BeFalse();
+        payload.Result.Observability.ConsoleExporterEnabled.Should().BeFalse();
+        payload.Result.Observability.OtlpExporterEnabled.Should().BeFalse();
+        payload.Result.Observability.ServiceName.Should().Be("Flowzer.WebApi");
         storage.GetAllActiveInstancesCallCount.Should().Be(0);
     }
 
@@ -235,6 +240,43 @@ public class ApiHardeningIntegrationTest
         {
             Environment.SetEnvironmentVariable(FilesystemStorageSystem.Storage.StorageRootEnvironmentVariableName, previousStorageRoot);
         }
+    }
+
+    [Test]
+    public async Task OperationsDiagnostics_ShouldDescribeEnabledOpenTelemetryExporters()
+    {
+        var storage = new TestStorage();
+
+        await using var factory = new TestWebApplicationFactory(
+            storage,
+            new TestFactoryOptions
+            {
+                AdditionalConfiguration = new Dictionary<string, string?>
+                {
+                    [$"{FlowzerObservabilityOptions.SectionName}:Enabled"] = "true",
+                    [$"{FlowzerObservabilityOptions.SectionName}:UseConsoleExporter"] = "true",
+                    [$"{FlowzerObservabilityOptions.SectionName}:OtlpEndpoint"] = "http://user:secret@127.0.0.1:4318/v1/traces?token=secret",
+                    [$"{FlowzerObservabilityOptions.SectionName}:OtlpHeaders"] = "authorization=Bearer secret",
+                    [$"{FlowzerObservabilityOptions.SectionName}:OtlpProtocol"] = "http/protobuf",
+                    [$"{FlowzerObservabilityOptions.SectionName}:ServiceName"] = "Flowzer.WebApi.Test"
+                }
+            });
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/operations/diagnostics");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<OperationsDiagnosticsDto>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeTrue();
+        payload.Result.Should().NotBeNull();
+        payload.Result!.Observability.Enabled.Should().BeTrue();
+        payload.Result.Observability.ConsoleExporterEnabled.Should().BeTrue();
+        payload.Result.Observability.OtlpExporterEnabled.Should().BeTrue();
+        payload.Result.Observability.OtlpEndpointHint.Should().Be("http://127.0.0.1:4318/v1/traces");
+        payload.Result.Observability.OtlpProtocol.Should().Be("HttpProtobuf");
+        payload.Result.Observability.OtlpHeadersHint.Should().Be("(configured)");
+        payload.Result.Observability.ServiceName.Should().Be("Flowzer.WebApi.Test");
     }
 
     [Test]
@@ -630,10 +672,17 @@ public class ApiHardeningIntegrationTest
             builder.UseSetting(WebHostDefaults.EnvironmentKey, options.EnvironmentName);
             builder.ConfigureAppConfiguration((_, configBuilder) =>
             {
-                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                var configurationValues = new Dictionary<string, string?>
                 {
                     ["TimerScheduler:Enabled"] = "false"
-                });
+                };
+
+                foreach (var entry in options.AdditionalConfiguration)
+                {
+                    configurationValues[entry.Key] = entry.Value;
+                }
+
+                configBuilder.AddInMemoryCollection(configurationValues);
             });
             builder.ConfigureServices(services =>
             {
@@ -665,6 +714,8 @@ public class ApiHardeningIntegrationTest
     {
         public string EnvironmentName { get; init; } = "Development";
         public CurrentUserContext? CurrentUserContext { get; init; }
+        public IReadOnlyDictionary<string, string?> AdditionalConfiguration { get; init; } =
+            new Dictionary<string, string?>();
     }
 
     private sealed class TestTransactionalStorageProvider(TestStorage storage) : ITransactionalStorageProvider

--- a/src/WebApiEngine/Controller/OperationsController.cs
+++ b/src/WebApiEngine/Controller/OperationsController.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Microsoft.Extensions.Options;
 using Model;
 using WebApiEngine.Diagnostics;
 using WebApiEngine.Shared;
@@ -10,6 +11,7 @@ public class OperationsController(
     IStorageSystem storageSystem,
     IHostEnvironment environment,
     TimerSchedulerDiagnosticsState timerSchedulerDiagnosticsState,
+    IOptions<FlowzerObservabilityOptions> observabilityOptions,
     ILogger<OperationsController> logger) : ControllerBase
 {
     [HttpGet("diagnostics")]
@@ -58,8 +60,9 @@ public class OperationsController(
                     MeterName = FlowzerDiagnostics.MeterName,
                     ActivitySourceName = FlowzerDiagnostics.ActivitySourceName,
                     Notes =
-                        "Dieses Paket liefert bewusst nur die lokale Metrics-/Tracing-Grundlage. Exporter und externe Observability-Backends bleiben Folgearbeit."
-                }
+                        "Die lokale Diagnosebasis bleibt klein, kann jetzt aber optional über OpenTelemetry-Exporter nach außen angebunden werden."
+                },
+                Observability = CreateObservabilitySnapshot(observabilityOptions.Value)
             };
 
             activity?.SetTag("flowzer.instances.total", payload.Storage.TotalInstances);
@@ -97,5 +100,42 @@ public class OperationsController(
         return string.IsNullOrWhiteSpace(leafName)
             ? "(custom FLOWZER_STORAGE_ROOT configured)"
             : $"(custom FLOWZER_STORAGE_ROOT configured: {leafName})";
+    }
+
+    private static OperationsObservabilityDto CreateObservabilitySnapshot(FlowzerObservabilityOptions options)
+    {
+        return new OperationsObservabilityDto
+        {
+            Enabled = options.Enabled,
+            ConsoleExporterEnabled = options.Enabled && options.UseConsoleExporter,
+            OtlpExporterEnabled = options.Enabled && options.HasOtlpExporter,
+            OtlpEndpointHint = RedactOtlpEndpoint(options.OtlpEndpoint),
+            OtlpProtocol = options.Enabled && options.HasOtlpExporter
+                ? options.ResolveOtlpProtocol().ToString()
+                : null,
+            OtlpHeadersHint = string.IsNullOrWhiteSpace(options.OtlpHeaders)
+                ? null
+                : "(configured)",
+            ServiceName = options.ServiceName,
+            ServiceVersion = options.ResolveServiceVersion()
+        };
+    }
+
+    private static string? RedactOtlpEndpoint(string? endpoint)
+    {
+        if (string.IsNullOrWhiteSpace(endpoint) || !Uri.TryCreate(endpoint, UriKind.Absolute, out var uri))
+        {
+            return null;
+        }
+
+        var builder = new UriBuilder(uri)
+        {
+            UserName = string.Empty,
+            Password = string.Empty,
+            Query = string.Empty,
+            Fragment = string.Empty
+        };
+
+        return builder.Uri.GetLeftPart(UriPartial.Path);
     }
 }

--- a/src/WebApiEngine/Controller/OperationsController.cs
+++ b/src/WebApiEngine/Controller/OperationsController.cs
@@ -109,13 +109,15 @@ public class OperationsController(
             Enabled = options.Enabled,
             ConsoleExporterEnabled = options.Enabled && options.UseConsoleExporter,
             OtlpExporterEnabled = options.Enabled && options.HasOtlpExporter,
-            OtlpEndpointHint = RedactOtlpEndpoint(options.OtlpEndpoint),
+            OtlpEndpointHint = options.Enabled && options.HasOtlpExporter
+                ? RedactOtlpEndpoint(options.OtlpEndpoint)
+                : null,
             OtlpProtocol = options.Enabled && options.HasOtlpExporter
                 ? options.ResolveOtlpProtocol().ToString()
                 : null,
-            OtlpHeadersHint = string.IsNullOrWhiteSpace(options.OtlpHeaders)
-                ? null
-                : "(configured)",
+            OtlpHeadersHint = options.Enabled && options.HasOtlpExporter && !string.IsNullOrWhiteSpace(options.OtlpHeaders)
+                ? "(configured)"
+                : null,
             ServiceName = options.ServiceName,
             ServiceVersion = options.ResolveServiceVersion()
         };

--- a/src/WebApiEngine/Diagnostics/FlowzerObservabilityOptions.cs
+++ b/src/WebApiEngine/Diagnostics/FlowzerObservabilityOptions.cs
@@ -1,0 +1,45 @@
+using OpenTelemetry.Exporter;
+
+namespace WebApiEngine.Diagnostics;
+
+/// <summary>
+/// Steuerbare Observability-Optionen für lokale und produktionsnahe Umgebungen.
+/// Das Paket hält die Defaults bewusst defensiv, damit bestehende Dev- und CI-Pfade
+/// ohne zusätzliche Exporter unverändert weiterlaufen.
+/// </summary>
+public sealed class FlowzerObservabilityOptions
+{
+    public const string SectionName = "Observability";
+
+    public bool Enabled { get; set; }
+    public bool UseConsoleExporter { get; set; }
+    public string? OtlpEndpoint { get; set; }
+    public string? OtlpHeaders { get; set; }
+    public string OtlpProtocol { get; set; } = "grpc";
+    public string ServiceName { get; set; } = FlowzerDiagnostics.MeterName;
+    public string? ServiceVersion { get; set; }
+
+    public bool HasOtlpExporter => !string.IsNullOrWhiteSpace(OtlpEndpoint);
+
+    public OtlpExportProtocol ResolveOtlpProtocol()
+    {
+        return OtlpProtocol.Trim().ToLowerInvariant() switch
+        {
+            "grpc" => OtlpExportProtocol.Grpc,
+            "http/protobuf" or "httpprotobuf" or "http-protobuf" => OtlpExportProtocol.HttpProtobuf,
+            _ => throw new ArgumentException(
+                $"Unsupported Observability:OtlpProtocol value '{OtlpProtocol}'. Use 'grpc' or 'http/protobuf'.",
+                nameof(OtlpProtocol))
+        };
+    }
+
+    public string ResolveServiceVersion()
+    {
+        if (!string.IsNullOrWhiteSpace(ServiceVersion))
+        {
+            return ServiceVersion;
+        }
+
+        return typeof(FlowzerObservabilityOptions).Assembly.GetName().Version?.ToString() ?? "unknown";
+    }
+}

--- a/src/WebApiEngine/Diagnostics/FlowzerObservabilityServiceCollectionExtensions.cs
+++ b/src/WebApiEngine/Diagnostics/FlowzerObservabilityServiceCollectionExtensions.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.Options;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace WebApiEngine.Diagnostics;
+
+/// <summary>
+/// Kapselt die optionale OpenTelemetry-Verdrahtung, damit Program.cs lesbar bleibt
+/// und Diagnosedaten dieselben stabilen Konfigurationswerte wiedergeben können.
+/// </summary>
+public static class FlowzerObservabilityServiceCollectionExtensions
+{
+    public static IServiceCollection AddFlowzerObservability(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<FlowzerObservabilityOptions>(configuration.GetSection(FlowzerObservabilityOptions.SectionName));
+
+        var options = configuration.GetSection(FlowzerObservabilityOptions.SectionName).Get<FlowzerObservabilityOptions>()
+                      ?? new FlowzerObservabilityOptions();
+
+        if (!options.Enabled)
+        {
+            return services;
+        }
+
+        services.AddOpenTelemetry()
+            .ConfigureResource(resource => resource.AddService(
+                serviceName: options.ServiceName,
+                serviceVersion: options.ResolveServiceVersion()))
+            .WithMetrics(metrics =>
+            {
+                metrics.AddMeter(FlowzerDiagnostics.MeterName);
+                metrics.AddAspNetCoreInstrumentation();
+                ConfigureExporters(metrics, options);
+            })
+            .WithTracing(tracing =>
+            {
+                tracing.AddSource(FlowzerDiagnostics.ActivitySourceName);
+                tracing.AddAspNetCoreInstrumentation();
+                ConfigureExporters(tracing, options);
+            });
+
+        return services;
+    }
+
+    private static void ConfigureExporters(MeterProviderBuilder metrics, FlowzerObservabilityOptions options)
+    {
+        if (options.UseConsoleExporter)
+        {
+            metrics.AddConsoleExporter();
+        }
+
+        if (options.HasOtlpExporter)
+        {
+            metrics.AddOtlpExporter(exporter =>
+            {
+                exporter.Endpoint = new Uri(options.OtlpEndpoint!, UriKind.Absolute);
+                exporter.Protocol = options.ResolveOtlpProtocol();
+                if (!string.IsNullOrWhiteSpace(options.OtlpHeaders))
+                {
+                    exporter.Headers = options.OtlpHeaders;
+                }
+            });
+        }
+    }
+
+    private static void ConfigureExporters(TracerProviderBuilder tracing, FlowzerObservabilityOptions options)
+    {
+        if (options.UseConsoleExporter)
+        {
+            tracing.AddConsoleExporter();
+        }
+
+        if (options.HasOtlpExporter)
+        {
+            tracing.AddOtlpExporter(exporter =>
+            {
+                exporter.Endpoint = new Uri(options.OtlpEndpoint!, UriKind.Absolute);
+                exporter.Protocol = options.ResolveOtlpProtocol();
+                if (!string.IsNullOrWhiteSpace(options.OtlpHeaders))
+                {
+                    exporter.Headers = options.OtlpHeaders;
+                }
+            });
+        }
+    }
+}

--- a/src/WebApiEngine/Diagnostics/FlowzerObservabilityServiceCollectionExtensions.cs
+++ b/src/WebApiEngine/Diagnostics/FlowzerObservabilityServiceCollectionExtensions.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.Options;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -25,6 +24,11 @@ public static class FlowzerObservabilityServiceCollectionExtensions
             return services;
         }
 
+        var otlpEndpoint = ResolveOtlpEndpoint(options);
+        var otlpProtocol = options.HasOtlpExporter
+            ? options.ResolveOtlpProtocol()
+            : (OpenTelemetry.Exporter.OtlpExportProtocol?)null;
+
         services.AddOpenTelemetry()
             .ConfigureResource(resource => resource.AddService(
                 serviceName: options.ServiceName,
@@ -33,31 +37,35 @@ public static class FlowzerObservabilityServiceCollectionExtensions
             {
                 metrics.AddMeter(FlowzerDiagnostics.MeterName);
                 metrics.AddAspNetCoreInstrumentation();
-                ConfigureExporters(metrics, options);
+                ConfigureExporters(metrics, options, otlpEndpoint, otlpProtocol);
             })
             .WithTracing(tracing =>
             {
                 tracing.AddSource(FlowzerDiagnostics.ActivitySourceName);
                 tracing.AddAspNetCoreInstrumentation();
-                ConfigureExporters(tracing, options);
+                ConfigureExporters(tracing, options, otlpEndpoint, otlpProtocol);
             });
 
         return services;
     }
 
-    private static void ConfigureExporters(MeterProviderBuilder metrics, FlowzerObservabilityOptions options)
+    private static void ConfigureExporters(
+        MeterProviderBuilder metrics,
+        FlowzerObservabilityOptions options,
+        Uri? otlpEndpoint,
+        OpenTelemetry.Exporter.OtlpExportProtocol? otlpProtocol)
     {
         if (options.UseConsoleExporter)
         {
             metrics.AddConsoleExporter();
         }
 
-        if (options.HasOtlpExporter)
+        if (otlpEndpoint is not null && otlpProtocol is not null)
         {
             metrics.AddOtlpExporter(exporter =>
             {
-                exporter.Endpoint = new Uri(options.OtlpEndpoint!, UriKind.Absolute);
-                exporter.Protocol = options.ResolveOtlpProtocol();
+                exporter.Endpoint = otlpEndpoint;
+                exporter.Protocol = otlpProtocol.Value;
                 if (!string.IsNullOrWhiteSpace(options.OtlpHeaders))
                 {
                     exporter.Headers = options.OtlpHeaders;
@@ -66,24 +74,47 @@ public static class FlowzerObservabilityServiceCollectionExtensions
         }
     }
 
-    private static void ConfigureExporters(TracerProviderBuilder tracing, FlowzerObservabilityOptions options)
+    private static void ConfigureExporters(
+        TracerProviderBuilder tracing,
+        FlowzerObservabilityOptions options,
+        Uri? otlpEndpoint,
+        OpenTelemetry.Exporter.OtlpExportProtocol? otlpProtocol)
     {
         if (options.UseConsoleExporter)
         {
             tracing.AddConsoleExporter();
         }
 
-        if (options.HasOtlpExporter)
+        if (otlpEndpoint is not null && otlpProtocol is not null)
         {
             tracing.AddOtlpExporter(exporter =>
             {
-                exporter.Endpoint = new Uri(options.OtlpEndpoint!, UriKind.Absolute);
-                exporter.Protocol = options.ResolveOtlpProtocol();
+                exporter.Endpoint = otlpEndpoint;
+                exporter.Protocol = otlpProtocol.Value;
                 if (!string.IsNullOrWhiteSpace(options.OtlpHeaders))
                 {
                     exporter.Headers = options.OtlpHeaders;
                 }
             });
         }
+    }
+
+    private static Uri? ResolveOtlpEndpoint(FlowzerObservabilityOptions options)
+    {
+        if (!options.HasOtlpExporter)
+        {
+            return null;
+        }
+
+        if (Uri.TryCreate(options.OtlpEndpoint, UriKind.Absolute, out var endpoint)
+            && (endpoint.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+                || endpoint.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)))
+        {
+            return endpoint;
+        }
+
+        throw new ArgumentException(
+            "Observability:OtlpEndpoint must be an absolute http(s) URI like 'http://localhost:4318' when Observability is enabled.",
+            nameof(options));
     }
 }

--- a/src/WebApiEngine/Middleware/FlowzerRequestDiagnosticsMiddleware.cs
+++ b/src/WebApiEngine/Middleware/FlowzerRequestDiagnosticsMiddleware.cs
@@ -17,7 +17,10 @@ public sealed class FlowzerRequestDiagnosticsMiddleware(
         var method = context.Request.Method;
         var routeName = context.GetEndpoint()?.DisplayName ?? path;
 
-        using var activity = FlowzerDiagnostics.ActivitySource.StartActivity("flowzer.request", ActivityKind.Server);
+        using var diagnosticsActivity = Activity.Current is null
+            ? FlowzerDiagnostics.ActivitySource.StartActivity("flowzer.request", ActivityKind.Internal)
+            : null;
+        var activity = Activity.Current ?? diagnosticsActivity;
         activity?.SetTag("http.method", method);
         activity?.SetTag("url.path", path);
         activity?.SetTag("flowzer.route_name", routeName);

--- a/src/WebApiEngine/Program.cs
+++ b/src/WebApiEngine/Program.cs
@@ -25,6 +25,7 @@ builder.Services.AddSingleton<ITransactionalStorageProvider, FilesystemStorageSy
 builder.Services.AddSingleton<IStorageSystem, FilesystemStorageSystem.Storage>();
 builder.Services.AddSingleton<ICurrentUserContextAccessor, HttpContextCurrentUserContextAccessor>();
 builder.Services.AddSingleton<TimerSchedulerDiagnosticsState>();
+builder.Services.AddFlowzerObservability(builder.Configuration);
 builder.Services.AddSingleton<FormBusinessLogic>();
 builder.Services.AddSingleton<DefinitionBusinessLogic>();
 builder.Services.AddSingleton<BpmnBusinessLogic>();

--- a/src/WebApiEngine/WebApiEngine.csproj
+++ b/src/WebApiEngine/WebApiEngine.csproj
@@ -7,8 +7,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.2" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/WebApiEngine/appsettings.Development.json
+++ b/src/WebApiEngine/appsettings.Development.json
@@ -8,5 +8,13 @@
   "TimerScheduler": {
     "Enabled": true,
     "PollIntervalSeconds": 2
+  },
+  "Observability": {
+    "Enabled": false,
+    "UseConsoleExporter": false,
+    "OtlpEndpoint": "",
+    "OtlpHeaders": "",
+    "OtlpProtocol": "grpc",
+    "ServiceName": "Flowzer.WebApi"
   }
 }

--- a/src/WebApiEngine/appsettings.json
+++ b/src/WebApiEngine/appsettings.json
@@ -9,5 +9,13 @@
     "Enabled": true,
     "PollIntervalSeconds": 5
   },
+  "Observability": {
+    "Enabled": false,
+    "UseConsoleExporter": false,
+    "OtlpEndpoint": "",
+    "OtlpHeaders": "",
+    "OtlpProtocol": "grpc",
+    "ServiceName": "Flowzer.WebApi"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Zusammenfassung

Dieses PR ergänzt für die Web-API einen **optional aktivierbaren OpenTelemetry-Pfad**, ohne den bisherigen Default für lokale Entwicklung, CI und UI-Smokes zu verschärfen.

## Enthalten

- optionale OpenTelemetry-Verdrahtung für `Meter` und `ActivitySource`
- konfigurierbare Console- und OTLP-Exporter
- neuer Observability-Snapshot in `GET /operations/diagnostics`
- redigierte OTLP-Endpunkt-/Header-Hinweise statt Secret-Leaks im Diagnose-Endpunkt
- ergänzte Integrationstests für deaktivierte und aktivierte Exporter-Konfiguration
- aktualisierte Betriebs-, Status- und Roadmap-Dokumentation

## Konfiguration

Beispiel:

```bash
Observability__Enabled=true
Observability__UseConsoleExporter=true
Observability__OtlpEndpoint=http://localhost:4318
Observability__OtlpProtocol=http/protobuf
```

## Validierung

- `dotnet build core-engine.sln --configuration Release`
- `dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'`
- `dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'`
- `dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'`
- `bash -n scripts/local/check-stack.sh scripts/runtime/check-runtime-stack.sh scripts/local/start-stack.sh scripts/local/stop-stack.sh scripts/runtime/start-runtime-stack.sh scripts/runtime/stop-runtime-stack.sh`
- `npm --prefix tests/ui-smoke ci`
- `npm --prefix tests/ui-smoke test`

Closes #91
