### PR TITLE
Reduziert generische Exceptions in Frontend, Storage und Engine

### DIFF
--- a/src/FilesystemStorageSystem/DefinitionStorage.cs
+++ b/src/FilesystemStorageSystem/DefinitionStorage.cs
@@ -1,10 +1,14 @@
 using Model;
 using Newtonsoft.Json;
 using StorageSystem;
+using FilesystemStorageSystem.Exceptions;
 using Version = Model.Version;
 
 namespace FilesystemStorageSystem;
 
+/// <summary>
+/// Persistiert BPMN-Definitionen, Binärinhalte und Metadaten dateibasiert unterhalb des konfigurierten Storage-Roots.
+/// </summary>
 public class DefinitionStorage : IDefinitionStorage
 {
     private readonly string _binaryBasePath;
@@ -24,13 +28,13 @@ public class DefinitionStorage : IDefinitionStorage
 
     public async Task StoreBinary(Guid guid, string data)
     {
-        var fullFileName = Path.Combine(_binaryBasePath, $"{guid}.json");
+        var fullFileName = GetBinaryPath(guid);
         await File.WriteAllTextAsync(fullFileName, data);
     }
 
     public Task<string> GetBinary(Guid guid)
     {
-        var fullFileName = Path.Combine(_binaryBasePath, $"{guid}.json");
+        var fullFileName = GetBinaryPath(guid);
         return File.ReadAllTextAsync(fullFileName);
     }
 
@@ -46,6 +50,7 @@ public class DefinitionStorage : IDefinitionStorage
 
     public Task<BpmnDefinition[]> GetAllDefinitions()
     {
+        EnsureDirectoryExists(_basePath);
         var definitions = new List<BpmnDefinition>();
         foreach (var file in Directory.GetFiles(_basePath, "*.json"))
         {
@@ -57,7 +62,7 @@ public class DefinitionStorage : IDefinitionStorage
 
     public Task StoreDefinition(BpmnDefinition definition)
     {
-        var fullFileName = Path.Combine(_basePath, $"{definition.Id}.json");
+        var fullFileName = GetDefinitionPath(definition.Id);
         var data = JsonConvert.SerializeObject(definition,  _storage.NewtonSoftDefaultSettings);
         return File.WriteAllTextAsync(fullFileName, data);
     }
@@ -102,10 +107,10 @@ public class DefinitionStorage : IDefinitionStorage
 
     public Task StoreMetaDefinition(BpmnMetaDefinition metaDefinition)
     {
-        var fullFileName = Path.Combine(_metabasePath, $"{metaDefinition.DefinitionId}.json");
+        var fullFileName = GetMetaDefinitionPath(metaDefinition.DefinitionId);
         if (File.Exists(fullFileName))
         {
-            throw new Exception($"Meta definition already exists for definitionId {metaDefinition.DefinitionId}");
+            throw new DefinitionStorageConflictException($"Meta definition already exists for definitionId {metaDefinition.DefinitionId}");
         }
         var data = JsonConvert.SerializeObject(metaDefinition, _storage.NewtonSoftDefaultSettings);
         return File.WriteAllTextAsync(fullFileName, data);
@@ -113,10 +118,10 @@ public class DefinitionStorage : IDefinitionStorage
 
     public Task UpdateMetaDefinition(BpmnMetaDefinition metaDefinition)
     {
-        var fullFileName = Path.Combine(_metabasePath, $"{metaDefinition.DefinitionId}.json");
+        var fullFileName = GetMetaDefinitionPath(metaDefinition.DefinitionId);
         if (!File.Exists(fullFileName))
         {
-            throw new Exception($"No meta definition found for definitionId {metaDefinition.DefinitionId}");
+            throw new DefinitionStorageNotFoundException($"No meta definition found for definitionId {metaDefinition.DefinitionId}");
         }
         var data = JsonConvert.SerializeObject(metaDefinition,_storage.NewtonSoftDefaultSettings);
         return File.WriteAllTextAsync(fullFileName, data);
@@ -124,14 +129,22 @@ public class DefinitionStorage : IDefinitionStorage
 
     public Task<BpmnMetaDefinition> GetMetaDefinitionById(string id)
     {
-        var fullFileName = Path.Combine(_metabasePath, $"{id}.json");
+        var fullFileName = GetMetaDefinitionPath(id);
+        if (!File.Exists(fullFileName))
+        {
+            throw new DefinitionStorageNotFoundException($"No meta definition found for definitionId {id}");
+        }
         var content = File.ReadAllText(fullFileName);
         return Task.FromResult(JsonConvert.DeserializeObject<BpmnMetaDefinition>(content)!);
     }
 
     public async Task<BpmnDefinition> GetDefinitionById(Guid id)
     {
-        var fullFileName = Path.Combine(_basePath, $"{id}.json");
+        var fullFileName = GetDefinitionPath(id);
+        if (!File.Exists(fullFileName))
+        {
+            throw new DefinitionStorageNotFoundException($"No definition found for definitionId {id}");
+        }
         var content = await File.ReadAllTextAsync(fullFileName);
         return JsonConvert.DeserializeObject<BpmnDefinition>(content)!;
     }
@@ -142,7 +155,7 @@ public class DefinitionStorage : IDefinitionStorage
         var latestDefinition = definitions.Where(x => x.DefinitionId == definitionId).MaxBy(x => x.Version);
         if (latestDefinition == null)
         {
-            throw new Exception($"No definition found for definitionId {definitionId}");
+            throw new DefinitionStorageNotFoundException($"No definition found for definitionId {definitionId}");
         }
         return latestDefinition;
     }
@@ -150,5 +163,19 @@ public class DefinitionStorage : IDefinitionStorage
     public async Task<BpmnDefinition?> GetDeployedDefinition(string definitionDefinitionId)
     {
         return  (await GetAllDefinitions()).SingleOrDefault(x => x.DefinitionId == definitionDefinitionId && x.IsActive);
+    }
+
+    private string GetBinaryPath(Guid guid) => Path.Combine(_binaryBasePath, $"{guid}.json");
+
+    private string GetDefinitionPath(Guid id) => Path.Combine(_basePath, $"{id}.json");
+
+    private string GetMetaDefinitionPath(string definitionId) => Path.Combine(_metabasePath, $"{definitionId}.json");
+
+    private static void EnsureDirectoryExists(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            Directory.CreateDirectory(path);
+        }
     }
 }

--- a/src/FilesystemStorageSystem/Exceptions/DefinitionStorageConflictException.cs
+++ b/src/FilesystemStorageSystem/Exceptions/DefinitionStorageConflictException.cs
@@ -1,0 +1,7 @@
+namespace FilesystemStorageSystem.Exceptions;
+
+/// <summary>
+/// Signalisiert einen Konflikt beim Persistieren von Definitionen oder Metadaten,
+/// zum Beispiel wenn ein Datensatz bereits vorhanden ist.
+/// </summary>
+public class DefinitionStorageConflictException(string message) : InvalidOperationException(message);

--- a/src/FilesystemStorageSystem/Exceptions/DefinitionStorageNotFoundException.cs
+++ b/src/FilesystemStorageSystem/Exceptions/DefinitionStorageNotFoundException.cs
@@ -1,0 +1,6 @@
+namespace FilesystemStorageSystem.Exceptions;
+
+/// <summary>
+/// Signalisiert, dass eine angeforderte Definition oder Metadefinition im Dateisystem nicht gefunden wurde.
+/// </summary>
+public class DefinitionStorageNotFoundException(string message) : FileNotFoundException(message);

--- a/src/Flowzer.Shared/ExpandoHelper.cs
+++ b/src/Flowzer.Shared/ExpandoHelper.cs
@@ -91,7 +91,7 @@ public static class ExpandoHelper
     public static bool HasProperty(this object? vars, string propertyName)
     {
         if (propertyName.Contains('.'))
-            throw new Exception("nested properties are not supported.");
+            throw new NotSupportedException("Nested properties are not supported.");
         return vars != null && ((IDictionary<string,object?>) vars).TryGetValue(propertyName, out _);
     }
     

--- a/src/FlowzerFrontend.Tests/ApiExceptionContractTest.cs
+++ b/src/FlowzerFrontend.Tests/ApiExceptionContractTest.cs
@@ -1,0 +1,60 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using FlowzerFrontend.Exceptions;
+using WebApiEngine.Shared;
+
+namespace FlowzerFrontend.Tests;
+
+public class ApiExceptionContractTest
+{
+    // Testzweck: Prüft, dass eine fehlende JSON-Antwort beim Laden einer Definition als ApiContractException endet.
+    [Test]
+    public async Task GetDefinition_ShouldThrowApiContractException_WhenResponseBodyIsNull()
+    {
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(HttpStatusCode.OK))
+        {
+            BaseAddress = new Uri("http://localhost:5182/")
+        };
+        var api = new FlowzerApi(httpClient);
+
+        var action = async () => await api.GetDefinition(Guid.NewGuid());
+
+        await action.Should()
+            .ThrowAsync<ApiContractException>()
+            .WithMessage("No definition found for definitionId *");
+    }
+
+    // Testzweck: Prüft, dass nicht erfolgreiche HTTP-Statuscodes beim Speichern eines Formulars als HttpRequestException propagiert werden.
+    [Test]
+    public async Task SaveForm_ShouldThrowHttpRequestException_WhenStatusCodeIsNotSuccessful()
+    {
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(HttpStatusCode.InternalServerError, "{}"))
+        {
+            BaseAddress = new Uri("http://localhost:5182/")
+        };
+        var api = new FlowzerApi(httpClient);
+
+        var action = async () => await api.SaveForm(new FormDto
+        {
+            Id = Guid.NewGuid(),
+            FormId = Guid.NewGuid(),
+            Version = new VersionDto(1, 0),
+            FormData = "{\"type\":\"form\"}"
+        });
+
+        var exceptionAssertion = await action.Should().ThrowAsync<HttpRequestException>();
+        exceptionAssertion.Which.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+    }
+
+    private sealed class StubHttpMessageHandler(HttpStatusCode statusCode, string? responseContent = null) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(responseContent ?? "null", Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}

--- a/src/FlowzerFrontend.Tests/FrontendExpandoHelperTest.cs
+++ b/src/FlowzerFrontend.Tests/FrontendExpandoHelperTest.cs
@@ -1,0 +1,20 @@
+using System.Dynamic;
+using FluentAssertions;
+using FlowzerFrontend.BusinessLogic;
+
+namespace FlowzerFrontend.Tests;
+
+public class FrontendExpandoHelperTest
+{
+    // Testzweck: Prüft, dass ein Typkonflikt beim Lesen aus Expando-Objekten als InvalidCastException gemeldet wird.
+    [Test]
+    public void GetValue_ShouldThrowInvalidCastException_WhenStoredValueHasDifferentType()
+    {
+        dynamic values = new ExpandoObject();
+        values.Count = "not-an-int";
+
+        var action = () => ExpandoHelper.GetValue<int>((ExpandoObject)values, "Count", defaultValue: 0);
+
+        action.Should().Throw<InvalidCastException>();
+    }
+}

--- a/src/FlowzerFrontend/ApiBase.cs
+++ b/src/FlowzerFrontend/ApiBase.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
-using System.Text.Json;
 using System.Text;
+using System.Text.Json;
+using FlowzerFrontend.Exceptions;
 using WebApiEngine.Shared;
 
 namespace FlowzerFrontend;
@@ -32,12 +33,20 @@ public class ApiBase
         var result = await HttpClient.GetFromJsonAsync<T>(url);
         if (result == null)
         {
-            throw new Exception($"Failed to get data from server. Returned object was null on request: {url}");
+            throw new ApiContractException($"Failed to get data from server. Returned object was null on request: {url}");
         }
         return result;
     }
