### PR TITLE
Strukturiert die Instanzansicht im Frontend

### DIFF
--- a/src/FlowzerFrontend.Tests/InstanceTreeViewBuilderTest.cs
+++ b/src/FlowzerFrontend.Tests/InstanceTreeViewBuilderTest.cs
@@ -1,0 +1,120 @@
+using System.Dynamic;
+using FluentAssertions;
+using FlowzerFrontend.BusinessLogic;
+using Microsoft.FluentUI.AspNetCore.Components;
+using WebApiEngine.Shared;
+
+namespace FlowzerFrontend.Tests;
+
+public class InstanceTreeViewBuilderTest
+{
+    // Testzweck: Prüft, dass die Token-Hierarchie der Instanzansicht in eine verschachtelte Tree-View-Struktur mit Root- und Child-Knoten übersetzt wird.
+    [Test]
+    public void BuildTokenItems_ShouldBuildNestedTree_ForRootAndChildTokens()
+    {
+        dynamic rootFlowElement = new ExpandoObject();
+        rootFlowElement.Name = "Approve invoice";
+
+        dynamic childFlowElement = new ExpandoObject();
+        childFlowElement.Id = "Activity_Child";
+
+        var rootTokenId = Guid.NewGuid();
+        var rootToken = new TokenDto
+        {
+            Id = rootTokenId,
+            CurrentFlowElement = rootFlowElement
+        };
+
+        var childToken = new TokenDto
+        {
+            Id = Guid.NewGuid(),
+            ParentTokenId = rootTokenId,
+            CurrentFlowElement = childFlowElement
+        };
+
+        var result = InstanceTreeViewBuilder.BuildTokenItems([rootToken, childToken]);
+
+        result.Should().HaveCount(1);
+        var rootItem = result.Single().Should().BeOfType<TreeViewItem>().Subject;
+        rootItem.Text.Should().Be("Approve invoice");
+        rootItem.Items.Should().NotBeNull();
+        rootItem.Items!.Should().HaveCount(1);
+        rootItem.Items!.Single().Should().BeOfType<TreeViewItem>().Which.Text.Should().Be("Activity_Child");
+    }
+
+    // Testzweck: Prüft, dass die Übersichtsgruppen nur dann Platzhalter laden, wenn die jeweilige Subscription-Kategorie auch Einträge besitzt.
+    [Test]
+    public void BuildSubscriptionOverview_ShouldSetLoadingItemsOnly_ForCategoriesWithEntries()
+    {
+        var instance = new ProcessInstanceInfoDto
+        {
+            InstanceId = Guid.NewGuid(),
+            DefinitionId = Guid.NewGuid(),
+            RelatedDefinitionId = "Definition_1",
+            RelatedDefinitionName = "Example",
+            MessageSubscriptionCount = 2,
+            ServiceSubscriptionCount = 0,
+            SignalSubscriptionCount = 1,
+            UserTaskSubscriptionCount = 0,
+            Tokens = []
+        };
+
+        var result = InstanceTreeViewBuilder.BuildSubscriptionOverview(instance);
+
+        result.Should().HaveCount(4);
+        result[0].Text.Should().Be("Message subscriptions (2)");
+        result[0].Items.Should().NotBeNullOrEmpty();
+        result[1].Text.Should().Be("Service subscriptions (0)");
+        result[1].Items.Should().BeNull();
+        result[2].Text.Should().Be("Signal subscriptions (1)");
+        result[2].Items.Should().NotBeNullOrEmpty();
+        result[3].Text.Should().Be("Usertask subscriptions (0)");
+        result[3].Items.Should().BeNull();
+    }
+
+    // Testzweck: Prüft, dass Message-Subscriptions stabile Tree-Items erzeugen und die Originalobjekte für spätere Aktionen im Mapping abgelegt werden.
+    [Test]
+    public void BuildMessageSubscriptionItems_ShouldReturnTreeItems_AndPopulateMappings()
+    {
+        var mapping = new Dictionary<string, object>();
+        var subscription = new MessageSubscriptionDto
+        {
+            Message = new MessageDefinitionDto { Name = "InvoiceReceived" },
+            ProcessId = "Process_1",
+            RelatedDefinitionId = "Definition_1",
+            DefinitionId = Guid.NewGuid(),
+            ProcessInstanceId = Guid.NewGuid()
+        };
+
+        var result = InstanceTreeViewBuilder.BuildMessageSubscriptionItems([subscription], mapping);
+
+        result.Should().HaveCount(1);
+        result.Single().Should().BeOfType<TreeViewItem>().Which.Id.Should().Be("message_InvoiceReceived");
+        mapping.Should().ContainKey("message_InvoiceReceived");
+        mapping["message_InvoiceReceived"].Should().BeSameAs(subscription);
+    }
+
+    // Testzweck: Prüft, dass bekannte Tree-IDs zuverlässig in fachliche Subscription-Kategorien übersetzt werden.
+    [TestCase("messages", InstanceSubscriptionTreeCategory.Messages)]
+    [TestCase("service", InstanceSubscriptionTreeCategory.Services)]
+    [TestCase("signal", InstanceSubscriptionTreeCategory.Signals)]
+    [TestCase("user", InstanceSubscriptionTreeCategory.UserTasks)]
+    public void TryParseSubscriptionCategory_ShouldParseKnownIds(
+        string itemId,
+        InstanceSubscriptionTreeCategory expectedCategory)
+    {
+        var success = InstanceTreeViewBuilder.TryParseSubscriptionCategory(itemId, out var category);
+
+        success.Should().BeTrue();
+        category.Should().Be(expectedCategory);
+    }
+
+    // Testzweck: Prüft, dass unbekannte Tree-IDs defensiv abgelehnt werden, damit die UI keine undefinierte Kategorie verarbeitet.
+    [Test]
+    public void TryParseSubscriptionCategory_ShouldRejectUnknownIds()
+    {
+        var success = InstanceTreeViewBuilder.TryParseSubscriptionCategory("unknown", out _);
+
+        success.Should().BeFalse();
+    }
+}

