### PR TITLE
Dokumentiert Testzwecke und konkretisiert den Folge-Schlachtplan

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,7 +37,7 @@ Bevorzuge kleine Änderungen mit klarer Wirkung statt großer, riskanter Umbaute
 
 ### 2. Tests ernst nehmen
 
-Wenn Engine-, Parser-, Gateway-, Multi-Instance-, Message- oder Signal-Logik verändert wird, sollten die Änderungen möglichst durch Tests abgesichert werden.
+Wenn Engine-, Parser-, Gateway-, Multi-Instance-, Message- oder Signal-Logik verändert wird, sollten die Änderungen möglichst durch Tests abgesichert werden. Jeder neue oder angepasste Test soll zusätzlich einen kurzen Kommentar zum Testzweck tragen (`// Testzweck: ...`).
 
 ### 3. Dokumentation mitdenken
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Dieses Repository enthält eine BPMN-Engine mit Parser, Laufzeit, API, Frontend 
 - **Nicht von vollständiger BPMN-2.0-Abdeckung ausgehen.** Erst im Code und in den Tests verifizieren.
 - **Kleine, fokussierte Änderungen bevorzugen.**
 - **Engine-Änderungen möglichst mit Tests absichern.**
+- **Jeder Test soll einen kurzen Kommentar zum Testzweck tragen (`// Testzweck: ...`).**
 - **Doku aktualisieren, wenn sich Architektur oder Setup ändern.**
 - **Code auf Englisch, erklärende Kommentare/Dokumentation bevorzugt auf Deutsch.**
 