+
+    protected async Task<T> GetRequiredJsonAsync<T>(string url, string errorMessage)
+    {
+        var result = await HttpClient.GetFromJsonAsync<T>(url);
+        return result ?? throw new ApiContractException(errorMessage);
+    }
     
-        
+    /// <summary>
+    /// Sendet eine HTTP-Anfrage mit JSON-Body an die API und gibt die rohe Antwort zurück.
+    /// </summary>
     public async Task<HttpResponseMessage> GetJsonRequest(string url, HttpMethod method, string body)
     {
         using var request = new HttpRequestMessage(method, url)
@@ -116,23 +125,21 @@ public class ApiBase
         else if (method == HttpMethod.Put)
             result = await HttpClient.PutAsync(url, content);
         else
-            throw new Exception("Method not supported");
-        
-        if (result == null)
-        {
-            throw new Exception($"Failed to get data from server. Returned result was null on request: {url}");
-        }
+            throw new NotSupportedException($"The HTTP method '{method}' is not supported by this helper.");
 
         if (throwOnUnsuccessfulStatusCodes &&  !result.IsSuccessStatusCode)
         {
-            throw new Exception($"Failed to get data from server. Returned status code was {result.StatusCode} on request: {url}");
+            throw new HttpRequestException(
+                $"Failed to get data from server. Returned status code was {result.StatusCode} on request: {url}",
+                null,
+                result.StatusCode);
         }
         
         var readFromJsonAsync = await result.Content.ReadFromJsonAsync<T>();
         
         if (readFromJsonAsync == null)
         {
-            throw new Exception($"Failed to get data from server. Returned object was null on request: {url}");
+            throw new ApiContractException($"Failed to get data from server. Returned object was null on request: {url}");
         }
         
         

--- a/src/FlowzerFrontend/BusinessLogic/ExpandoHelper.cs
+++ b/src/FlowzerFrontend/BusinessLogic/ExpandoHelper.cs
@@ -20,7 +20,7 @@ public static class ExpandoHelper
             }
             else
             {
-                throw new InvalidCastException("Value is not of type " + typeof(T).Name + " valuetype is " + value?.GetType().Name ?? "null");
+                throw new InvalidCastException("Value is not of type " + typeof(T).Name + " value type is " + (value?.GetType().Name ?? "null"));
             }
         }
 