--- a/src/FlowzerFrontend/BusinessLogic/InstanceSubscriptionTreeCategory.cs
+++ b/src/FlowzerFrontend/BusinessLogic/InstanceSubscriptionTreeCategory.cs
@@ -1,0 +1,27 @@
+namespace FlowzerFrontend.BusinessLogic;
+
+/// <summary>
+/// Beschreibt die vier Subscription-Gruppen der Instanzansicht.
+/// </summary>
+public enum InstanceSubscriptionTreeCategory
+{
+    /// <summary>
+    /// Gruppiert Message-Subscriptions.
+    /// </summary>
+    Messages,
+
+    /// <summary>
+    /// Gruppiert Service-Task-Subscriptions.
+    /// </summary>
+    Services,
+
+    /// <summary>
+    /// Gruppiert Signal-Subscriptions.
+    /// </summary>
+    Signals,
+
+    /// <summary>
+    /// Gruppiert User-Task-Subscriptions.
+    /// </summary>
+    UserTasks
+}

--- a/src/FlowzerFrontend/BusinessLogic/InstanceTreeViewBuilder.cs
+++ b/src/FlowzerFrontend/BusinessLogic/InstanceTreeViewBuilder.cs
@@ -1,0 +1,204 @@
+using Microsoft.FluentUI.AspNetCore.Components;
+using WebApiEngine.Shared;
+
+namespace FlowzerFrontend.BusinessLogic;
+
+/// <summary>
+/// Kapselt den Aufbau der Tree-View-Struktur für die Instanzansicht,
+/// damit die Blazor-Seite nur noch Rendering und Orchestrierung übernimmt.
+/// </summary>
+public static class InstanceTreeViewBuilder
+{
+    /// <summary>
+    /// Baut aus den Tokens einer Instanz eine verschachtelte Tree-View-Struktur.
+    /// </summary>
+    public static IReadOnlyList<ITreeViewItem> BuildTokenItems(IEnumerable<TokenDto> tokens)
+    {
+        ArgumentNullException.ThrowIfNull(tokens);
+
+        var allTokens = tokens.ToList();
+        var rootTokens = allTokens
+            .Where(token => token.ParentTokenId == null || token.ParentTokenId == Guid.Empty)
+            .ToList();
+
+        if (rootTokens.Count == 0)
+        {
+            return [];
+        }
+
+        return BuildTokenItems(allTokens, rootTokens);
+    }
+
+    /// <summary>
+    /// Erstellt die vier festen Subscription-Gruppen inklusive Ladeplatzhaltern.
+    /// </summary>
+    public static IReadOnlyList<TreeViewItem> BuildSubscriptionOverview(ProcessInstanceInfoDto instance)
+    {
+        ArgumentNullException.ThrowIfNull(instance);
+
+        return
+        [
+            CreateSubscriptionOverviewItem(InstanceSubscriptionTreeCategory.Messages, instance.MessageSubscriptionCount),
+            CreateSubscriptionOverviewItem(InstanceSubscriptionTreeCategory.Services, instance.ServiceSubscriptionCount),
+            CreateSubscriptionOverviewItem(InstanceSubscriptionTreeCategory.Signals, instance.SignalSubscriptionCount),
+            CreateSubscriptionOverviewItem(InstanceSubscriptionTreeCategory.UserTasks, instance.UserTaskSubscriptionCount)
+        ];
+    }
+
+    /// <summary>
+    /// Übersetzt eine Tree-Item-ID der Instanzansicht in die zugehörige Subscription-Kategorie.
+    /// </summary>
+    public static bool TryParseSubscriptionCategory(
+        string? itemId,
+        out InstanceSubscriptionTreeCategory category)
+    {
+        switch (itemId)
+        {
+            case "messages":
+                category = InstanceSubscriptionTreeCategory.Messages;
+                return true;
+            case "service":
+                category = InstanceSubscriptionTreeCategory.Services;
+                return true;
+            case "signal":
+                category = InstanceSubscriptionTreeCategory.Signals;
+                return true;
+            case "user":
+                category = InstanceSubscriptionTreeCategory.UserTasks;
+                return true;
+            default:
+                category = default;
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Baut Tree-Items für Message-Subscriptions und merkt sich die Originalobjekte für Folgeaktionen.
+    /// </summary>
+    public static IReadOnlyList<ITreeViewItem> BuildMessageSubscriptionItems(
+        IEnumerable<MessageSubscriptionDto> subscriptions,
+        IDictionary<string, object> treeItemMappings)
+    {
+        ArgumentNullException.ThrowIfNull(subscriptions);
+        ArgumentNullException.ThrowIfNull(treeItemMappings);
+
+        return subscriptions.Select(subscription =>
+            {
+                var id = "message_" + subscription.Message.Name;
+                treeItemMappings[id] = subscription;
+                return (ITreeViewItem)new TreeViewItem(id, subscription.Message.Name);
+            })
+            .ToList();
+    }
+
+    /// <summary>
+    /// Baut Tree-Items für aktive Service-Task-Subscriptions.
+    /// </summary>
+    public static IReadOnlyList<ITreeViewItem> BuildServiceSubscriptionItems(IEnumerable<TokenDto> subscriptions)
+    {
+        ArgumentNullException.ThrowIfNull(subscriptions);
+
+        return subscriptions.Select(subscription =>
+            {
+                var implementationName = TokenDisplayHelper.GetImplementation(subscription)
+                                         ?? subscription.CurrentFlowNodeId
+                                         ?? "(service task)";
+                return (ITreeViewItem)new TreeViewItem(subscription.Id.ToString(), implementationName);
+            })
+            .ToList();
+    }
+
+    /// <summary>
+    /// Baut Tree-Items für aktive Signal-Subscriptions.
+    /// </summary>
+    public static IReadOnlyList<ITreeViewItem> BuildSignalSubscriptionItems(IEnumerable<SignalSubscriptionDto> subscriptions)
+    {
+        ArgumentNullException.ThrowIfNull(subscriptions);
+
+        return subscriptions.Select(subscription =>
+                (ITreeViewItem)new TreeViewItem(subscription.Signal, subscription.Signal))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Baut Tree-Items für aktive User-Tasks.
+    /// </summary>
+    public static IReadOnlyList<ITreeViewItem> BuildUserTaskSubscriptionItems(IEnumerable<TokenDto> subscriptions)
+    {
+        ArgumentNullException.ThrowIfNull(subscriptions);
+
+        return subscriptions.Select(subscription =>
+            {
+                var implementationName = TokenDisplayHelper.GetImplementation(subscription)
+                                         ?? subscription.CurrentFlowNodeId
+                                         ?? "(user task)";
+                return (ITreeViewItem)new TreeViewItem(subscription.Id.ToString(), implementationName);
+            })
+            .ToList();
+    }
+
+    private static IReadOnlyList<ITreeViewItem> BuildTokenItems(
+        IReadOnlyCollection<TokenDto> allTokens,
+        IReadOnlyCollection<TokenDto> currentLevelTokens)
+    {
+        var result = new List<ITreeViewItem>(currentLevelTokens.Count);
+
+        foreach (var token in currentLevelTokens)
+        {
+            var subTokens = allTokens.Where(candidate => candidate.ParentTokenId == token.Id).ToList();
+            var subItems = BuildTokenItems(allTokens, subTokens);
+
+            result.Add(new TreeViewItem
+            {
+                Id = token.Id.ToString(),
+                Text = TokenDisplayHelper.GetDisplayName(token, "(root token)"),
+                Items = subItems,
+                Expanded = true
+            });
+        }
+
+        return result;
+    }
+
+    private static TreeViewItem CreateSubscriptionOverviewItem(
+        InstanceSubscriptionTreeCategory category,
+        int count)
+    {
+        var item = new TreeViewItem
+        {
+            Id = GetSubscriptionItemId(category),
+            Text = GetSubscriptionTitle(category, count)
+        };
+
+        if (count > 0)
+        {
+            item.Items = TreeViewItem.LoadingTreeViewItems;
+        }
+
+        return item;
+    }
+
+    private static string GetSubscriptionItemId(InstanceSubscriptionTreeCategory category)
+    {
+        return category switch
+        {
+            InstanceSubscriptionTreeCategory.Messages => "messages",
+            InstanceSubscriptionTreeCategory.Services => "service",
+            InstanceSubscriptionTreeCategory.Signals => "signal",
+            InstanceSubscriptionTreeCategory.UserTasks => "user",
+            _ => throw new ArgumentOutOfRangeException(nameof(category), category, "Unsupported subscription category.")
+        };
+    }
+
+    private static string GetSubscriptionTitle(InstanceSubscriptionTreeCategory category, int count)
+    {
+        return category switch
+        {
+            InstanceSubscriptionTreeCategory.Messages => $"Message subscriptions ({count})",
+            InstanceSubscriptionTreeCategory.Services => $"Service subscriptions ({count})",
+            InstanceSubscriptionTreeCategory.Signals => $"Signal subscriptions ({count})",
+            InstanceSubscriptionTreeCategory.UserTasks => $"Usertask subscriptions ({count})",
+            _ => throw new ArgumentOutOfRangeException(nameof(category), category, "Unsupported subscription category.")
+        };
+    }
+}

--- a/src/FlowzerFrontend/BusinessLogic/InstanceTreeViewBuilder.cs
+++ b/src/FlowzerFrontend/BusinessLogic/InstanceTreeViewBuilder.cs
@@ -9,6 +9,22 @@ namespace FlowzerFrontend.BusinessLogic;
 /// </summary>
 public static class InstanceTreeViewBuilder
 {
+    private static readonly IReadOnlyDictionary<InstanceSubscriptionTreeCategory, InstanceSubscriptionDefinition>
+        SubscriptionDefinitions =
+            new Dictionary<InstanceSubscriptionTreeCategory, InstanceSubscriptionDefinition>
+            {
+                [InstanceSubscriptionTreeCategory.Messages] = new("messages", "Message subscriptions"),
+                [InstanceSubscriptionTreeCategory.Services] = new("service", "Service subscriptions"),
+                [InstanceSubscriptionTreeCategory.Signals] = new("signal", "Signal subscriptions"),
+                [InstanceSubscriptionTreeCategory.UserTasks] = new("user", "Usertask subscriptions")
+            };
+
+    private static readonly IReadOnlyDictionary<string, InstanceSubscriptionTreeCategory> SubscriptionCategoriesByItemId =
+        SubscriptionDefinitions.ToDictionary(
+            definition => definition.Value.ItemId,
+            definition => definition.Key,
+            StringComparer.Ordinal);
+
     /// <summary>
     /// Baut aus den Tokens einer Instanz eine verschachtelte Tree-View-Struktur.
     /// </summary>
@@ -52,24 +68,13 @@ public static class InstanceTreeViewBuilder
         string? itemId,
         out InstanceSubscriptionTreeCategory category)
     {
-        switch (itemId)
+        if (string.IsNullOrWhiteSpace(itemId))
         {
-            case "messages":
-                category = InstanceSubscriptionTreeCategory.Messages;
-                return true;
-            case "service":
-                category = InstanceSubscriptionTreeCategory.Services;
-                return true;
-            case "signal":
-                category = InstanceSubscriptionTreeCategory.Signals;
-                return true;
-            case "user":
-                category = InstanceSubscriptionTreeCategory.UserTasks;
-                return true;
-            default:
-                category = default;
-                return false;
+            category = default;
+            return false;
         }
+
+        return SubscriptionCategoriesByItemId.TryGetValue(itemId, out category);
     }
 
     /// <summary>
@@ -180,25 +185,23 @@ public static class InstanceTreeViewBuilder
 
     private static string GetSubscriptionItemId(InstanceSubscriptionTreeCategory category)
     {
-        return category switch
-        {
-            InstanceSubscriptionTreeCategory.Messages => "messages",
-            InstanceSubscriptionTreeCategory.Services => "service",
-            InstanceSubscriptionTreeCategory.Signals => "signal",
-            InstanceSubscriptionTreeCategory.UserTasks => "user",
-            _ => throw new ArgumentOutOfRangeException(nameof(category), category, "Unsupported subscription category.")
-        };
+        return GetSubscriptionDefinition(category).ItemId;
     }
 
     private static string GetSubscriptionTitle(InstanceSubscriptionTreeCategory category, int count)
     {
-        return category switch
-        {
-            InstanceSubscriptionTreeCategory.Messages => $"Message subscriptions ({count})",
-            InstanceSubscriptionTreeCategory.Services => $"Service subscriptions ({count})",
-            InstanceSubscriptionTreeCategory.Signals => $"Signal subscriptions ({count})",
-            InstanceSubscriptionTreeCategory.UserTasks => $"Usertask subscriptions ({count})",
-            _ => throw new ArgumentOutOfRangeException(nameof(category), category, "Unsupported subscription category.")
-        };
+        return $"{GetSubscriptionDefinition(category).Title} ({count})";
     }
+
+    private static InstanceSubscriptionDefinition GetSubscriptionDefinition(InstanceSubscriptionTreeCategory category)
+    {
+        if (!SubscriptionDefinitions.TryGetValue(category, out var definition))
+        {
+            throw new ArgumentOutOfRangeException(nameof(category), category, "Unsupported subscription category.");
+        }
+
+        return definition;
+    }
+
+    private sealed record InstanceSubscriptionDefinition(string ItemId, string Title);
 }

--- a/src/FlowzerFrontend/Pages/Instance.razor.cs
+++ b/src/FlowzerFrontend/Pages/Instance.razor.cs
@@ -136,7 +136,9 @@ public partial class Instance : IAsyncDisposable
 
         if (!InstanceTreeViewBuilder.TryParseSubscriptionCategory(e.CurrentItem.Id, out var category))
         {
-            throw new ArgumentOutOfRangeException(nameof(e.CurrentItem.Id), e.CurrentItem.Id, "Unsupported tree item category.");
+            e.CurrentItem.Items = [];
+            ErrorDialog($"Unsupported tree item category '{e.CurrentItem.Id}'.");
+            return;
         }
 
         e.CurrentItem.Items = await LoadSubscriptionItems(category);

--- a/src/FlowzerFrontend/Pages/Instance.razor.cs
+++ b/src/FlowzerFrontend/Pages/Instance.razor.cs
@@ -10,10 +10,6 @@ namespace FlowzerFrontend.Pages;
 public partial class Instance : IAsyncDisposable
 {
     private const string ViewerInteropPath = "window.FlowzerInstanceViewer";
-    private const string MessagesTreeItemKey = "messages";
-    private const string ServiceTreeItemKey = "service";
-    private const string SignalTreeItemKey = "singal";
-    private const string UserTaskTreeItemKey = "user";
 
     private ProcessInstanceInfoDto? _instance;
     private bool IsViewerInitialized { get; set; }
@@ -108,165 +104,62 @@ public partial class Instance : IAsyncDisposable
         var data = await FlowzerApi.GetXmlDefinition(_instance.DefinitionId);
         PendingXml = data;
         await ShowVariables(_instance.Tokens);
-        LoadMeesageSubscriptionOverview();
+        LoadSubscriptionOverview();
         await InvokeAsync(StateHasChanged);
     }
 
     private async Task ShowVariables(List<TokenDto> instanceTokens)
     {
-        var rootTokens = instanceTokens.Where(x => x.ParentTokenId == null || x.ParentTokenId == Guid.Empty).ToList();
-        if (rootTokens.Count == 0)
-        {
-            VariableItems = [];
-            return;
-        }
-        VariableItems =  GetTokenTreeViewItem(instanceTokens, rootTokens);
+        VariableItems = InstanceTreeViewBuilder.BuildTokenItems(instanceTokens);
         
         await InvokeAsync(StateHasChanged);
     }
 
-    private IEnumerable<ITreeViewItem> GetTokenTreeViewItem(List<TokenDto> allTokens, List<TokenDto> list)
+    private void LoadSubscriptionOverview()
     {
-        var result = new List<ITreeViewItem>();
-        foreach (var x in list)
-        {
-            var text = TokenDisplayHelper.GetDisplayName(x, "(root token)");
+        if (_instance == null)
+            return;
 
-            var subTokens = allTokens.Where(y => y.ParentTokenId == x.Id).ToList();
-            var subItems = GetTokenTreeViewItem(allTokens, subTokens);
-            result.Add(new TreeViewItem()
-            {
-                Id = x.Id.ToString(),
-                Text = text,
-                Items = subItems,
-                Expanded = true
-            });
+        var subscriptionOverview = InstanceTreeViewBuilder.BuildSubscriptionOverview(_instance);
+        foreach (var item in subscriptionOverview)
+        {
+            item.OnExpandedAsync = OnSubscriptionItemExpanded;
         }
-        return result;
+
+        Items = subscriptionOverview;
     }
 
-    private void LoadMeesageSubscriptionOverview()
-    {
-        if (_instance == null)
-            return;
-        
-        var messageSubscriptionsTreeItem = new TreeViewItem()
-        {
-            Id = MessagesTreeItemKey,
-            Text = "Message subscriptions (" + _instance.MessageSubscriptionCount + ")",
-            OnExpandedAsync = OnMessageSubscriptionItemExpanded,
-        };
-        if (_instance.MessageSubscriptionCount > 0)
-            messageSubscriptionsTreeItem.Items = TreeViewItem.LoadingTreeViewItems;
-
-        var serviceSubscriptiontTreeItem = new TreeViewItem()
-        {
-            Id = ServiceTreeItemKey,
-            Text = "Service subscriptions (" + _instance.ServiceSubscriptionCount + ")",
-            OnExpandedAsync = OnMessageSubscriptionItemExpanded,
-        };
-        if (_instance.ServiceSubscriptionCount > 0)
-            serviceSubscriptiontTreeItem.Items = TreeViewItem.LoadingTreeViewItems;
-
-
-        var signalSubscriptionTreeItem = new TreeViewItem()
-        {
-            Id = SignalTreeItemKey,
-            Text = "Signal subscriptions (" + _instance.SignalSubscriptionCount + ")",
-            OnExpandedAsync = OnMessageSubscriptionItemExpanded,
-        };
-        if (_instance.SignalSubscriptionCount > 0)
-            signalSubscriptionTreeItem.Items = TreeViewItem.LoadingTreeViewItems;
-
-
-        var userTaskSubscriptionTreeItem = new TreeViewItem()
-        {
-            Id = UserTaskTreeItemKey,
-            Text = "Usertask subscriptions (" + _instance.UserTaskSubscriptionCount + ")",
-            OnExpandedAsync = OnMessageSubscriptionItemExpanded,
-        };
-        if (_instance.UserTaskSubscriptionCount > 0)
-            userTaskSubscriptionTreeItem.Items = TreeViewItem.LoadingTreeViewItems;
-
-        Items = new[]
-        {
-            messageSubscriptionsTreeItem,
-            serviceSubscriptiontTreeItem,
-            signalSubscriptionTreeItem,
-            userTaskSubscriptionTreeItem
-        };
-    }
-
-    private async Task OnMessageSubscriptionItemExpanded(TreeViewItemExpandedEventArgs e)
+    private async Task OnSubscriptionItemExpanded(TreeViewItemExpandedEventArgs e)
     {
         if (_instance == null)
             return;
 
-
-        e.CurrentItem.Items = e.CurrentItem.Id switch
+        if (!InstanceTreeViewBuilder.TryParseSubscriptionCategory(e.CurrentItem.Id, out var category))
         {
-            MessagesTreeItemKey => (await LoadMessageSubscriptions()).ToList(),
-            ServiceTreeItemKey => await LoadServiceSubscriptions(),
-            SignalTreeItemKey => await LoadSignalSubscriptions(),
-            UserTaskTreeItemKey => await LoadUserTaskSubscriptions(),
-            _ => throw new Exception("Unknown item type")
+            throw new ArgumentOutOfRangeException(nameof(e.CurrentItem.Id), e.CurrentItem.Id, "Unsupported tree item category.");
+        }
+
+        e.CurrentItem.Items = await LoadSubscriptionItems(category);
+    }
+
+    private async Task<IReadOnlyList<ITreeViewItem>> LoadSubscriptionItems(InstanceSubscriptionTreeCategory category)
+    {
+        if (_instance == null)
+            return [];
+
+        return category switch
+        {
+            InstanceSubscriptionTreeCategory.Messages => InstanceTreeViewBuilder.BuildMessageSubscriptionItems(
+                await FlowzerApi.GetMessageSubscriptions(_instance.InstanceId),
+                _treeItemMappings),
+            InstanceSubscriptionTreeCategory.Services => InstanceTreeViewBuilder.BuildServiceSubscriptionItems(
+                await FlowzerApi.GetServiceSubscriptions(_instance.InstanceId)),
+            InstanceSubscriptionTreeCategory.Signals => InstanceTreeViewBuilder.BuildSignalSubscriptionItems(
+                await FlowzerApi.GetSignalSubscriptions(_instance.InstanceId)),
+            InstanceSubscriptionTreeCategory.UserTasks => InstanceTreeViewBuilder.BuildUserTaskSubscriptionItems(
+                await FlowzerApi.GetUserTasks(_instance.InstanceId)),
+            _ => throw new ArgumentOutOfRangeException(nameof(category), category, "Unsupported subscription category.")
         };
-
-    }
-
-    private async Task<IEnumerable<ITreeViewItem>> LoadMessageSubscriptions()
-    {
-        if (_instance == null)
-            return [];
-        return (await FlowzerApi.GetMessageSubscriptions(_instance.InstanceId)).Select(
-            x =>
-            {
-                var id = "message_" + x.Message.Name;
-                _treeItemMappings[id] = x;
-                var treeViewItem = new TreeViewItem(id, x.Message.Name);
-                return treeViewItem;
-            });
-    }
-
-    private async Task<IEnumerable<ITreeViewItem>> LoadServiceSubscriptions()
-    {
-        if (_instance == null)
-            return [];
-        return (await FlowzerApi.GetServiceSubscriptions(_instance.InstanceId)).Select(
-            x =>
-            {
-                var implementationName = TokenDisplayHelper.GetImplementation(x) ?? x.CurrentFlowNodeId ?? "(service task)";
-                var treeViewItem = new TreeViewItem(x.Id.ToString(), implementationName);
-                return treeViewItem;
-            });
-    }
-
-
-    private async Task<IEnumerable<ITreeViewItem>> LoadSignalSubscriptions()
-    {
-        if (_instance == null)
-            return [];
-        return (await FlowzerApi.GetSignalSubscriptions(_instance.InstanceId)).Select(
-            x =>
-            {
-                var treeViewItem = new TreeViewItem(x.Signal, x.Signal);
-                return treeViewItem;
-            });
-    }
-
-    private async Task<IEnumerable<ITreeViewItem>> LoadUserTaskSubscriptions()
-    {
-        if (_instance == null)
-            return [];
-        
-        
-        return (await FlowzerApi.GetUserTasks(_instance.InstanceId)).Select(
-            x =>
-            {
-                var implementationName = TokenDisplayHelper.GetImplementation(x) ?? x.CurrentFlowNodeId ?? "(user task)";
-                var treeViewItem = new TreeViewItem(x.Id.ToString(), implementationName);
-                return treeViewItem;
-            });
     }
 
 
@@ -302,7 +195,7 @@ public partial class Instance : IAsyncDisposable
         }
         catch (Exception e)
         {
-            throw new Exception($"Error adding token '{instanceTokenKey}', Message:" + e.Message, e);
+            throw new InvalidOperationException($"Error adding token '{instanceTokenKey}'.", e);
         }
     }
 


### PR DESCRIPTION
## Zusammenfassung

Dieser PR strukturiert die Instanzansicht im Frontend sauberer, ohne den fachlichen Ablauf der Seite zu verändern.

## Änderungen

- Tree-/Subscription-Aufbau aus `Instance.razor.cs` in `InstanceTreeViewBuilder` ausgelagert
- neue fachliche Kategorie `InstanceSubscriptionTreeCategory` für die vier festen Subscription-Gruppen ergänzt
- verbleibende generische Exceptions im Kernpfad der Instanzansicht durch passendere Fehler ersetzt
- Benennungen in der Instanzseite bereinigt (`LoadSubscriptionOverview`, `OnSubscriptionItemExpanded`)
- neue Unit-Tests für Token-Hierarchie, Subscription-Overview, Message-Mapping und Category-Parsing ergänzt

## Validierung

- `dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release`
- `dotnet build core-engine.sln --configuration Release`
- `npm --prefix tests/ui-smoke test`
- geprüft, dass nach dem UI-Smoke-Lauf keine `chrome-headless-shell`-/Playwright-Prozesse hängen bleiben

Relates to #96
Closes #101