--- a/DEVELOPMENT-GUIDELINES.md
+++ b/DEVELOPMENT-GUIDELINES.md
@@ -194,6 +194,7 @@ public class ServiceTask : Task
 [TestFixture]
 public class CoreEngineTests
 {
+    // Testzweck: Prüft, dass eine gültige BPMN-Datei erfolgreich geladen wird.
     [Test]
     public async Task LoadBpmnFile_ValidXml_ShouldLoadSuccessfully()
     {
@@ -209,6 +210,7 @@ public class CoreEngineTests
         Assert.That(subscriptions, Is.Not.Empty);
     }
     
+    // Testzweck: Prüft, dass der Abschluss einer UserTask den Token korrekt weiterführt.
     [Test]
     public async Task HandleEvent_UserTaskCompletion_ShouldAdvanceToken()
     {

--- a/DEVELOPMENT-GUIDELINES.md
+++ b/DEVELOPMENT-GUIDELINES.md
@@ -188,6 +188,8 @@ public class ServiceTask : Task
 
 ### Test-Struktur (empfohlen)
 
+- **Jeder Test bekommt direkt oberhalb von `[Test]` einen kurzen Kommentar im Format `// Testzweck: ...`, der den Zweck des Tests erklärt.**
+
 ```csharp
 [TestFixture]
 public class CoreEngineTests

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Diese Punkte sollte man kennen, bevor man loslegt:
 
 - [docs/PROJECT-STATUS.md](docs/PROJECT-STATUS.md) – ehrliche Bestandsaufnahme
 - [docs/ROADMAP.md](docs/ROADMAP.md) – Vorschlag für die nächsten Schritte
+- [docs/CODEBASE-AUDIT-2026-04.md](docs/CODEBASE-AUDIT-2026-04.md) – Audit-Feststellungen und Folgepakete nach der Revitalisierung
 - [docs/ICORE.md](docs/ICORE.md) – dokumentierter Kernvertrag und minimaler Integrationspfad
 - [docs/DEMO.md](docs/DEMO.md) – Console-Demo, Startbefehl und erwartete Ausgabe
 - [docs/FRONTEND.md](docs/FRONTEND.md) – Frontend-Konfiguration, lokale Starts und UI-Smoke-Tests

--- a/docs/CODEBASE-AUDIT-2026-04.md
+++ b/docs/CODEBASE-AUDIT-2026-04.md
@@ -107,7 +107,7 @@ Empfohlene Reihenfolge:
 ## Was dieses Audit direkt ausgelöst hat
 
 - Der Folge-Backlog wurde in konkrete Issues zerlegt.
-- Alle bestehenden `[Test]`-Methoden erhalten in Folgearbeit bzw. im zugehörigen Paket einen kurzen Kommentar zum Testzweck.
+- Alle bestehenden NUnit- und Playwright-Tests wurden im zugehörigen Paket um einen kurzen Kommentar zum Testzweck ergänzt.
 - Die weitere Arbeit orientiert sich nicht mehr an diffusen Sammelaufgaben, sondern an klar reviewbaren Paketen.
 
 ## Leitprinzip für die nächsten Pakete

--- a/docs/CODEBASE-AUDIT-2026-04.md
+++ b/docs/CODEBASE-AUDIT-2026-04.md
@@ -1,0 +1,120 @@
+# Codebase-Audit April 2026
+
+**Stand:** 13. April 2026
+
+## Ziel des Audits
+
+Dieses Audit beantwortet drei Fragen:
+
+1. **Was fehlt nach der ersten Revitalisierungswelle noch?**
+2. **Wo ist der Code heute schon solide, aber noch nicht sauber genug strukturiert?**
+3. **Welche Arbeitspakete sollten als Nächstes in eigenen `codex/*`-Branches nach `next` umgesetzt werden?**
+
+## Kurzfazit
+
+Die Codebasis ist heute **klar arbeitsfähig und deutlich belastbarer** als noch zu Beginn der Rettungsphase. Gleichzeitig zeigt das Audit, dass die nächsten Schritte nicht mehr primär „Build wieder grün bekommen“, sondern **Wartbarkeit, Semantik, Auth und Betriebsreife** betreffen.
+
+## Was heute schon gut ist
+
+- `next` baut und testet reproduzierbar
+- Engine-, API-, Frontend- und UI-Smoke-Pfade sind vorhanden
+- Timer-, Boundary-, Diagnose- und erste Observability-Pfade sind inzwischen im Produktpfad angekommen
+- die Projektstruktur ist fachlich grundsätzlich sinnvoll getrennt (`FlowzerBPMN`, `core-engine`, `WebApiEngine`, `FlowzerFrontend`, Storage)
+
+## Wichtigste Audit-Ergebnisse
+
+### 1. Runtime-Semantik ist verbessert, aber noch nicht abgeschlossen
+
+Offene Restthemen liegen vor allem in:
+
+- spezieller Boundary-/Spezialtimer-Recovery
+- weitergehender Error-/Escalation-Semantik
+- Kompensation und präziseren Abbruchpfaden
+- offenen Start-/Initialisierungsfragen wie `ProcessEngine.ActiveUserTasks()`
+
+**Folgeissue:** [#93](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/93)
+
+### 2. Auth-/Identity-Pfade sind noch eine Übergangslösung
+
+Die API erzwingt heute bereits einen aufgelösten Benutzerkontext, aber:
+
+- Rollen und Claims sind noch nicht als vollständiges Modell ausgearbeitet
+- der technische Development-Header ist bewusst nur ein lokaler Helfer
+- produktive Auth-/Berechtigungspfade brauchen noch eine klarere Zielarchitektur
+
+**Folgeissue:** [#94](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/94)
+
+### 3. Operations-Basis ist vorhanden, aber noch nicht produktionsreif
+
+Vorhanden sind inzwischen:
+
+- lokale Compose-/Runtime-Skripte
+- Health-/Readiness-Endpunkte
+- Diagnose-Endpunkt
+- optionale OpenTelemetry-Exporter
+
+Nicht abgeschlossen sind dagegen u. a.:
+
+- Collector-/Dashboard-/Alerting-Pfade
+- Secrets- und TLS-Strategie
+- Reverse-Proxy-Härtung
+- Backup-/Restore- und Recovery-Automatisierung
+
+**Folgeissue:** [#95](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/95)
+
+### 4. Codehygiene und Struktur sind der nächste große Hebel
+
+Das Audit hat mehrere strukturelle Baustellen sichtbar gemacht:
+
+- sehr große Dateien erschweren Reviews und Wartung, z. B.:
+  - `src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs`
+  - `src/core-engine-tests/EngineTest.cs`
+  - `src/core-engine/ModelParser.cs`
+  - `src/WebApiEngine/BusinessLogic/BpmnBusinessLogic.cs`
+  - `src/FlowzerFrontend/Pages/Instance.razor.cs`
+- es existieren weiterhin mehrere generische `Exception`-Würfe statt fachlich passender Fehler
+- offene TODOs markieren noch nicht sauber abgeschlossene Pfade
+- öffentliche Methoden in Kern- und API-Klassen sind nicht überall dokumentiert
+
+**Folgeissue:** [#96](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/96)
+
+### 5. Die Testsuite ist fachlich wertvoll, aber war bislang zu wenig erklärt
+
+Zum Audit-Zeitpunkt gab es **166** `[Test]`-Methoden in den drei zentralen Testprojekten.
+
+Der technische Abdeckungsstand war gut, aber die Wartbarkeit litt darunter, dass die Tests ihren Zweck nicht immer unmittelbar erklärten. Deshalb gilt jetzt als Leitlinie:
+
+- **jeder Test braucht einen kurzen Kommentar zum Testzweck**
+- große Testsammlungen sollen mittelfristig weiter aufgeteilt werden
+- E2E-/UI-Smoke-Pfade sollen gezielt, aber nicht unkontrolliert wachsen
+
+**Folgeissue:** [#97](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/97)
+
+## Priorisierter Schlachtplan
+
+Der übergreifende Folgeplan ist als eigenes GitHub-Issue dokumentiert:
+
+- [#98 Schlachtplan nach der Revitalisierung: Wartbarkeit, Runtime, Auth und Betrieb gezielt weiterziehen](https://github.com/flowzer-io/flowzer-bpmn-core-engine/issues/98)
+
+Empfohlene Reihenfolge:
+
+1. Codehygiene und Verständlichkeit erhöhen
+2. Testsuite dokumentieren und strukturieren
+3. Runtime-Restsemantik schließen
+4. Auth-/Identity-Modell produktionsnäher machen
+5. Operations-/Deployment-Reife ausbauen
+
+## Was dieses Audit direkt ausgelöst hat
+
+- Der Folge-Backlog wurde in konkrete Issues zerlegt.
+- Alle bestehenden `[Test]`-Methoden erhalten in Folgearbeit bzw. im zugehörigen Paket einen kurzen Kommentar zum Testzweck.
+- Die weitere Arbeit orientiert sich nicht mehr an diffusen Sammelaufgaben, sondern an klar reviewbaren Paketen.
+
+## Leitprinzip für die nächsten Pakete
+
+Die Revitalisierung ist jetzt an einem Punkt, an dem **Qualität vor Breite** wichtiger ist als neue Features. Das Repository profitiert aktuell am meisten von:
+
+- kleineren, nachvollziehbaren Refactorings
+- präziserer Semantik in Edge Cases
+- klarerem Betriebsmodell
+- verständlicherer Test- und API-Dokumentation

--- a/src/FlowzerFrontend.Tests/FlowzerApiOptionsTest.cs
+++ b/src/FlowzerFrontend.Tests/FlowzerApiOptionsTest.cs
@@ -8,6 +8,7 @@ namespace FlowzerFrontend.Tests;
 
 public class FlowzerApiOptionsTest
 {
+    // Testzweck: Deckt den Fall „Resolve Base Address Should Fallback To Host Base Address When Base URL Is Missing“ ab.
     [Test]
     public void ResolveBaseAddress_ShouldFallbackToHostBaseAddress_WhenBaseUrlIsMissing()
     {
@@ -18,6 +19,7 @@ public class FlowzerApiOptionsTest
         result.Should().Be(new Uri("http://localhost:5269/"));
     }
 
+    // Testzweck: Deckt den Fall „Resolve Base Address Should Use Configured Absolute Base Address When Present“ ab.
     [Test]
     public void ResolveBaseAddress_ShouldUseConfiguredAbsoluteBaseAddress_WhenPresent()
     {
@@ -31,6 +33,7 @@ public class FlowzerApiOptionsTest
         result.Should().Be(new Uri("https://api.flowzer.local/v1/"));
     }
 
+    // Testzweck: Deckt den Fall „Resolve Base Address Should Combine Relative Base Address With Frontend Host“ ab.
     [Test]
     public void ResolveBaseAddress_ShouldCombineRelativeBaseAddress_WithFrontendHost()
     {
@@ -44,6 +47,7 @@ public class FlowzerApiOptionsTest
         result.Should().Be(new Uri("http://localhost:5269/backend/"));
     }
 
+    // Testzweck: Deckt den Fall „Resolve Development User ID Should Return Configured User When Frontend Runs In Development“ ab.
     [Test]
     public void ResolveDevelopmentUserId_ShouldReturnConfiguredUser_WhenFrontendRunsInDevelopment()
     {
@@ -58,6 +62,7 @@ public class FlowzerApiOptionsTest
         result.Should().Be(developmentUserId);
     }
 
+    // Testzweck: Deckt den Fall „Resolve Development User ID Should Return Null When Frontend Does Not Run In Development“ ab.
     [Test]
     public void ResolveDevelopmentUserId_ShouldReturnNull_WhenFrontendDoesNotRunInDevelopment()
     {
@@ -71,6 +76,7 @@ public class FlowzerApiOptionsTest
         result.Should().BeNull();
     }
 
+    // Testzweck: Deckt den Fall „Apply Default Headers Should Add Technical User Header When Development User Is Configured“ ab.
     [Test]
     public void ApplyDefaultHeaders_ShouldAddTechnicalUserHeader_WhenDevelopmentUserIsConfigured()
     {
@@ -93,6 +99,7 @@ public class FlowzerApiOptionsTest
             .Be(developmentUserId.ToString());
     }
 
+    // Testzweck: Deckt den Fall „Apply Default Headers Should Not Add Technical User Header Outside Development“ ab.
     [Test]
     public void ApplyDefaultHeaders_ShouldNotAddTechnicalUserHeader_OutsideDevelopment()
     {
@@ -107,6 +114,7 @@ public class FlowzerApiOptionsTest
         httpClient.DefaultRequestHeaders.Contains(FlowzerApiOptions.DevelopmentUserIdHeaderName).Should().BeFalse();
     }
 
+    // Testzweck: Deckt den Fall „Get JSON Request Should Use Configured HTTP Method And JSON Payload“ ab.
     [Test]
     public async Task GetJsonRequest_ShouldUseConfiguredHttpMethod_AndJsonPayload()
     {
@@ -128,6 +136,7 @@ public class FlowzerApiOptionsTest
         handler.LastContent.Should().Be(payload);
     }
 
+    // Testzweck: Deckt den Fall „Get Signal Subscriptions Should Use Signals Route“ ab.
     [Test]
     public async Task GetSignalSubscriptions_ShouldUseSignalsRoute()
     {
@@ -157,6 +166,7 @@ public class FlowzerApiOptionsTest
         handler.LastRequestUri.Should().Be(new Uri($"http://localhost:5182/instance/{instanceId}/subscription/signals"));
     }
 
+    // Testzweck: Deckt den Fall „Get Service Subscriptions Should Use Services Route“ ab.
     [Test]
     public async Task GetServiceSubscriptions_ShouldUseServicesRoute()
     {
@@ -183,6 +193,7 @@ public class FlowzerApiOptionsTest
         handler.LastRequestUri.Should().Be(new Uri($"http://localhost:5182/instance/{instanceId}/subscription/services"));
     }
 
+    // Testzweck: Deckt den Fall „Get Latest Form Should Use Latest Form Route“ ab.
     [Test]
     public async Task GetLatestForm_ShouldUseLatestFormRoute()
     {
@@ -208,6 +219,7 @@ public class FlowzerApiOptionsTest
         handler.LastRequestUri.Should().Be(new Uri($"http://localhost:5182/form/{formId}/latest"));
     }
 
+    // Testzweck: Deckt den Fall „Get Form Should Use Versioned Form Route“ ab.
     [Test]
     public async Task GetForm_ShouldUseVersionedFormRoute()
     {
@@ -234,6 +246,7 @@ public class FlowzerApiOptionsTest
         handler.LastRequestUri.Should().Be(new Uri($"http://localhost:5182/form/{formId}/{version}"));
     }
 
+    // Testzweck: Deckt den Fall „Upload Definition Should Include Previous GUID Query When Provided“ ab.
     [Test]
     public async Task UploadDefinition_ShouldIncludePreviousGuidQuery_WhenProvided()
     {
@@ -254,6 +267,7 @@ public class FlowzerApiOptionsTest
         handler.LastRequestUri.Should().Be(new Uri($"http://localhost:5182/definition?previousGuid={previousGuid}"));
     }
 
+    // Testzweck: Deckt den Fall „Upload Definition Should Not Include Previous GUID Query When GUID Is Empty“ ab.
     [Test]
     public async Task UploadDefinition_ShouldNotIncludePreviousGuidQuery_WhenGuidIsEmpty()
     {
@@ -272,6 +286,7 @@ public class FlowzerApiOptionsTest
         handler.LastRequestUri.Should().Be(new Uri("http://localhost:5182/definition"));
     }
 
+    // Testzweck: Deckt den Fall „Deploy Definition Should Include Previous GUID Query When Provided“ ab.
     [Test]
     public async Task DeployDefinition_ShouldIncludePreviousGuidQuery_WhenProvided()
     {

--- a/src/FlowzerFrontend.Tests/FormRouteHelperTest.cs
+++ b/src/FlowzerFrontend.Tests/FormRouteHelperTest.cs
@@ -5,6 +5,7 @@ namespace FlowzerFrontend.Tests;
 
 public class FormRouteHelperTest
 {
+    // Testzweck: Deckt den Fall „Parse Should Recognize Create Route“ ab.
     [Test]
     public void Parse_ShouldRecognizeCreateRoute()
     {
@@ -15,6 +16,7 @@ public class FormRouteHelperTest
         result.ErrorMessage.Should().BeNull();
     }
 
+    // Testzweck: Deckt den Fall „Parse Should Return GUID When Route Contains Existing Form ID“ ab.
     [Test]
     public void Parse_ShouldReturnGuid_WhenRouteContainsExistingFormId()
     {
@@ -27,6 +29,7 @@ public class FormRouteHelperTest
         result.ErrorMessage.Should().BeNull();
     }
 
+    // Testzweck: Deckt den Fall „Parse Should Return Error For Invalid Route Value“ ab.
     [Test]
     public void Parse_ShouldReturnError_ForInvalidRouteValue()
     {

--- a/src/FlowzerFrontend.Tests/InstanceListFilterHelperTest.cs
+++ b/src/FlowzerFrontend.Tests/InstanceListFilterHelperTest.cs
@@ -6,6 +6,7 @@ namespace FlowzerFrontend.Tests;
 
 public class InstanceListFilterHelperTest
 {
+    // Testzweck: Deckt den Fall „Parse Or Default Should Fallback To All For Unknown Values“ ab.
     [Test]
     public void ParseOrDefault_ShouldFallbackToAll_ForUnknownValues()
     {
@@ -14,6 +15,7 @@ public class InstanceListFilterHelperTest
         result.Should().Be(InstanceListFilter.All);
     }
 
+    // Testzweck: Deckt den Fall „Apply Should Return Only Active States For Active Filter“ ab.
     [Test]
     public void Apply_ShouldReturnOnlyActiveStates_ForActiveFilter()
     {
@@ -33,6 +35,7 @@ public class InstanceListFilterHelperTest
             instance.State == ProcessInstanceStateDto.Waiting);
     }
 
+    // Testzweck: Deckt den Fall „Apply Should Return Only Done States For Done Filter“ ab.
     [Test]
     public void Apply_ShouldReturnOnlyDoneStates_ForDoneFilter()
     {
@@ -51,6 +54,7 @@ public class InstanceListFilterHelperTest
             instance.State == ProcessInstanceStateDto.Terminated);
     }
 
+    // Testzweck: Deckt den Fall „Apply Should Return Only Error States For Error Filter“ ab.
     [Test]
     public void Apply_ShouldReturnOnlyErrorStates_ForErrorFilter()
     {
@@ -69,6 +73,7 @@ public class InstanceListFilterHelperTest
             instance.State == ProcessInstanceStateDto.Failed);
     }
 
+    // Testzweck: Deckt den Fall „To Route Segment Should Return Stable Segments“ ab.
     [Test]
     public void ToRouteSegment_ShouldReturnStableSegments()
     {

--- a/src/FlowzerFrontend.Tests/ModelListViewHelperTest.cs
+++ b/src/FlowzerFrontend.Tests/ModelListViewHelperTest.cs
@@ -7,6 +7,7 @@ namespace FlowzerFrontend.Tests;
 
 public class ModelListViewHelperTest
 {
+    // Testzweck: Deckt den Fall „Apply Query Should Filter Across Name Definition ID And Description“ ab.
     [Test]
     public void ApplyQuery_ShouldFilterAcrossNameDefinitionIdAndDescription()
     {
@@ -32,6 +33,7 @@ public class ModelListViewHelperTest
         result[0].DefinitionId.Should().Be("invoice-process");
     }
 
+    // Testzweck: Deckt den Fall „Apply Query Should Sort Ascending By Name“ ab.
     [Test]
     public void ApplyQuery_ShouldSortAscendingByName()
     {
@@ -46,6 +48,7 @@ public class ModelListViewHelperTest
         result.Select(model => model.Name).Should().Equal("Alpha", "Zeta");
     }
 
+    // Testzweck: Deckt den Fall „Apply Query Should Sort Descending By Name“ ab.
     [Test]
     public void ApplyQuery_ShouldSortDescendingByName()
     {

--- a/src/FlowzerFrontend.Tests/TokenDisplayHelperTest.cs
+++ b/src/FlowzerFrontend.Tests/TokenDisplayHelperTest.cs
@@ -7,6 +7,7 @@ namespace FlowzerFrontend.Tests;
 
 public class TokenDisplayHelperTest
 {
+    // Testzweck: Deckt den Fall „Get Implementation Should Return Null When Current Flow Element Is Missing“ ab.
     [Test]
     public void GetImplementation_ShouldReturnNull_WhenCurrentFlowElementIsMissing()
     {
@@ -17,6 +18,7 @@ public class TokenDisplayHelperTest
         result.Should().BeNull();
     }
 
+    // Testzweck: Deckt den Fall „Get Flow Element ID Should Fallback To Current Flow Node ID When Expando Value Is Missing“ ab.
     [Test]
     public void GetFlowElementId_ShouldFallbackToCurrentFlowNodeId_WhenExpandoValueIsMissing()
     {
@@ -30,6 +32,7 @@ public class TokenDisplayHelperTest
         result.Should().Be("Activity_UserTask");
     }
 
+    // Testzweck: Deckt den Fall „Get Implementation Should Return Null When Expando Contains Null Value“ ab.
     [Test]
     public void GetImplementation_ShouldReturnNull_WhenExpandoContainsNullValue()
     {
@@ -46,6 +49,7 @@ public class TokenDisplayHelperTest
         result.Should().BeNull();
     }
 
+    // Testzweck: Deckt den Fall „Get Display Name Should Prefer Name And Fallback To ID“ ab.
     [Test]
     public void GetDisplayName_ShouldPreferName_AndFallbackToId()
     {

--- a/src/FlowzerFrontend.Tests/UriHelperTest.cs
+++ b/src/FlowzerFrontend.Tests/UriHelperTest.cs
@@ -4,6 +4,7 @@ namespace FlowzerFrontend.Tests;
 
 public class UriHelperTest
 {
+    // Testzweck: Deckt den Fall „Get Instances URL Should Return Base Instances Route When No Filter Is Provided“ ab.
     [Test]
     public void GetInstancesUrl_ShouldReturnBaseInstancesRoute_WhenNoFilterIsProvided()
     {
@@ -12,6 +13,7 @@ public class UriHelperTest
         result.Should().Be("/instances");
     }
 
+    // Testzweck: Deckt den Fall „Get Instances URL Should Append Filter Segment When Filter Is Provided“ ab.
     [Test]
     public void GetInstancesUrl_ShouldAppendFilterSegment_WhenFilterIsProvided()
     {

--- a/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/ApiHardeningIntegrationTest.cs
@@ -23,6 +23,7 @@ namespace WebApiEngine.Tests;
 [NonParallelizable]
 public class ApiHardeningIntegrationTest
 {
+    // Testzweck: Deckt den Fall „Health Should Return Successful Liveness Payload“ ab.
     [Test]
     public async Task Health_ShouldReturnSuccessfulLivenessPayload()
     {
@@ -42,6 +43,7 @@ public class ApiHardeningIntegrationTest
         payload.Result.Storage.Should().Be("NotChecked");
     }
 
+    // Testzweck: Deckt den Fall „Ready Health Should Return Service Unavailable When Storage Probe Fails“ ab.
     [Test]
     public async Task ReadyHealth_ShouldReturnServiceUnavailable_WhenStorageProbeFails()
     {
@@ -65,6 +67,7 @@ public class ApiHardeningIntegrationTest
         payload.ErrorMessage.Should().Be("Storage is unavailable.");
     }
 
+    // Testzweck: Deckt den Fall „Operations Diagnostics Should Return Scheduler And Storage Snapshot“ ab.
     [Test]
     public async Task OperationsDiagnostics_ShouldReturnSchedulerAndStorageSnapshot()
     {
@@ -193,6 +196,7 @@ public class ApiHardeningIntegrationTest
         storage.GetAllActiveInstancesCallCount.Should().Be(0);
     }
 
+    // Testzweck: Deckt den Fall „Operations Diagnostics Should Return Service Unavailable When Storage Snapshot Fails“ ab.
     [Test]
     public async Task OperationsDiagnostics_ShouldReturnServiceUnavailable_WhenStorageSnapshotFails()
     {
@@ -213,6 +217,7 @@ public class ApiHardeningIntegrationTest
         payload.ErrorMessage.Should().Be("Operations diagnostics are currently unavailable.");
     }
 
+    // Testzweck: Deckt den Fall „Operations Diagnostics Should Redact Custom Storage Root Outside Development“ ab.
     [Test]
     public async Task OperationsDiagnostics_ShouldRedactCustomStorageRootOutsideDevelopment()
     {
@@ -245,6 +250,7 @@ public class ApiHardeningIntegrationTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Operations Diagnostics Should Describe Enabled Open Telemetry Exporters“ ab.
     [Test]
     public async Task OperationsDiagnostics_ShouldDescribeEnabledOpenTelemetryExporters()
     {
@@ -282,6 +288,7 @@ public class ApiHardeningIntegrationTest
         payload.Result.Observability.ServiceName.Should().Be("Flowzer.WebApi.Test");
     }
 
+    // Testzweck: Deckt den Fall „Operations Diagnostics Should Hide Configured OTLP Hints When Observability Is Disabled“ ab.
     [Test]
     public async Task OperationsDiagnostics_ShouldHideConfiguredOtlpHints_WhenObservabilityIsDisabled()
     {
@@ -314,6 +321,7 @@ public class ApiHardeningIntegrationTest
         payload.Result.Observability.OtlpHeadersHint.Should().BeNull();
     }
 
+    // Testzweck: Deckt den Fall „Add Flowzer Observability Should Throw Clear Argument Exception When OTLP Endpoint Is Invalid“ ab.
     [Test]
     public void AddFlowzerObservability_ShouldThrowClearArgumentException_WhenOtlpEndpointIsInvalid()
     {
@@ -333,6 +341,7 @@ public class ApiHardeningIntegrationTest
             .WithMessage("*Observability:OtlpEndpoint*absolute http(s) URI*");
     }
 
+    // Testzweck: Deckt den Fall „Upload Definition Should Use Technical User Header When No Authentication Exists Yet“ ab.
     [Test]
     public async Task UploadDefinition_ShouldUseTechnicalUserHeader_WhenNoAuthenticationExistsYet()
     {
@@ -361,6 +370,7 @@ public class ApiHardeningIntegrationTest
         storage.StoredDefinitions[0].SavedByUser.Should().Be(expectedUserId);
     }
 
+    // Testzweck: Deckt den Fall „Upload Definition Should Return Unauthorized When No Authentication Data Is Present Outside Development“ ab.
     [Test]
     public async Task UploadDefinition_ShouldReturnUnauthorized_WhenNoAuthenticationDataIsPresentOutsideDevelopment()
     {
@@ -388,6 +398,7 @@ public class ApiHardeningIntegrationTest
         storage.StoredDefinitions.Should().BeEmpty();
     }
 
+    // Testzweck: Deckt den Fall „Deploy Definition Should Return Unauthorized When No Authentication Data Is Present Outside Development“ ab.
     [Test]
     public async Task DeployDefinition_ShouldReturnUnauthorized_WhenNoAuthenticationDataIsPresentOutsideDevelopment()
     {
@@ -415,6 +426,7 @@ public class ApiHardeningIntegrationTest
         storage.StoredDefinitions.Should().BeEmpty();
     }
 
+    // Testzweck: Deckt den Fall „Get All User Tasks Should Return Unauthorized When No Authentication Data Is Present Outside Development“ ab.
     [Test]
     public async Task GetAllUserTasks_ShouldReturnUnauthorized_WhenNoAuthenticationDataIsPresentOutsideDevelopment()
     {
@@ -435,6 +447,7 @@ public class ApiHardeningIntegrationTest
         payload.ErrorMessage.Should().Contain("resolved user context");
     }
 
+    // Testzweck: Deckt den Fall „Get All User Tasks Should Use Resolved User Context When Accessor Provides Authenticated User“ ab.
     [Test]
     public async Task GetAllUserTasks_ShouldUseResolvedUserContext_WhenAccessorProvidesAuthenticatedUser()
     {
@@ -460,6 +473,7 @@ public class ApiHardeningIntegrationTest
         payload.Result.Should().BeEmpty();
     }
 
+    // Testzweck: Deckt den Fall „User Task Endpoint Should Return Bad Request When Process Instance ID Is Missing“ ab.
     [Test]
     public async Task UserTaskEndpoint_ShouldReturnBadRequest_WhenProcessInstanceIdIsMissing()
     {
@@ -491,6 +505,7 @@ public class ApiHardeningIntegrationTest
         payload.ErrorMessage.Should().Contain("ProcessInstanceId");
     }
 
+    // Testzweck: Deckt den Fall „User Task Endpoint Should Return Unauthorized When No Authentication Data Is Present Outside Development“ ab.
     [Test]
     public async Task UserTaskEndpoint_ShouldReturnUnauthorized_WhenNoAuthenticationDataIsPresentOutsideDevelopment()
     {
@@ -516,6 +531,7 @@ public class ApiHardeningIntegrationTest
         payload.ErrorMessage.Should().Contain("resolved user context");
     }
 
+    // Testzweck: Deckt den Fall „Form Result Should Return Unauthorized When No Authentication Data Is Present Outside Development“ ab.
     [Test]
     public async Task FormResult_ShouldReturnUnauthorized_WhenNoAuthenticationDataIsPresentOutsideDevelopment()
     {
@@ -541,6 +557,7 @@ public class ApiHardeningIntegrationTest
         payload.ErrorMessage.Should().Contain("resolved user context");
     }
 
+    // Testzweck: Deckt den Fall „Missing Form Metadata Should Return JSON API Contract When Controller Throws File Not Found“ ab.
     [Test]
     public async Task MissingFormMetadata_ShouldReturnJsonApiContract_WhenControllerThrowsFileNotFound()
     {
@@ -561,6 +578,7 @@ public class ApiHardeningIntegrationTest
         payload.ErrorMessage.Should().Contain("Form metadata was not found");
     }
 
+    // Testzweck: Deckt den Fall „Message Endpoint Should Return API Status Result When No Subscription Matches“ ab.
     [Test]
     public async Task MessageEndpoint_ShouldReturnApiStatusResult_WhenNoSubscriptionMatches()
     {
@@ -582,6 +600,7 @@ public class ApiHardeningIntegrationTest
         payload.ErrorMessage.Should().Contain("No process instance is waiting for a message");
     }
 
+    // Testzweck: Deckt den Fall „Message Endpoint Should Return Not Found When Subscription References Missing Process“ ab.
     [Test]
     public async Task MessageEndpoint_ShouldReturnNotFound_WhenSubscriptionReferencesMissingProcess()
     {
@@ -604,6 +623,7 @@ public class ApiHardeningIntegrationTest
         payload.ErrorMessage.Should().Contain("No process with the id");
     }
 
+    // Testzweck: Deckt den Fall „Message Endpoint Should Return Successful Result Payload When Message Was Handled“ ab.
     [Test]
     public async Task MessageEndpoint_ShouldReturnSuccessfulResultPayload_WhenMessageWasHandled()
     {

--- a/src/WebApiEngine.Tests/FormControllerIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/FormControllerIntegrationTest.cs
@@ -14,6 +14,7 @@ namespace WebApiEngine.Tests;
 
 public class FormControllerIntegrationTest
 {
+    // Testzweck: Deckt den Fall „Save Form Should Create Initial Version When No Version Exists“ ab.
     [Test]
     public async Task SaveForm_ShouldCreateInitialVersion_WhenNoVersionExists()
     {
@@ -43,6 +44,7 @@ public class FormControllerIntegrationTest
             form.Version.Minor == 1);
     }
 
+    // Testzweck: Deckt den Fall „Save Form Should Return Bad Request When Form ID Is Empty“ ab.
     [Test]
     public async Task SaveForm_ShouldReturnBadRequest_WhenFormIdIsEmpty()
     {
@@ -65,6 +67,7 @@ public class FormControllerIntegrationTest
         payload.ErrorMessage.Should().Be("FormId is required");
     }
 
+    // Testzweck: Deckt den Fall „Get Form Should Return Specific Version When Version Identifier Is Provided“ ab.
     [Test]
     public async Task GetForm_ShouldReturnSpecificVersion_WhenVersionIdentifierIsProvided()
     {
@@ -103,6 +106,7 @@ public class FormControllerIntegrationTest
         payload.Result.Version.ToString().Should().Be("1.0");
     }
 
+    // Testzweck: Deckt den Fall „Get Form Should Return Bad Request When Version Identifier Is Invalid“ ab.
     [Test]
     public async Task GetForm_ShouldReturnBadRequest_WhenVersionIdentifierIsInvalid()
     {
@@ -128,6 +132,7 @@ public class FormControllerIntegrationTest
         payload.ErrorMessage.Should().Contain("Version string must have two parts separated by a dot.");
     }
 
+    // Testzweck: Deckt den Fall „Save Form Metadata Should Use Route Form ID When Body Form ID Is Empty“ ab.
     [Test]
     public async Task SaveFormMetadata_ShouldUseRouteFormId_WhenBodyFormIdIsEmpty()
     {

--- a/src/WebApiEngine.Tests/FormStorageTest.cs
+++ b/src/WebApiEngine.Tests/FormStorageTest.cs
@@ -7,6 +7,7 @@ namespace WebApiEngine.Tests;
 [NonParallelizable]
 public class FormStorageTest
 {
+    // Testzweck: Deckt den Fall „Get Max Version Should Return Zero Version When No Forms Exist“ ab.
     [Test]
     public async Task GetMaxVersion_ShouldReturnZeroVersion_WhenNoFormsExist()
     {
@@ -18,6 +19,7 @@ public class FormStorageTest
         version.Minor.Should().Be(0);
     }
 
+    // Testzweck: Deckt den Fall „Update Form Meta Data Should Overwrite Existing Metadata“ ab.
     [Test]
     public async Task UpdateFormMetaData_ShouldOverwriteExistingMetadata()
     {
@@ -30,6 +32,7 @@ public class FormStorageTest
         metadata.Name.Should().Be("Neue Bezeichnung");
     }
 
+    // Testzweck: Deckt den Fall „Delete Form Meta Data Should Delete Metadata And Associated Forms“ ab.
     [Test]
     public async Task DeleteFormMetaData_ShouldDeleteMetadataAndAssociatedForms()
     {
@@ -51,6 +54,7 @@ public class FormStorageTest
         await FluentActions.Awaiting(() => context.FormStorage.GetForm(firstForm.Id)).Should().ThrowAsync<FileNotFoundException>();
     }
 
+    // Testzweck: Deckt den Fall „Delete Form Should Delete Only Requested Version“ ab.
     [Test]
     public async Task DeleteForm_ShouldDeleteOnlyRequestedVersion()
     {

--- a/src/WebApiEngine.Tests/HttpContextCurrentUserContextAccessorTest.cs
+++ b/src/WebApiEngine.Tests/HttpContextCurrentUserContextAccessorTest.cs
@@ -10,6 +10,7 @@ namespace WebApiEngine.Tests;
 [NonParallelizable]
 public class HttpContextCurrentUserContextAccessorTest
 {
+    // Testzweck: Deckt den Fall „Get Current User Should Resolve Name Identifier Claim“ ab.
     [Test]
     public void GetCurrentUser_ShouldResolveNameIdentifierClaim()
     {
@@ -28,6 +29,7 @@ public class HttpContextCurrentUserContextAccessorTest
         currentUser.IsFallback.Should().BeFalse();
     }
 
+    // Testzweck: Deckt den Fall „Get Current User Should Resolve Sub Claim When Name Identifier Is Missing“ ab.
     [Test]
     public void GetCurrentUser_ShouldResolveSubClaim_WhenNameIdentifierIsMissing()
     {
@@ -46,6 +48,7 @@ public class HttpContextCurrentUserContextAccessorTest
         currentUser.IsFallback.Should().BeFalse();
     }
 
+    // Testzweck: Deckt den Fall „Get Current User Should Use Header In Development“ ab.
     [Test]
     public void GetCurrentUser_ShouldUseHeaderInDevelopment()
     {
@@ -61,6 +64,7 @@ public class HttpContextCurrentUserContextAccessorTest
         currentUser.IsFallback.Should().BeFalse();
     }
 
+    // Testzweck: Deckt den Fall „Get Current User Should Ignore Header Outside Development“ ab.
     [Test]
     public void GetCurrentUser_ShouldIgnoreHeaderOutsideDevelopment()
     {

--- a/src/WebApiEngine.Tests/InstanceControllerIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/InstanceControllerIntegrationTest.cs
@@ -15,6 +15,7 @@ namespace WebApiEngine.Tests;
 
 public class InstanceControllerIntegrationTest
 {
+    // Testzweck: Deckt den Fall „Get Signal Subscriptions Should Return Subscriptions For Instance“ ab.
     [Test]
     public async Task GetSignalSubscriptions_ShouldReturnSubscriptionsForInstance()
     {
@@ -42,6 +43,7 @@ public class InstanceControllerIntegrationTest
         payload.Result[0].ProcessInstanceId.Should().Be(instanceId);
     }
 
+    // Testzweck: Deckt den Fall „Get Service Subscriptions Should Return Active Service Task Tokens“ ab.
     [Test]
     public async Task GetServiceSubscriptions_ShouldReturnActiveServiceTaskTokens()
     {
@@ -63,6 +65,7 @@ public class InstanceControllerIntegrationTest
         payload.Result.Should().OnlyContain(token => token.State == FlowNodeStateDto.Active);
     }
 
+    // Testzweck: Deckt den Fall „Get Timer Subscriptions Should Return Timers For Instance“ ab.
     [Test]
     public async Task GetTimerSubscriptions_ShouldReturnTimersForInstance()
     {
@@ -95,6 +98,7 @@ public class InstanceControllerIntegrationTest
         payload.Result[0].Kind.Should().Be(nameof(TimerSubscriptionKind.IntermediateCatchEvent));
     }
 
+    // Testzweck: Deckt den Fall „Get All Instances Should Include Finished Instances For Done And Error Filters“ ab.
     [Test]
     public async Task GetAllInstances_ShouldIncludeFinishedInstances_ForDoneAndErrorFilters()
     {

--- a/src/WebApiEngine.Tests/ManualMappingExtensionsTest.cs
+++ b/src/WebApiEngine.Tests/ManualMappingExtensionsTest.cs
@@ -12,6 +12,7 @@ namespace WebApiEngine.Tests;
 
 public class ManualMappingExtensionsTest
 {
+    // Testzweck: Deckt den Fall „Message DTO To Model Should Serialize Variables As JSON“ ab.
     [Test]
     public void MessageDto_ToModel_ShouldSerializeVariablesAsJson()
     {
@@ -37,6 +38,7 @@ public class ManualMappingExtensionsTest
         result.Variables.Should().Contain("\"Amount\":12");
     }
 
+    // Testzweck: Deckt den Fall „Message To DTO Should Deserialize Variables From JSON“ ab.
     [Test]
     public void Message_ToDto_ShouldDeserializeVariablesFromJson()
     {
@@ -57,6 +59,7 @@ public class ManualMappingExtensionsTest
         result.Variables.GetValue("approved").Should().Be(true);
     }
 
+    // Testzweck: Deckt den Fall „Token To DTO Should Map Runtime Fields Without Auto Mapper“ ab.
     [Test]
     public void Token_ToDto_ShouldMapRuntimeFieldsWithoutAutoMapper()
     {
@@ -125,6 +128,7 @@ public class ManualMappingExtensionsTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Extended User Task Subscription To DTO Should Include Definition And Token Data“ ab.
     [Test]
     public void ExtendedUserTaskSubscription_ToDto_ShouldIncludeDefinitionAndTokenData()
     {
@@ -166,6 +170,7 @@ public class ManualMappingExtensionsTest
         result.UserGroups.Should().BeEquivalentTo(subscription.UserGroups);
     }
 
+    // Testzweck: Deckt den Fall „BPMN Meta Definition DTO To Model And Back Should Preserve Values“ ab.
     [Test]
     public void BpmnMetaDefinitionDto_ToModel_AndBack_ShouldPreserveValues()
     {
@@ -182,6 +187,7 @@ public class ManualMappingExtensionsTest
         roundtrip.Should().BeEquivalentTo(dto);
     }
 
+    // Testzweck: Deckt den Fall „Form DTO To Model And Back Should Preserve Relevant Values“ ab.
     [Test]
     public void FormDto_ToModel_AndBack_ShouldPreserveRelevantValues()
     {
@@ -199,6 +205,7 @@ public class ManualMappingExtensionsTest
         roundtrip.Should().BeEquivalentTo(dto);
     }
 
+    // Testzweck: Deckt den Fall „Form DTO To Model Should Throw When Form Data Is Missing“ ab.
     [Test]
     public void FormDto_ToModel_ShouldThrow_WhenFormDataIsMissing()
     {
@@ -217,6 +224,7 @@ public class ManualMappingExtensionsTest
             .WithMessage("*FormData is required*");
     }
 
+    // Testzweck: Deckt den Fall „Token To DTO Should Use Empty String For Non Flow Node Tokens“ ab.
     [Test]
     public void Token_ToDto_ShouldUseEmptyString_ForNonFlowNodeTokens()
     {

--- a/src/WebApiEngine.Tests/ModelVersionTest.cs
+++ b/src/WebApiEngine.Tests/ModelVersionTest.cs
@@ -4,6 +4,7 @@ namespace WebApiEngine.Tests;
 
 public class ModelVersionTest
 {
+    // Testzweck: Deckt den Fall „Equality Operators Should Compare Major And Minor Values“ ab.
     [Test]
     public void EqualityOperators_ShouldCompareMajorAndMinorValues()
     {
@@ -18,6 +19,7 @@ public class ModelVersionTest
         left.GetHashCode().Should().Be(equalRight.GetHashCode());
     }
 
+    // Testzweck: Deckt den Fall „Plus Operator Should Return New Instance Without Mutating Original Version“ ab.
     [Test]
     public void PlusOperator_ShouldReturnNewInstance_WithoutMutatingOriginalVersion()
     {

--- a/src/WebApiEngine.Tests/StoragePathTest.cs
+++ b/src/WebApiEngine.Tests/StoragePathTest.cs
@@ -6,6 +6,7 @@ namespace WebApiEngine.Tests;
 [NonParallelizable]
 public class StoragePathTest
 {
+    // Testzweck: Deckt den Fall „Get Base Path Should Use Configured Storage Root When Environment Variable Is Set“ ab.
     [Test]
     public void GetBasePath_ShouldUseConfiguredStorageRoot_WhenEnvironmentVariableIsSet()
     {

--- a/src/WebApiEngine.Tests/TimerControllerIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/TimerControllerIntegrationTest.cs
@@ -15,6 +15,7 @@ namespace WebApiEngine.Tests;
 [NonParallelizable]
 public class TimerControllerIntegrationTest
 {
+    // Testzweck: Deckt den Fall „Get All Timers Should Return Definition And Instance Scoped Timer Subscriptions“ ab.
     [Test]
     public async Task GetAllTimers_ShouldReturnDefinitionAndInstanceScopedTimerSubscriptions()
     {

--- a/src/WebApiEngine.Tests/TimerRuntimeIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/TimerRuntimeIntegrationTest.cs
@@ -12,6 +12,7 @@ namespace WebApiEngine.Tests;
 [NonParallelizable]
 public class TimerRuntimeIntegrationTest
 {
+    // Testzweck: Deckt den Fall „Deploy Definition Should Persist Process Start Timer Subscription“ ab.
     [Test]
     public async Task DeployDefinition_ShouldPersistProcessStartTimerSubscription()
     {
@@ -41,6 +42,7 @@ public class TimerRuntimeIntegrationTest
         definition.DeployedOn.Should().NotBeNull();
     }
 
+    // Testzweck: Deckt den Fall „Deploy Definition Should Persist Recurring Process Start Timer Subscription With Remaining Occurrences“ ab.
     [Test]
     public async Task DeployDefinition_ShouldPersistRecurringProcessStartTimerSubscriptionWithRemainingOccurrences()
     {
@@ -58,6 +60,7 @@ public class TimerRuntimeIntegrationTest
         timerSubscription.RemainingOccurrences.Should().Be(3);
     }
 
+    // Testzweck: Deckt den Fall „Handle Time Should Start Due Definition Timer And Remove Start Subscription“ ab.
     [Test]
     public async Task HandleTime_ShouldStartDueDefinitionTimer_AndRemoveStartSubscription()
     {
@@ -78,6 +81,7 @@ public class TimerRuntimeIntegrationTest
         storage.Instances.Values.Single().IsFinished.Should().BeTrue();
     }
 
+    // Testzweck: Deckt den Fall „Handle Time Should Reschedule Recurring Definition Timer After First Trigger“ ab.
     [Test]
     public async Task HandleTime_ShouldRescheduleRecurringDefinitionTimer_AfterFirstTrigger()
     {
@@ -103,6 +107,7 @@ public class TimerRuntimeIntegrationTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Handle Time Should Catch Up Recurring Definition Timer And Keep Next Due Subscription“ ab.
     [Test]
     public async Task HandleTime_ShouldCatchUpRecurringDefinitionTimer_AndKeepNextDueSubscription()
     {
@@ -129,6 +134,7 @@ public class TimerRuntimeIntegrationTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Load Should Recover Overdue Recurring Definition Timer And Keep Next Due Subscription“ ab.
     [Test]
     public async Task Load_ShouldRecoverOverdueRecurringDefinitionTimer_AndKeepNextDueSubscription()
     {
@@ -168,6 +174,7 @@ public class TimerRuntimeIntegrationTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Handle Time Should Recover Legacy Recurring Definition Timer When Remaining Occurrences Were Not Persisted Yet“ ab.
     [Test]
     public async Task HandleTime_ShouldRecoverLegacyRecurringDefinitionTimer_WhenRemainingOccurrencesWereNotPersistedYet()
     {
@@ -206,6 +213,7 @@ public class TimerRuntimeIntegrationTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Handle Time Should Advance Due Instance Timer And Clear Persisted Instance Timer“ ab.
     [Test]
     public async Task HandleTime_ShouldAdvanceDueInstanceTimer_AndClearPersistedInstanceTimer()
     {
@@ -263,6 +271,7 @@ public class TimerRuntimeIntegrationTest
         storage.Instances[instance.InstanceId].IsFinished.Should().BeTrue();
     }
 
+    // Testzweck: Deckt den Fall „Handle Time Should Advance Due Boundary Timer And Clear Persisted Boundary Timer“ ab.
     [Test]
     public async Task HandleTime_ShouldAdvanceDueBoundaryTimer_AndClearPersistedBoundaryTimer()
     {

--- a/src/WebApiEngine.Tests/TimerSubscriptionStorageTest.cs
+++ b/src/WebApiEngine.Tests/TimerSubscriptionStorageTest.cs
@@ -7,6 +7,7 @@ namespace WebApiEngine.Tests;
 [NonParallelizable]
 public class TimerSubscriptionStorageTest
 {
+    // Testzweck: Deckt den Fall „Add And Get Timer Subscriptions Should Persist Definition And Instance Timers“ ab.
     [Test]
     public async Task AddAndGetTimerSubscriptions_ShouldPersistDefinitionAndInstanceTimers()
     {
@@ -38,6 +39,7 @@ public class TimerSubscriptionStorageTest
         instanceTimers.Should().ContainSingle(subscription => subscription.Id == instanceTimer.Id);
     }
 
+    // Testzweck: Deckt den Fall „Remove Operations Should Delete Matching Timer Subscriptions Only“ ab.
     [Test]
     public async Task RemoveOperations_ShouldDeleteMatchingTimerSubscriptionsOnly()
     {

--- a/src/WebApiEngine.Tests/VersionDtoTest.cs
+++ b/src/WebApiEngine.Tests/VersionDtoTest.cs
@@ -5,6 +5,7 @@ namespace WebApiEngine.Tests;
 
 public class VersionDtoTest
 {
+    // Testzweck: Deckt den Fall „Equals And Hash Code Should Treat Same Version Values As Equal“ ab.
     [Test]
     public void EqualsAndHashCode_ShouldTreatSameVersionValuesAsEqual()
     {
@@ -16,6 +17,7 @@ public class VersionDtoTest
         left.GetHashCode().Should().Be(right.GetHashCode());
     }
 
+    // Testzweck: Deckt den Fall „From String Should Parse Valid Version Numbers“ ab.
     [Test]
     public void FromString_ShouldParseValidVersionNumbers()
     {
@@ -24,6 +26,7 @@ public class VersionDtoTest
         result.Should().BeEquivalentTo(new VersionDto(2, 7));
     }
 
+    // Testzweck: Deckt den Fall „From String Should Throw For Invalid Version Strings“ ab.
     [Test]
     public void FromString_ShouldThrowForInvalidVersionStrings()
     {
@@ -32,6 +35,7 @@ public class VersionDtoTest
         action.Should().Throw<ArgumentException>();
     }
 
+    // Testzweck: Deckt den Fall „Shared DTOs Should Expose Safe Defaults For Optional Collections And Metadata“ ab.
     [Test]
     public void SharedDtos_ShouldExposeSafeDefaults_ForOptionalCollectionsAndMetadata()
     {

--- a/src/core-engine-tests/CoreEngineTest.cs
+++ b/src/core-engine-tests/CoreEngineTest.cs
@@ -6,6 +6,7 @@ namespace core_engine_tests;
 
 public class CoreEngineTest
 {
+    // Testzweck: Deckt den Fall „Load BPMN File Should Expose Initial Start Subscription“ ab.
     [Test]
     public async System.Threading.Tasks.Task LoadBpmnFile_ShouldExposeInitialStartSubscription()
     {
@@ -21,6 +22,7 @@ public class CoreEngineTest
         subscriptions[0].BpmnNodeId.Should().Be("StartEvent_1");
     }
 
+    // Testzweck: Deckt den Fall „Load BPMN File Should Expose Message And Signal Subscriptions“ ab.
     [Test]
     public async System.Threading.Tasks.Task LoadBpmnFile_ShouldExposeMessageAndSignalSubscriptions()
     {
@@ -42,6 +44,7 @@ public class CoreEngineTest
             subscription.Name == "InventoryRefresh");
     }
 
+    // Testzweck: Deckt den Fall „Load BPMN File Should Hide Unsupported Plain Start Subscriptions When Multiple Plain Starts Exist“ ab.
     [Test]
     public async System.Threading.Tasks.Task LoadBpmnFile_ShouldHideUnsupportedPlainStartSubscriptions_WhenMultiplePlainStartsExist()
     {
@@ -55,6 +58,7 @@ public class CoreEngineTest
         subscriptions.Should().BeEmpty();
     }
 
+    // Testzweck: Deckt den Fall „Handle Event Should Start Process And Expose User Task“ ab.
     [Test]
     public async System.Threading.Tasks.Task HandleEvent_ShouldStartProcessAndExposeUserTask()
     {
@@ -76,6 +80,7 @@ public class CoreEngineTest
         result.Instance.Interactions[0].NodeId.Should().Be("UserTask_1");
     }
 
+    // Testzweck: Deckt den Fall „Handle Event Should Start Process From Message Subscription“ ab.
     [Test]
     public async System.Threading.Tasks.Task HandleEvent_ShouldStartProcessFromMessageSubscription()
     {
@@ -98,6 +103,7 @@ public class CoreEngineTest
         result.Instance.Interactions[0].NodeId.Should().Be("MessageUserTask_1");
     }
 
+    // Testzweck: Deckt den Fall „Handle Event Should Start Process From Signal Subscription“ ab.
     [Test]
     public async System.Threading.Tasks.Task HandleEvent_ShouldStartProcessFromSignalSubscription()
     {
@@ -120,6 +126,7 @@ public class CoreEngineTest
         result.Instance.Interactions[0].NodeId.Should().Be("SignalUserTask_1");
     }
 
+    // Testzweck: Deckt den Fall „Handle Event Should Advance User Task To Service Task And Then Finish Process“ ab.
     [Test]
     public async System.Threading.Tasks.Task HandleEvent_ShouldAdvanceUserTaskToServiceTask_AndThenFinishProcess()
     {
@@ -164,6 +171,7 @@ public class CoreEngineTest
         finishedSnapshots[^1].State.Should().Be(ProcessInstanceState.Completed);
     }
 
+    // Testzweck: Deckt den Fall „Handle Event Should Allow Restart After Completed Instance Was Cleaned Up“ ab.
     [Test]
     public async System.Threading.Tasks.Task HandleEvent_ShouldAllowRestartAfterCompletedInstanceWasCleanedUp()
     {
@@ -208,6 +216,7 @@ public class CoreEngineTest
         restartedResult.Instance.Interactions[0].NodeId.Should().Be("UserTask_1");
     }
 
+    // Testzweck: Deckt den Fall „Handle Event Should Require Interaction ID When Multiple Active Interactions Share The Same Node“ ab.
     [Test]
     public async System.Threading.Tasks.Task HandleEvent_ShouldRequireInteractionId_WhenMultipleActiveInteractionsShareTheSameNode()
     {
@@ -248,6 +257,7 @@ public class CoreEngineTest
         continueResult.Instance.State.Should().Be(ProcessInstanceState.Completed);
     }
 
+    // Testzweck: Deckt den Fall „Load BPMN File Should Clear State When Reload Fails“ ab.
     [Test]
     public async System.Threading.Tasks.Task LoadBpmnFile_ShouldClearState_WhenReloadFails()
     {

--- a/src/core-engine-tests/DateExpressionTest.cs
+++ b/src/core-engine-tests/DateExpressionTest.cs
@@ -6,79 +6,79 @@ public class DateExpressionTest
 {
     // Testzweck: Prüft das Parsen einer ISO-8601-Dauer mit Jahren, Monaten und Tagen.
     [Test]
-        public void Test_ParseIso8601Duration_YearsMonthsDays()
-        {
-            string isoDuration = "P1Y2M10D";
-            TimeSpan expected = new TimeSpan(1 * 365 + 2 * 30 + 10, 0, 0, 0);
-            TimeSpan actual = DateExtensions.ParseIso8601Duration(isoDuration);
-            Assert.That(actual, Is.EqualTo(expected));
-        }
+    public void Test_ParseIso8601Duration_YearsMonthsDays()
+    {
+        string isoDuration = "P1Y2M10D";
+        TimeSpan expected = new TimeSpan(1 * 365 + 2 * 30 + 10, 0, 0, 0);
+        TimeSpan actual = DateExtensions.ParseIso8601Duration(isoDuration);
+        Assert.That(actual, Is.EqualTo(expected));
+    }
 
-        // Testzweck: Prüft das Parsen einer ISO-8601-Dauer mit Wochenangabe.
-        [Test]
-        public void Test_ParseIso8601Duration_Weeks()
-        {
-            string isoDuration = "P3W";
-            TimeSpan expected = new TimeSpan(3 * 7, 0, 0, 0);
-            TimeSpan actual = DateExtensions.ParseIso8601Duration(isoDuration);
-            Assert.That(actual, Is.EqualTo(expected));
-        }
+    // Testzweck: Prüft das Parsen einer ISO-8601-Dauer mit Wochenangabe.
+    [Test]
+    public void Test_ParseIso8601Duration_Weeks()
+    {
+        string isoDuration = "P3W";
+        TimeSpan expected = new TimeSpan(3 * 7, 0, 0, 0);
+        TimeSpan actual = DateExtensions.ParseIso8601Duration(isoDuration);
+        Assert.That(actual, Is.EqualTo(expected));
+    }
 
-        // Testzweck: Prüft das Parsen einer ISO-8601-Dauer mit Tages- und Zeitanteilen.
-        [Test]
-        public void Test_ParseIso8601Duration_DaysHoursMinutesSeconds()
-        {
-            string isoDuration = "P10DT2H30M15S";
-            TimeSpan expected = new TimeSpan(10, 2, 30, 15);
-            TimeSpan actual = DateExtensions.ParseIso8601Duration(isoDuration);
-            Assert.That(actual, Is.EqualTo(expected));
-        }
+    // Testzweck: Prüft das Parsen einer ISO-8601-Dauer mit Tages- und Zeitanteilen.
+    [Test]
+    public void Test_ParseIso8601Duration_DaysHoursMinutesSeconds()
+    {
+        string isoDuration = "P10DT2H30M15S";
+        TimeSpan expected = new TimeSpan(10, 2, 30, 15);
+        TimeSpan actual = DateExtensions.ParseIso8601Duration(isoDuration);
+        Assert.That(actual, Is.EqualTo(expected));
+    }
 
-        // Testzweck: Prüft das Parsen einer ISO-8601-Dauer mit Stunden und Minuten.
-        [Test]
-        public void Test_ParseIso8601Duration_HoursMinutes()
-        {
-            string isoDuration = "PT2H30M";
-            TimeSpan expected = new TimeSpan(0, 2, 30, 0);
-            TimeSpan actual = DateExtensions.ParseIso8601Duration(isoDuration);
-            Assert.That(actual, Is.EqualTo(expected));
-        }
+    // Testzweck: Prüft das Parsen einer ISO-8601-Dauer mit Stunden und Minuten.
+    [Test]
+    public void Test_ParseIso8601Duration_HoursMinutes()
+    {
+        string isoDuration = "PT2H30M";
+        TimeSpan expected = new TimeSpan(0, 2, 30, 0);
+        TimeSpan actual = DateExtensions.ParseIso8601Duration(isoDuration);
+        Assert.That(actual, Is.EqualTo(expected));
+    }
 
-        // Testzweck: Prüft, dass eine leere ISO-8601-Dauer korrekt als Null-Dauer behandelt wird.
-        [Test]
-        public void Test_ParseIso8601Duration_Empty()
-        {
-            string isoDuration = "P";
-            TimeSpan expected = TimeSpan.Zero;
-            TimeSpan actual = DateExtensions.ParseIso8601Duration(isoDuration);
-            Assert.That(actual, Is.EqualTo(expected));
-        }
+    // Testzweck: Prüft, dass eine leere ISO-8601-Dauer korrekt als Null-Dauer behandelt wird.
+    [Test]
+    public void Test_ParseIso8601Duration_Empty()
+    {
+        string isoDuration = "P";
+        TimeSpan expected = TimeSpan.Zero;
+        TimeSpan actual = DateExtensions.ParseIso8601Duration(isoDuration);
+        Assert.That(actual, Is.EqualTo(expected));
+    }
 
-        // Testzweck: Prüft das Parsen einer ISO-8601-Dauer mit reinem Zeitanteil.
-        [Test]
-        public void Test_ParseIso8601Duration_OnlyTime()
-        {
-            string isoDuration = "PT30M";
-            TimeSpan expected = new TimeSpan(0, 0, 30, 0);
-            TimeSpan actual = DateExtensions.ParseIso8601Duration(isoDuration);
-            Assert.That(actual, Is.EqualTo(expected));
-        }
+    // Testzweck: Prüft das Parsen einer ISO-8601-Dauer mit reinem Zeitanteil.
+    [Test]
+    public void Test_ParseIso8601Duration_OnlyTime()
+    {
+        string isoDuration = "PT30M";
+        TimeSpan expected = new TimeSpan(0, 0, 30, 0);
+        TimeSpan actual = DateExtensions.ParseIso8601Duration(isoDuration);
+        Assert.That(actual, Is.EqualTo(expected));
+    }
 
-        // Testzweck: Prüft das Parsen einer ISO-8601-Dauer mit reinem Datumsanteil.
-        [Test]
-        public void Test_ParseIso8601Duration_OnlyDate()
-        {
-            string isoDuration = "P1Y2M";
-            TimeSpan expected = new TimeSpan(1 * 365 + 2 * 30, 0, 0, 0);
-            TimeSpan actual = DateExtensions.ParseIso8601Duration(isoDuration);
-            Assert.That(actual, Is.EqualTo(expected));
-        }
+    // Testzweck: Prüft das Parsen einer ISO-8601-Dauer mit reinem Datumsanteil.
+    [Test]
+    public void Test_ParseIso8601Duration_OnlyDate()
+    {
+        string isoDuration = "P1Y2M";
+        TimeSpan expected = new TimeSpan(1 * 365 + 2 * 30, 0, 0, 0);
+        TimeSpan actual = DateExtensions.ParseIso8601Duration(isoDuration);
+        Assert.That(actual, Is.EqualTo(expected));
+    }
 
-        // Testzweck: Prüft, dass ein ungültiges ISO-8601-Format sauber abgelehnt wird.
-        [Test]
-        public void Test_ParseIso8601Duration_InvalidFormat()
-        {
-            string isoDuration = "InvalidFormat";
-            Assert.Throws<ArgumentException>(() => DateExtensions.ParseIso8601Duration(isoDuration));
-        }
+    // Testzweck: Prüft, dass ein ungültiges ISO-8601-Format sauber abgelehnt wird.
+    [Test]
+    public void Test_ParseIso8601Duration_InvalidFormat()
+    {
+        string isoDuration = "InvalidFormat";
+        Assert.Throws<ArgumentException>(() => DateExtensions.ParseIso8601Duration(isoDuration));
+    }
 }

--- a/src/core-engine-tests/DateExpressionTest.cs
+++ b/src/core-engine-tests/DateExpressionTest.cs
@@ -4,6 +4,7 @@ namespace core_engine_tests;
 
 public class DateExpressionTest
 {
+    // Testzweck: Prüft das Parsen einer ISO-8601-Dauer mit Jahren, Monaten und Tagen.
     [Test]
         public void Test_ParseIso8601Duration_YearsMonthsDays()
         {
@@ -13,6 +14,7 @@ public class DateExpressionTest
             Assert.That(actual, Is.EqualTo(expected));
         }
 
+        // Testzweck: Prüft das Parsen einer ISO-8601-Dauer mit Wochenangabe.
         [Test]
         public void Test_ParseIso8601Duration_Weeks()
         {
@@ -22,6 +24,7 @@ public class DateExpressionTest
             Assert.That(actual, Is.EqualTo(expected));
         }
 
+        // Testzweck: Prüft das Parsen einer ISO-8601-Dauer mit Tages- und Zeitanteilen.
         [Test]
         public void Test_ParseIso8601Duration_DaysHoursMinutesSeconds()
         {
@@ -31,6 +34,7 @@ public class DateExpressionTest
             Assert.That(actual, Is.EqualTo(expected));
         }
 
+        // Testzweck: Prüft das Parsen einer ISO-8601-Dauer mit Stunden und Minuten.
         [Test]
         public void Test_ParseIso8601Duration_HoursMinutes()
         {
@@ -40,6 +44,7 @@ public class DateExpressionTest
             Assert.That(actual, Is.EqualTo(expected));
         }
 
+        // Testzweck: Prüft, dass eine leere ISO-8601-Dauer korrekt als Null-Dauer behandelt wird.
         [Test]
         public void Test_ParseIso8601Duration_Empty()
         {
@@ -49,6 +54,7 @@ public class DateExpressionTest
             Assert.That(actual, Is.EqualTo(expected));
         }
 
+        // Testzweck: Prüft das Parsen einer ISO-8601-Dauer mit reinem Zeitanteil.
         [Test]
         public void Test_ParseIso8601Duration_OnlyTime()
         {
@@ -58,6 +64,7 @@ public class DateExpressionTest
             Assert.That(actual, Is.EqualTo(expected));
         }
 
+        // Testzweck: Prüft das Parsen einer ISO-8601-Dauer mit reinem Datumsanteil.
         [Test]
         public void Test_ParseIso8601Duration_OnlyDate()
         {
@@ -67,6 +74,7 @@ public class DateExpressionTest
             Assert.That(actual, Is.EqualTo(expected));
         }
 
+        // Testzweck: Prüft, dass ein ungültiges ISO-8601-Format sauber abgelehnt wird.
         [Test]
         public void Test_ParseIso8601Duration_InvalidFormat()
         {

--- a/src/core-engine-tests/DemoScenarioRunnerTest.cs
+++ b/src/core-engine-tests/DemoScenarioRunnerTest.cs
@@ -6,6 +6,7 @@ namespace core_engine_tests;
 
 public class DemoScenarioRunnerTest
 {
+    // Testzweck: Deckt den Fall „Run Async Should Execute The Documented Happy Path“ ab.
     [Test]
     public async System.Threading.Tasks.Task RunAsync_ShouldExecuteTheDocumentedHappyPath()
     {

--- a/src/core-engine-tests/EngineTest.cs
+++ b/src/core-engine-tests/EngineTest.cs
@@ -12,6 +12,7 @@ namespace core_engine_tests;
 
 public class EngineTest
 {
+    // Testzweck: Prüft den einfachen Start-/ServiceTask-/Ende-Happy-Path inklusive Variablenrückgabe.
     [Test]
     public async Task StartStopWithVariables()
     {
@@ -41,6 +42,7 @@ public class EngineTest
         }
     }
 
+    // Testzweck: Prüft Input-/Output-Mappings zwischen Token-Variablen und Prozessvariablen.
     [Test]
     public async Task VariableMappingTest()
     {
@@ -66,6 +68,7 @@ public class EngineTest
     }
 
 
+    // Testzweck: Prüft, dass bedingte Sequenzflüsse nur den erwarteten Zielpfad aktivieren.
     [Test]
     public async Task ConditionalSequenceFlowTest()
     {
@@ -79,6 +82,7 @@ public class EngineTest
         }
     }
 
+    // Testzweck: Prüft das Zusammenführen eines einfachen parallelen Gateway-Pfads.
     [Test]
     public async Task ParallelGatewayTest()
     {
@@ -93,6 +97,7 @@ public class EngineTest
     }
 
 
+    // Testzweck: Prüft ein komplexeres Parallel-Gateway-Szenario mit mehreren Join-Zuständen.
     [Test]
     public async Task ParallelGatewayComplexTest()
     {
@@ -143,6 +148,7 @@ public class EngineTest
         }
     }
 
+    // Testzweck: Prüft, dass ein exklusives Gateway genau den erwarteten Pfad auswählt.
     [Test]
     public async Task ExklusiveGatewayTest()
     {
@@ -157,6 +163,7 @@ public class EngineTest
         });
     }
 
+    // Testzweck: Prüft den Unterschied zwischen normalem Endereignis und Terminate-End-Event.
     [Test]
     public async Task TerminateEndEventTest()
     {
@@ -180,6 +187,7 @@ public class EngineTest
         });
     }
 
+    // Testzweck: Deckt den Fall „Handle Error Should Fail Instance Without Throwing Not Implemented Exception“ ab.
     [Test]
     public async Task HandleError_ShouldFailInstanceWithoutThrowingNotImplementedException()
     {
@@ -198,6 +206,7 @@ public class EngineTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Handle Escalation Should Fail Instance Without Throwing Not Implemented Exception“ ab.
     [Test]
     public async Task HandleEscalation_ShouldFailInstanceWithoutThrowingNotImplementedException()
     {
@@ -216,6 +225,7 @@ public class EngineTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Handle Error On Completed Instance Should Keep Completed State“ ab.
     [Test]
     public async Task HandleError_OnCompletedInstance_ShouldKeepCompletedState()
     {
@@ -242,6 +252,7 @@ public class EngineTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Handle Escalation On Completed Instance Should Keep Completed State“ ab.
     [Test]
     public async Task HandleEscalation_OnCompletedInstance_ShouldKeepCompletedState()
     {
@@ -268,6 +279,7 @@ public class EngineTest
         }
     }
 
+    // Testzweck: Prüft parallele Multi-Instance-Ausführung inklusive Ergebnisaggregation und Reihenfolge.
     [Test]
     public async Task ParallelTaskTest()
     {
@@ -334,6 +346,7 @@ public class EngineTest
         // });
     }
 
+    // Testzweck: Prüft sequentielle Multi-Instance-Ausführung inklusive Ergebnisaggregation.
     [Test]
     public async Task SequentialTest()
     {
@@ -387,6 +400,7 @@ public class EngineTest
         }
     }
 
+    // Testzweck: Prüft Multi-Instance-Ausführung mit Completion Condition und vorzeitigem Abschluss.
     [Test]
     public async Task ParallelTaskWithCompletionConditionTest()
     {
@@ -432,6 +446,7 @@ public class EngineTest
         
     }
     
+    // Testzweck: Prüft, dass ein einfacher Timer-Start eine plausible Fälligkeit und Wiederholungszahl liefert.
     [Test]
     public async Task SimpleTimerTest()
     {
@@ -451,6 +466,7 @@ public class EngineTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Timer Start Event Should Start Process When Due“ ab.
     [Test]
     public void TimerStartEvent_ShouldStartProcessWhenDue()
     {
@@ -499,6 +515,7 @@ public class EngineTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Recurring Timer Start Event Should Reschedule After First Trigger“ ab.
     [Test]
     public void RecurringTimerStartEvent_ShouldRescheduleAfterFirstTrigger()
     {
@@ -518,6 +535,7 @@ public class EngineTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Recurring Timer Start Event Should Catch Up Missed Occurrences And Keep Next Due Date“ ab.
     [Test]
     public void RecurringTimerStartEvent_ShouldCatchUpMissedOccurrencesAndKeepNextDueDate()
     {
@@ -537,6 +555,7 @@ public class EngineTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Recurring Timer Start Event Should Reject Non Positive Repeat Intervals“ ab.
     [Test]
     public void RecurringTimerStartEvent_ShouldRejectNonPositiveRepeatIntervals()
     {
@@ -566,6 +585,7 @@ public class EngineTest
             .WithMessage("*positive ISO-8601 duration interval*");
     }
 
+    // Testzweck: Deckt den Fall „Intermediate Timer Catch Event Should Stay Active And Expose Due Date“ ab.
     [Test]
     public void IntermediateTimerCatchEvent_ShouldStayActiveAndExposeDueDate()
     {
@@ -610,6 +630,7 @@ public class EngineTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Intermediate Timer Catch Event Should Continue When Due“ ab.
     [Test]
     public void IntermediateTimerCatchEvent_ShouldContinueWhenDue()
     {
@@ -652,6 +673,7 @@ public class EngineTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Boundary Timer Event Should Interrupt Activity And Complete Boundary Path When Due“ ab.
     [Test]
     public void BoundaryTimerEvent_ShouldInterruptActivityAndCompleteBoundaryPathWhenDue()
     {
@@ -688,6 +710,7 @@ public class EngineTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Boundary Timer Event Should Trigger Only Once For Non Interrupting Boundary Timer“ ab.
     [Test]
     public void BoundaryTimerEvent_ShouldTriggerOnlyOnceForNonInterruptingBoundaryTimer()
     {
@@ -739,6 +762,7 @@ public class EngineTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Cancel Should Terminate Waiting Instance And Clear Active Tasks“ ab.
     [Test]
     public void Cancel_ShouldTerminateWaitingInstanceAndClearActiveTasks()
     {
@@ -785,6 +809,7 @@ public class EngineTest
         }
     }
     
+    // Testzweck: Prüft die Ausführung mehrerer Subprozess-Ebenen innerhalb derselben Instanz.
     [Test]
     public async Task SubProcessTest()
     {

--- a/src/core-engine-tests/ExpandoHelperTest.cs
+++ b/src/core-engine-tests/ExpandoHelperTest.cs
@@ -4,6 +4,7 @@ namespace core_engine_tests;
 
 public class ExpandoHelperTest
 {
+    // Testzweck: Prüft die Umwandlung eines verschachtelten Objekts in eine dynamische Struktur.
     [Test]
     public void ToDynamicTest()
     {
@@ -18,6 +19,7 @@ public class ExpandoHelperTest
         Assert.That(dynamicOrder.GetValue("Address.Firstname"), Is.EqualTo("Lukas"));
     }
     
+    // Testzweck: Prüft das Lesen und Schreiben verschachtelter Werte in dynamischen Variablenstrukturen.
     [Test]
     public void GetSetTest()
     {
@@ -27,6 +29,7 @@ public class ExpandoHelperTest
         Assert.That(dynamicOrder.GetValue("Address.Firstname"), Is.EqualTo("Berlin"));
     }
     
+    // Testzweck: Prüft, dass neue Eigenschaften in einer dynamischen Struktur angelegt werden können.
     [Test]
     public void AddPropertyTest()
     {

--- a/src/core-engine-tests/InstanceEngineOutputMappingTest.cs
+++ b/src/core-engine-tests/InstanceEngineOutputMappingTest.cs
@@ -12,6 +12,7 @@ namespace core_engine_tests;
 
 public class InstanceEngineOutputMappingTest
 {
+    // Testzweck: Deckt den Fall „Prepare Output Data Should Initialize Sub Process Variables For Multi Instance Propagation“ ab.
     [Test]
     public void PrepareOutputData_ShouldInitializeSubProcessVariablesForMultiInstancePropagation()
     {
@@ -26,6 +27,7 @@ public class InstanceEngineOutputMappingTest
         ((List<object?>?)subProcessToken.Variables!.GetValue("MitarbeiterOut")).Should().BeEquivalentTo(outputCollection);
     }
 
+    // Testzweck: Deckt den Fall „Prepare Output Data Should Apply Output Mappings For Multi Instance Tokens“ ab.
     [Test]
     public void PrepareOutputData_ShouldApplyOutputMappingsForMultiInstanceTokens()
     {
@@ -45,6 +47,7 @@ public class InstanceEngineOutputMappingTest
             .BeEquivalentTo(outputCollection);
     }
 
+    // Testzweck: Deckt den Fall „Get Correct Variables Token Should Throw Helpful Exception When Parent Scope Is Requested Without Parent“ ab.
     [Test]
     public void GetCorrectVariablesToken_ShouldThrowHelpfulException_WhenParentScopeIsRequestedWithoutParent()
     {

--- a/src/core-engine-tests/JavaScriptExpressionTest.cs
+++ b/src/core-engine-tests/JavaScriptExpressionTest.cs
@@ -9,6 +9,7 @@ namespace core_engine_tests;
 
 public class JavaScriptExpressionTest
 {
+    // Testzweck: Prüft den minimalen JavaScript-/Dynamic-Grundfall für die Testumgebung.
     [Test]
     public void JavaScriptTest1()
     {
@@ -16,6 +17,7 @@ public class JavaScriptExpressionTest
         globals.TryAdd("a", "fghjk");
     }
 
+    // Testzweck: Deckt den Fall „Is Missing V8 Dependency Should Return True For Type Load Exception“ ab.
     [Test]
     public void IsMissingV8Dependency_ShouldReturnTrueForTypeLoadException()
     {
@@ -26,6 +28,7 @@ public class JavaScriptExpressionTest
         shouldIgnore.Should().BeTrue();
     }
 
+    // Testzweck: Deckt den Fall „Is Missing V8 Dependency Should Return True For Nested Dll Not Found Exception“ ab.
     [Test]
     public void IsMissingV8Dependency_ShouldReturnTrueForNestedDllNotFoundException()
     {
@@ -38,6 +41,7 @@ public class JavaScriptExpressionTest
         shouldIgnore.Should().BeTrue();
     }
 
+    // Testzweck: Deckt den Fall „Is Missing V8 Dependency Should Return False For Other Exceptions“ ab.
     [Test]
     public void IsMissingV8Dependency_ShouldReturnFalseForOtherExceptions()
     {
@@ -48,6 +52,7 @@ public class JavaScriptExpressionTest
         shouldIgnore.Should().BeFalse();
     }
 
+    // Testzweck: Prüft die FEEL-Auswertung über ClearScript/V8, sofern die nativen Abhängigkeiten vorhanden sind.
     [Test]
     public void JavaScriptFeelTest()
     {

--- a/src/core-engine-tests/MessageTest.cs
+++ b/src/core-engine-tests/MessageTest.cs
@@ -12,6 +12,7 @@ public class MessageTest
     private static Definitions Definitions { get; } = ModelParser.ParseModel(File.OpenRead("embeddings/Messages.bpmn")).GetAwaiter().GetResult();
     private Process Process { get; } = Definitions.GetProcesses().First();
     
+    // Testzweck: Prüft den vollständigen Nachrichtenfluss mit Boundary-, Receive- und Intermediate-Message-Ereignissen.
     [Test]
     public void Flow1Test()
     {
@@ -76,6 +77,7 @@ public class MessageTest
         }
     }
 
+    // Testzweck: Prüft, dass ein Message-Start-Event direkt eine neue Instanz bis zum Abschluss auslösen kann.
     [Test]
     public void Flow2Test()
     {

--- a/src/core-engine-tests/ModelParserTest.cs
+++ b/src/core-engine-tests/ModelParserTest.cs
@@ -13,6 +13,7 @@ namespace core_engine_tests;
 
 public class ModelParserTest
 {
+    // Testzweck: Prüft, dass der Parser die zentrale Beispiel-BPMN mit allen erwarteten Flow-Node-Typen einliest.
     [Test]
     public async Task ReadProcessesTest()
     {
@@ -55,6 +56,7 @@ public class ModelParserTest
             "Der Hashcode des Processes muss bei mehrmaligem Aufruf gleich bleiben");
     }
 
+    // Testzweck: Prüft, dass Subprozesse, verschachtelte Subprozesse und Call Activities korrekt geparst werden.
     [Test]
     public async Task SubprocessParseTest()
     {
@@ -74,6 +76,7 @@ public class ModelParserTest
         process.FlowElements.OfType<SubProcess>().Count(p => p.LoopCharacteristics != null).Should().Be(1);
     }
 
+    // Testzweck: Deckt den Fall „Parse Model Should Only Return Executable Processes“ ab.
     [Test]
     public async Task ParseModel_ShouldOnlyReturnExecutableProcesses()
     {
@@ -105,6 +108,7 @@ public class ModelParserTest
             .Be("ExecutableProcess");
     }
 
+    // Testzweck: Deckt den Fall „Parse Model Should Parse Boundary Timer Event“ ab.
     [Test]
     public void ParseModel_ShouldParseBoundaryTimerEvent()
     {

--- a/src/core-engine-tests/SignalTest.cs
+++ b/src/core-engine-tests/SignalTest.cs
@@ -13,6 +13,7 @@ public class SignalTest
 
     private Process Process { get; } = Definitions.GetProcesses().First();
 
+    // Testzweck: Prüft den Signalfluss mit Start- und Intermediate-Signal-Ereignis innerhalb derselben Instanz.
     [Test]
     public void Flow1Test()
     {
@@ -31,6 +32,7 @@ public class SignalTest
         }
     }
 
+    // Testzweck: Prüft, dass ein Signalstart mehrere Instanzen mit unterschiedlichen Pfaden auslösen kann.
     [Test]
     public void Flow2Test()
     {

--- a/src/core-engine-tests/SimpleExpressionHandlerTest.cs
+++ b/src/core-engine-tests/SimpleExpressionHandlerTest.cs
@@ -10,6 +10,7 @@ public class SimpleExpressionHandlerTest
 {
     private readonly SimpleExpressionHandler _handler = new();
 
+    // Testzweck: Deckt den Fall „Get Value Should Resolve Numeric Literal“ ab.
     [Test]
     public void GetValue_ShouldResolveNumericLiteral()
     {
@@ -18,6 +19,7 @@ public class SimpleExpressionHandlerTest
         result.Should().Be(12345);
     }
 
+    // Testzweck: Deckt den Fall „Get Value Should Parse JSON Object And Array Payloads“ ab.
     [Test]
     public void GetValue_ShouldParseJsonObjectAndArrayPayloads()
     {
@@ -35,6 +37,7 @@ public class SimpleExpressionHandlerTest
         tags[1].GetValue("Index").Should().Be(2L);
     }
 
+    // Testzweck: Deckt den Fall „Match Expression Should Compare Nested Properties“ ab.
     [Test]
     public void MatchExpression_ShouldCompareNestedProperties()
     {
@@ -54,6 +57,7 @@ public class SimpleExpressionHandlerTest
         matches.Should().BeTrue();
     }
 
+    // Testzweck: Deckt den Fall „Match Expression Should Evaluate Boolean Comparisons“ ab.
     [Test]
     public void MatchExpression_ShouldEvaluateBooleanComparisons()
     {
@@ -70,6 +74,7 @@ public class SimpleExpressionHandlerTest
         matches.Should().BeTrue();
     }
 
+    // Testzweck: Deckt den Fall „Get Value Should Parse Decimal Literals Culture Invariant“ ab.
     [Test]
     public void GetValue_ShouldParseDecimalLiteralsCultureInvariant()
     {
@@ -93,6 +98,7 @@ public class SimpleExpressionHandlerTest
         }
     }
 
+    // Testzweck: Deckt den Fall „Create Default Should Fallback To Simple Expression Handler When Clear Script Is Unavailable“ ab.
     [Test]
     public void CreateDefault_ShouldFallbackToSimpleExpressionHandler_WhenClearScriptIsUnavailable()
     {
@@ -101,6 +107,7 @@ public class SimpleExpressionHandlerTest
         config.ExpressionHandler.Should().BeOfType<SimpleExpressionHandler>();
     }
 
+    // Testzweck: Deckt den Fall „Create Default Should Keep Custom Expression Handler When Factory Succeeds“ ab.
     [Test]
     public void CreateDefault_ShouldKeepCustomExpressionHandler_WhenFactorySucceeds()
     {

--- a/tests/ui-smoke/tests/core-paths.spec.js
+++ b/tests/ui-smoke/tests/core-paths.spec.js
@@ -90,6 +90,7 @@ async function ensureModelerScenario(request) {
   return modelerScenarioPromise;
 }
 
+// Testzweck: Prüft, dass ein per API angelegtes Formular in Liste und Detailansicht des Frontends stabil geladen wird.
 test('Formulare aus der API erscheinen in Liste und Detailansicht', async ({ page, request }) => {
   const formName = createSuffix('ui-smoke-form');
   const { formId } = await saveForm(request, {
@@ -110,6 +111,7 @@ test('Formulare aus der API erscheinen in Liste und Detailansicht', async ({ pag
   await expect(page.locator('#blazor-error-ui')).toBeHidden();
 });
 
+// Testzweck: Prüft, dass bereitgestellte Modelle im Frontend sichtbar sind und der Diagramm-/Property-Panel-Pfad ohne UI-Fehler lädt.
 test('Bereitgestellte Modelle erscheinen im Frontend und öffnen den Diagrammzugriff', async ({ page, request }) => {
   const modelerScenario = await ensureModelerScenario(request);
   const { definitionId, modelName } = modelerScenario;
@@ -130,6 +132,7 @@ test('Bereitgestellte Modelle erscheinen im Frontend und öffnen den Diagrammzug
   await expect(page.locator('#definition-load-error')).toHaveCount(0);
 });
 
+// Testzweck: Prüft, dass der Modeler beim Speichern eine neue Version erzeugt und die Route auf die neue Definitions-GUID umstellt.
 test('Der Modeler speichert mit Versionsbezug und aktualisiert die Definitionsroute', async ({ page, request }) => {
   const modelerScenario = await ensureModelerScenario(request);
   const { definitionId, definitionGuid } = modelerScenario;
@@ -164,6 +167,7 @@ test('Der Modeler speichert mit Versionsbezug und aktualisiert die Definitionsro
   await expect(page.locator('#definition-load-error')).toHaveCount(0);
 });
 
+// Testzweck: Prüft den UI-Happy-Path von Message-Start über offenen User-Task bis zur abgeschlossenen Instanzansicht.
 test('Message-Start-Prozess wandert von offenem Task zu Done Instances', async ({ page, request }) => {
   const runtimeScenario = await ensureRuntimeScenario(request);
   const { modelName, messageName } = runtimeScenario;

--- a/tests/ui-smoke/tests/navigation.spec.js
+++ b/tests/ui-smoke/tests/navigation.spec.js
@@ -44,6 +44,7 @@ const smokePages = [
 ];
 
 for (const smokePage of smokePages) {
+  // Testzweck: Prüft für jede Kernroute, dass die Seite ohne fatale Frontend-Fehler lädt und ihre Grundelemente sichtbar sind.
   test(`${smokePage.path} lädt ohne fatale UI-Fehler`, async ({ page }) => {
     const pageErrors = [];
     const failedRequests = [];
@@ -61,6 +62,7 @@ for (const smokePage of smokePages) {
   });
 }
 
+// Testzweck: Prüft, dass die Hauptnavigation zwischen den wichtigsten Kernseiten korrekt routet.
 test('Hauptnavigation springt zwischen den Kernseiten', async ({ page }) => {
   await page.goto('/', { waitUntil: 'networkidle' });
 
@@ -77,6 +79,7 @@ test('Hauptnavigation springt zwischen den Kernseiten', async ({ page }) => {
   await expect(page.getByRole('heading', { level: 1, name: 'Instances' })).toBeVisible();
 });
 
+// Testzweck: Prüft, dass die Instanzfilter-Navigation ausschließlich auf gültige Frontend-Routen verzweigt.
 test('Instanzfilter-Navigation bleibt innerhalb gültiger Frontend-Routen', async ({ page }) => {
   await page.goto('/instances', { waitUntil: 'networkidle' });
 
@@ -98,6 +101,7 @@ test('Instanzfilter-Navigation bleibt innerhalb gültiger Frontend-Routen', asyn
 });
 
 
+// Testzweck: Prüft, dass ungültige Modellrouten kontrolliert einen Inline-Fehler statt eines fatalen Blazor-Absturzes zeigen.
 test('Ungültige Modellrouten zeigen einen Inline-Fehler statt eines fatalen Blazor-Absturzes', async ({ page }) => {
   const pageErrors = [];
 


### PR DESCRIPTION
## Zusammenfassung

Dieses PR setzt den nächsten Qualitäts-Schritt nach der Revitalisierung um:

- dokumentierter **Schlachtplan** als GitHub-Issue-Backlog und Repo-Audit
- kurzer **Testzweck-Kommentar für jede bestehende `[Test]`-Methode**
- Leitlinien ergänzt, damit diese Test-Kommentierung künftig erhalten bleibt

## Was wurde umgesetzt?

### 1. Audit und Folgeplan dokumentiert
- neues Audit-Dokument: `docs/CODEBASE-AUDIT-2026-04.md`
- README um den Audit-Verweis ergänzt
- Folge-Backlog über die neuen Issues strukturiert:
  - #93 Runtime-Semantik weiter schließen
  - #94 Auth-/Claim-/Rollenmodell härten
  - #95 Operations-/Deployment-/Recovery-Story ausbauen
  - #96 Codehygiene und Struktur bereinigen
  - #97 Testsuite dokumentieren und aufräumen
  - #98 übergreifender Schlachtplan

### 2. Testsuite verständlicher gemacht
- allen bestehenden `[Test]`-Methoden in
  - `src/core-engine-tests`
  - `src/WebApiEngine.Tests`
  - `src/FlowzerFrontend.Tests`
  wurde ein kurzer Kommentar im Format `// Testzweck: ...` spendiert
- aktueller Stand dabei:
  - `166` Tests
  - `166` Testzweck-Kommentare

### 3. Regeln für neue Tests festgeschrieben
- `DEVELOPMENT-GUIDELINES.md` ergänzt
- `AGENTS.md` ergänzt
- `.github/copilot-instructions.md` ergänzt

## Validierung

```bash
dotnet build core-engine.sln --configuration Release
dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'
dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'
dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'
```

## Verknüpfte Issues
- Closes #97
- Relates to #98