--- a/src/FlowzerFrontend/BusinessLogic/ExpandoHelper.cs
+++ b/src/FlowzerFrontend/BusinessLogic/ExpandoHelper.cs
@@ -20,7 +20,7 @@ public static class ExpandoHelper
             }
             else
             {
-                throw new Exception("Value is not of type " + typeof(T).Name + " valuetype is " + value?.GetType().Name ?? "null");
+                throw new InvalidCastException("Value is not of type " + typeof(T).Name + " valuetype is " + value?.GetType().Name ?? "null");
             }
         }
 

--- a/src/FlowzerFrontend/Exceptions/ApiContractException.cs
+++ b/src/FlowzerFrontend/Exceptions/ApiContractException.cs
@@ -1,0 +1,7 @@
+namespace FlowzerFrontend.Exceptions;
+
+/// <summary>
+/// Signalisiert, dass der Frontend-Client eine unerwartete oder unvollständige HTTP-/JSON-Antwort
+/// erhalten hat und der erwartete API-Vertrag damit verletzt wurde.
+/// </summary>
+public class ApiContractException(string message) : ApiException(message);

--- a/src/FlowzerFrontend/Exceptions/ApiException.cs
+++ b/src/FlowzerFrontend/Exceptions/ApiException.cs
@@ -1,0 +1,7 @@
+namespace FlowzerFrontend.Exceptions;
+
+/// <summary>
+/// Repräsentiert einen fachlichen API-Fehler, der bereits als kontrollierter Fehlervertrag
+/// vom Server oder von einer API-nahen Frontendprüfung zurückgegeben wurde.
+/// </summary>
+public class ApiException(string? errorMessage) : Exception(errorMessage);

--- a/src/FlowzerFrontend/FlowzerApi.cs
+++ b/src/FlowzerFrontend/FlowzerApi.cs
@@ -1,8 +1,12 @@
 using System.Net.Http.Json;
+using FlowzerFrontend.Exceptions;
 using WebApiEngine.Shared;
 
 namespace FlowzerFrontend;
 
+/// <summary>
+/// Kapselt die HTTP-Kommunikation des Blazor-Frontends mit der Flowzer-Web-API.
+/// </summary>
 public class FlowzerApi: ApiBase
 {
     public FlowzerApi(HttpClient httpClient) : base(httpClient)
@@ -16,60 +20,72 @@ public class FlowzerApi: ApiBase
     
     internal async Task<BpmnMetaDefinitionDto> GetMetaDefinitionById(string definitionId)
     {
-        var bpmnMetaDefinitionDto = await HttpClient.GetFromJsonAsync<BpmnMetaDefinitionDto>($"definition/meta/{definitionId}");
-        if (bpmnMetaDefinitionDto == null)
-        {
-            throw new Exception($"No meta definition found for definitionId {definitionId}");
-        }
-        return bpmnMetaDefinitionDto;
+        return await GetRequiredJsonAsync<BpmnMetaDefinitionDto>(
+            $"definition/meta/{definitionId}",
+            $"No meta definition found for definitionId {definitionId}");
     }
 
     internal async Task<BpmnDefinitionDto> GetLatestDefinition(string metaDefinitionId)
     {
-        var bpmnDefinitionDto = await HttpClient.GetFromJsonAsync<BpmnDefinitionDto>($"definition/meta/{metaDefinitionId}/latest");
-        if (bpmnDefinitionDto == null)
-        {
-            throw new Exception($"No definition found for definitionId {metaDefinitionId}");
-        }
-        return bpmnDefinitionDto;
+        return await GetRequiredJsonAsync<BpmnDefinitionDto>(
+            $"definition/meta/{metaDefinitionId}/latest",
+            $"No definition found for definitionId {metaDefinitionId}");
     }
     
+    /// <summary>
+    /// Lädt eine konkrete Definitionsversion anhand ihrer GUID.
+    /// </summary>
     public async Task<BpmnDefinitionDto> GetDefinition(Guid? definitionId)
     {
-        var bpmnDefinitionDto = await HttpClient.GetFromJsonAsync<BpmnDefinitionDto>($"definition/{definitionId}");
-        if (bpmnDefinitionDto == null)
-        {
-            throw new Exception($"No definition found for definitionId {definitionId}");
-        }
-        return bpmnDefinitionDto;
+        return await GetRequiredJsonAsync<BpmnDefinitionDto>(
+            $"definition/{definitionId}",
+            $"No definition found for definitionId {definitionId}");
     }
     
+    /// <summary>
+    /// Persistiert geänderte Metadaten einer BPMN-Definition.
+    /// </summary>
     public async Task UpdateMetaDefinition(BpmnMetaDefinitionDto currentMetaDefinition)
     {
         await PutAsJsonAsyncSave<object>($"definition/meta", currentMetaDefinition);
     }
     
+    /// <summary>
+    /// Lädt das BPMN-XML zu einer konkreten Definitionsversion.
+    /// </summary>
     internal async Task<string> GetXmlDefinition(Guid guid)
     {
         return await HttpClient.GetStringAsync($"definition/xml/{guid}");
     }
 
+    /// <summary>
+    /// Lädt alle bekannten BPMN-Metadefinitionen inklusive erweitertem UI-Kontext.
+    /// </summary>
     public Task<ExtendedBpmnMetaDefinitionDto[]> GetAllBpmnMetaDefinitions()
     {
         return GetAsJsonAsyncSave<ExtendedBpmnMetaDefinitionDto[]>("definition/meta");
     }
 
+    /// <summary>
+    /// Erstellt serverseitig eine neue leere BPMN-Definition.
+    /// </summary>
     public async Task<BpmnMetaDefinitionDto> CreateEmptyDefinition()
     {
         return await GetAsJsonAsyncSave<BpmnMetaDefinitionDto>("definition/new");
     }
 
+    /// <summary>
+    /// Speichert eine BPMN-Definition als neue Version, optional basierend auf einer bestehenden Version.
+    /// </summary>
     public async Task<BpmnDefinitionDto> UploadDefinition(string xml, Guid? previousGuid = null)
     {
         var url = AppendPreviousGuidQuery("definition", previousGuid);
         return await PostAsJsonAsyncSave<BpmnDefinitionDto>(url, xml);
     }
 
+    /// <summary>
+    /// Speichert und deployt eine BPMN-Definition als neue aktive Version.
+    /// </summary>
     public async Task<BpmnDefinitionDto> DeployDefinition(string xml, Guid? previousGuid = null)
     {
         var url = AppendPreviousGuidQuery("definition/deploy", previousGuid);
@@ -80,78 +96,121 @@ public class FlowzerApi: ApiBase
         throw new ApiException(apiStatusResult.ErrorMessage);
     }
 
+    /// <summary>
+    /// Lädt alle bekannten Prozessinstanzen.
+    /// </summary>
     public async Task<List<ProcessInstanceInfoDto>> GetAllInstances()
     {
         return await GetAsJsonAndThrowOnErrorAsync<List<ProcessInstanceInfoDto>>("instance");
     }
 
+    /// <summary>
+    /// Lädt die Detaildaten einer Prozessinstanz.
+    /// </summary>
     public async Task<ProcessInstanceInfoDto> GetProcessInstance(Guid instanceGuid)
     {
         return await GetAsJsonAndThrowOnErrorAsync<ProcessInstanceInfoDto>("instance/" + instanceGuid);
     }
 
+    /// <summary>
+    /// Lädt alle aktiven Message-Subscriptions einer Instanz.
+    /// </summary>
     public async Task<MessageSubscriptionDto[]> GetMessageSubscriptions(Guid instanceGuid)
     {
         return await GetAsJsonAndThrowOnErrorAsync<MessageSubscriptionDto[]>("instance/" + instanceGuid + "/subscription/messages");
     }
     
+    /// <summary>
+    /// Lädt alle aktiven Service-Task-Subscriptions einer Instanz.
+    /// </summary>
     public async Task<TokenDto[]> GetServiceSubscriptions(Guid instanceGuid)
     {
         return await GetAsJsonAndThrowOnErrorAsync<TokenDto[]>("instance/" + instanceGuid + "/subscription/services");
     }
 
+    /// <summary>
+    /// Lädt alle aktiven Signal-Subscriptions einer Instanz.
+    /// </summary>
     public async Task<SignalSubscriptionDto[]> GetSignalSubscriptions(Guid instanceGuid)
     {
         return await GetAsJsonAndThrowOnErrorAsync<SignalSubscriptionDto[]>("instance/" + instanceGuid + "/subscription/signals");
     }
 
+    /// <summary>
+    /// Lädt alle aktiven User-Tasks einer Instanz.
+    /// </summary>
     public async Task<TokenDto[]> GetUserTasks(Guid instanceGuid)
     {
         return await GetAsJsonAndThrowOnErrorAsync<TokenDto[]>("instance/" + instanceGuid + "/subscription/userTasks");
     }
 
+    /// <summary>
+    /// Lädt alle offenen User-Tasks über alle Instanzen hinweg.
+    /// </summary>
     public async Task<ExtendedUserTaskSubscriptionDto[]> GetAllUserTasks()
     {
         return await GetAsJsonAndThrowOnErrorAsync<ExtendedUserTaskSubscriptionDto[]>("usertask");
     }
     
+    /// <summary>
+    /// Lädt die Metadaten eines Formulars.
+    /// </summary>
     public async Task<FormMetaDataDto> GetFormMetaData(Guid metaDataId)
     {
         return await GetAsJsonAndThrowOnErrorAsync<FormMetaDataDto>("form/meta/" + metaDataId);
     }
     
+    /// <summary>
+    /// Lädt die aktuellste Version eines Formulars.
+    /// </summary>
     public async Task<FormDto> GetLatestForm(Guid formId)
     {
         return await GetAsJsonAndThrowOnErrorAsync<FormDto>("form/" + formId + "/latest");
     }
     
-        
+    /// <summary>
+    /// Lädt eine konkrete Version eines Formulars.
+    /// </summary>
     public async Task<FormDto> GetForm(Guid formId, VersionDto version)
     {
         return await GetAsJsonAndThrowOnErrorAsync<FormDto>("form/" + formId + "/" + version);
     }
 
-
+    /// <summary>
+    /// Persistiert geänderte Formularmetadaten.
+    /// </summary>
     public async Task SaveFormMetaData(FormMetaDataDto formMetaDataDto)
     {
         await PostAsJsonAndOnErrorAsync<dynamic>("form/meta/" + formMetaDataDto.FormId, formMetaDataDto);
     }
 
+    /// <summary>
+    /// Speichert ein Formular als neue Version.
+    /// </summary>
     public async Task<FormDto> SaveForm(FormDto formData)
     {
         return await PostAsJsonAndOnErrorAsync<FormDto>("form", formData);
     }
 
+    /// <summary>
+    /// Lädt alle bekannten Formularmetadaten.
+    /// </summary>
     public async Task<List<FormMetaDataDto>> GetFormMetaDatas()
     {
         return await GetAsJsonAndThrowOnErrorAsync<List<FormMetaDataDto>>("form/meta");
     }
 
+    /// <summary>
+    /// Sucht Formularmetadaten anhand des Formularnamens.
+    /// </summary>
     public async Task<List<FormMetaDataDto>> GetFormMetaByName(string formName)
     {
         return await GetAsJsonAndThrowOnErrorAsync<List<FormMetaDataDto>>("form/meta?search=" + formName);
     }
 
+    /// <summary>
+    /// Sendet ein abgeschlossenes User-Task-Formular an die API zurück.
+    /// </summary>
     public async Task CompleteUserTask(UserTaskResultDto userTaskResult)
     {
         await PostAsJsonAndOnErrorAsync<dynamic>("form/result", userTaskResult);
@@ -168,5 +227,3 @@ public class FlowzerApi: ApiBase
         return $"{url}{separator}previousGuid={Uri.EscapeDataString(previousGuid.Value.ToString())}";
     }
 }
-
-public class ApiException(string? errorMessage) : Exception(errorMessage);

--- a/src/FlowzerFrontend/Pages/EditDefinition.razor.cs
+++ b/src/FlowzerFrontend/Pages/EditDefinition.razor.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using FlowzerFrontend.Exceptions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.JSInterop;
@@ -228,7 +229,7 @@ public partial class EditDefinition : IAsyncDisposable
         var saveXmlResult = await JsRuntime.InvokeAsyncNoneCached<JsonObject>($"{EditorInteropPath}.saveXml");
         if (saveXmlResult["xml"] is not JsonNode xmlNode)
         {
-            throw new Exception("The BPMN editor returned no XML payload.");
+            throw new InvalidOperationException("The BPMN editor returned no XML payload.");
         }
 
         return xmlNode.GetValue<string>();

--- a/src/FlowzerFrontend/Pages/EditForm.razor.cs
+++ b/src/FlowzerFrontend/Pages/EditForm.razor.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using FlowzerFrontend.BusinessLogic;
+using FlowzerFrontend.Exceptions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.FluentUI.AspNetCore.Components;

--- a/src/WebApiEngine.Tests/DefinitionStorageTest.cs
+++ b/src/WebApiEngine.Tests/DefinitionStorageTest.cs
@@ -1,0 +1,107 @@
+using FilesystemStorageSystem;
+using FilesystemStorageSystem.Exceptions;
+using FluentAssertions;
+using Model;
+
+namespace WebApiEngine.Tests;
+
+[NonParallelizable]
+public class DefinitionStorageTest
+{
+    // Testzweck: Prüft, dass doppelte Metadefinitionen als fachlicher Konfliktfehler gemeldet werden.
+    [Test]
+    public async Task StoreMetaDefinition_ShouldThrowConflictException_WhenMetaAlreadyExists()
+    {
+        using var context = new DefinitionStorageTestContext();
+        var metaDefinition = context.CreateMetaDefinition("Invoice");
+        await context.DefinitionStorage.StoreMetaDefinition(metaDefinition);
+
+        var action = async () => await context.DefinitionStorage.StoreMetaDefinition(metaDefinition);
+
+        await action.Should().ThrowAsync<DefinitionStorageConflictException>();
+    }
+
+    // Testzweck: Prüft, dass das Aktualisieren fehlender Metadefinitionen als NotFound-Fehler endet.
+    [Test]
+    public async Task UpdateMetaDefinition_ShouldThrowNotFoundException_WhenMetaDoesNotExist()
+    {
+        using var context = new DefinitionStorageTestContext();
+
+        var action = async () => await context.DefinitionStorage.UpdateMetaDefinition(context.CreateMetaDefinition("Missing"));
+
+        await action.Should().ThrowAsync<DefinitionStorageNotFoundException>();
+    }
+
+    // Testzweck: Prüft, dass das Laden fehlender Metadefinitionen als NotFound-Fehler endet.
+    [Test]
+    public async Task GetMetaDefinitionById_ShouldThrowNotFoundException_WhenMetaDoesNotExist()
+    {
+        using var context = new DefinitionStorageTestContext();
+
+        var action = async () => await context.DefinitionStorage.GetMetaDefinitionById(context.DefinitionId);
+
+        await action.Should().ThrowAsync<DefinitionStorageNotFoundException>();
+    }
+
+    // Testzweck: Prüft, dass das Laden der neuesten Definition ohne vorhandene Versionen als NotFound-Fehler endet.
+    [Test]
+    public async Task GetLatestDefinition_ShouldThrowNotFoundException_WhenDefinitionDoesNotExist()
+    {
+        using var context = new DefinitionStorageTestContext();
+
+        var action = async () => await context.DefinitionStorage.GetLatestDefinition(context.DefinitionId);
+
+        await action.Should().ThrowAsync<DefinitionStorageNotFoundException>();
+    }
+
+    private sealed class DefinitionStorageTestContext : IDisposable
+    {
+        private readonly string _definitionsPath;
+        private readonly string _metaPath;
+
+        public DefinitionStorageTestContext()
+        {
+            Storage = new Storage();
+            DefinitionStorage = Storage.DefinitionStorage;
+            DefinitionId = $"definition-{Guid.NewGuid():N}";
+            _definitionsPath = Storage.GetBasePath("FileStorage/Definitions");
+            _metaPath = Storage.GetBasePath("FileStorage/Definitions/Meta");
+            Cleanup();
+        }
+
+        public Storage Storage { get; }
+        public StorageSystem.IDefinitionStorage DefinitionStorage { get; }
+        public string DefinitionId { get; }
+
+        public BpmnMetaDefinition CreateMetaDefinition(string name)
+        {
+            return new BpmnMetaDefinition
+            {
+                DefinitionId = DefinitionId,
+                Name = name
+            };
+        }
+
+        public void Dispose()
+        {
+            Cleanup();
+        }
+
+        private void Cleanup()
+        {
+            foreach (var file in Directory.GetFiles(_definitionsPath, "*.json"))
+            {
+                if (File.ReadAllText(file).Contains(DefinitionId, StringComparison.Ordinal))
+                {
+                    File.Delete(file);
+                }
+            }
+
+            var metaPath = Path.Combine(_metaPath, $"{DefinitionId}.json");
+            if (File.Exists(metaPath))
+            {
+                File.Delete(metaPath);
+            }
+        }
+    }
+}

--- a/src/WebApiEngine/Middleware/ApiExceptionHandlingExtensions.cs
+++ b/src/WebApiEngine/Middleware/ApiExceptionHandlingExtensions.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using FilesystemStorageSystem.Exceptions;
 using Microsoft.AspNetCore.Diagnostics;
 using WebApiEngine.Shared;
 
@@ -48,6 +49,7 @@ public static class ApiExceptionHandlingExtensions
     {
         return exception switch
         {
+            DefinitionStorageConflictException => StatusCodes.Status409Conflict,
             FileNotFoundException or KeyNotFoundException => StatusCodes.Status404NotFound,
             ArgumentException or FormatException or JsonException => StatusCodes.Status400BadRequest,
             UnauthorizedAccessException => StatusCodes.Status401Unauthorized,

--- a/src/core-engine-tests/ExpandoHelperTest.cs
+++ b/src/core-engine-tests/ExpandoHelperTest.cs
@@ -38,6 +38,18 @@ public class ExpandoHelperTest
         dynamicOrder.SetValue("Address.FirstnameNew", "Berlin");
         Assert.That(dynamicOrder.GetValue("Address.FirstnameNew"), Is.EqualTo("Berlin"));
     }
+
+    // Testzweck: Prüft, dass HasProperty verschachtelte Property-Pfade weiterhin bewusst ablehnt.
+    [Test]
+    public void HasProperty_ShouldThrowNotSupportedException_WhenNestedPropertyIsRequested()
+    {
+        var order = new Order();
+        var dynamicOrder = order.ToDynamic();
+
+        var action = () => dynamicOrder.HasProperty("Address.Firstname");
+
+        Assert.That(action, Throws.TypeOf<NotSupportedException>());
+    }
 }
 
 public class Order

--- a/src/core-engine-tests/InstanceEngineExceptionTest.cs
+++ b/src/core-engine-tests/InstanceEngineExceptionTest.cs
@@ -1,0 +1,24 @@
+using FluentAssertions;
+using core_engine.Exceptions;
+using Variables = System.Dynamic.ExpandoObject;
+
+namespace core_engine_tests;
+
+public class InstanceEngineExceptionTest
+{
+    // Testzweck: Prüft, dass abgeschlossene Tokens nicht erneut über HandleTaskResult abgeschlossen werden können.
+    [Test]
+    public async System.Threading.Tasks.Task HandleTaskResult_ShouldThrowFlowzerRuntimeException_WhenTokenIsNotActive()
+    {
+        var instanceEngine = await Helper.StartFirstProcessOfFile("StartStopWithVariables.bpmn");
+        var activeServiceTask = instanceEngine.GetActiveServiceTasks().Single();
+
+        instanceEngine.HandleTaskResult(activeServiceTask.Id, new Variables());
+
+        var action = () => instanceEngine.HandleTaskResult(activeServiceTask.Id, new Variables());
+
+        action.Should()
+            .Throw<FlowzerRuntimeException>()
+            .WithMessage("Token ist nicht aktiv");
+    }
+}

--- a/src/core-engine/InstanceEngine/Base.cs
+++ b/src/core-engine/InstanceEngine/Base.cs
@@ -96,7 +96,7 @@ public partial class InstanceEngine: ICatchHandler
         var token = GetToken(tokenId);
         if (token.State != FlowNodeState.Active)
         {
-            throw new Exception("Token ist nicht aktiv");
+            throw new FlowzerRuntimeException("Token ist nicht aktiv");
         }
 
         data ??= new Variables();

--- a/src/core-engine/InstanceEngine/InstanceEngine.cs
+++ b/src/core-engine/InstanceEngine/InstanceEngine.cs
@@ -8,7 +8,7 @@ public partial class InstanceEngine
     public void Start(Variables? data)
     {
         CreateInitialTokens(data);
-        if (Tokens.Count == 0) throw new Exception("No tokens created");
+        if (Tokens.Count == 0) throw new FlowzerRuntimeException("No tokens created");
         Run();
     }
 


### PR DESCRIPTION
## Zusammenfassung

Dieses Paket zieht den nächsten Codehygiene-Schritt aus **#96** nach `next`:

- generische `Exception`-Würfe in Frontend-, Storage- und Engine-Kernpfaden reduziert
- fachlich passendere Exception-Typen für API-Vertrag, Dateisystem-Storage und Runtime eingeführt
- erste XML-Dokumentation für die öffentliche `FlowzerApi`-Oberfläche ergänzt
- kleine Redundanzen in den Frontend-API-Helfern bereinigt
- neue Regressionstests für die neuen Fehlerpfade ergänzt

## Technische Änderungen

### Frontend / API-Client
- `ApiException` und `ApiContractException` in eigene Exception-Typen ausgelagert
- `ApiBase` wirft bei fehlerhaften HTTP-Statuscodes jetzt `HttpRequestException`
- fehlende oder leere JSON-Antworten werden jetzt als `ApiContractException` behandelt
- `FlowzerApi` nutzt einen gemeinsamen `GetRequiredJsonAsync(...)`-Pfad
- öffentliche `FlowzerApi`-Methoden sind stärker dokumentiert

### Storage / Web-API
- `DefinitionStorage` verwendet jetzt:
  - `DefinitionStorageConflictException`
  - `DefinitionStorageNotFoundException`
- Pfadbildung und Directory-Schutz im `DefinitionStorage` etwas bereinigt
- `ApiExceptionHandlingExtensions` mappt Storage-Konflikte jetzt auf **409 Conflict**

### Engine / Hilfslogik
- `InstanceEngine` meldet in Kernpfaden jetzt `FlowzerRuntimeException` statt generischer `Exception`
- Shared-/Frontend-`ExpandoHelper` nutzen passendere Exception-Typen
- `EditDefinition` meldet fehlendes XML vom Editor jetzt als `InvalidOperationException`

## Tests

Neu bzw. erweitert:
- `src/FlowzerFrontend.Tests/ApiExceptionContractTest.cs`
- `src/FlowzerFrontend.Tests/FrontendExpandoHelperTest.cs`
- `src/WebApiEngine.Tests/DefinitionStorageTest.cs`
- `src/core-engine-tests/InstanceEngineExceptionTest.cs`
- `src/core-engine-tests/ExpandoHelperTest.cs`

## Validierung

```bash
dotnet build core-engine.sln --configuration Release
dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-build
dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-build
dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-build
npm --prefix tests/ui-smoke test
```

## Bezug

Relates to #96
