### PR TITLE
Präzisiert Parser-Fehler für User-Tasks

### DIFF
--- a/src/core-engine-tests/ModelParserTest.cs
+++ b/src/core-engine-tests/ModelParserTest.cs
@@ -5,6 +5,7 @@ using BPMN.Flowzer.Events;
 using BPMN.Gateways;
 using BPMN.HumanInteraction;
 using BPMN.Process;
+using core_engine.Exceptions;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Task = System.Threading.Tasks.Task;
@@ -161,6 +162,59 @@ public class ModelParserTest
             boundaryTimer.TimerType.Should().Be(FlowzerTimerType.TimeDuration);
             boundaryTimer.TimerDefinition.TimeDuration!.Body.Should().Be("PT5S");
         }
+    }
+
+    // Testzweck: Prüft, dass User-Tasks ihre Implementierung auch aus formId lesen, wenn kein formKey vorhanden ist.
+    [Test]
+    public void ParseModel_ShouldUseFormId_WhenUserTaskHasNoFormKey()
+    {
+        const string xml = """
+                           <?xml version="1.0" encoding="UTF-8"?>
+                           <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                             xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                                             id="Definitions_UserTaskFormId">
+                             <bpmn:process id="Process_UserTaskFormId" isExecutable="true">
+                               <bpmn:startEvent id="StartEvent_1" />
+                               <bpmn:userTask id="Activity_UserTask">
+                                 <bpmn:extensionElements>
+                                   <zeebe:formDefinition formId="Form_InvoiceReview" />
+                                 </bpmn:extensionElements>
+                               </bpmn:userTask>
+                             </bpmn:process>
+                           </bpmn:definitions>
+                           """;
+
+        var model = ModelParser.ParseModel(xml);
+        var userTask = model.GetProcesses().Single().FlowElements.OfType<UserTask>().Should().ContainSingle().Subject;
+
+        userTask.Implementation.Should().Be("Form_InvoiceReview");
+    }
+
+    // Testzweck: Prüft, dass der Parser für User-Tasks ohne formKey/formId eine fachlich präzise Parser-Exception auslöst.
+    [Test]
+    public void ParseModel_ShouldThrowFlowzerModelParseException_WhenUserTaskHasNoImplementation()
+    {
+        const string xml = """
+                           <?xml version="1.0" encoding="UTF-8"?>
+                           <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                             xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                                             id="Definitions_UserTaskMissingImplementation">
+                             <bpmn:process id="Process_UserTaskMissingImplementation" isExecutable="true">
+                               <bpmn:startEvent id="StartEvent_1" />
+                               <bpmn:userTask id="Activity_UserTask">
+                                 <bpmn:extensionElements>
+                                   <zeebe:formDefinition />
+                                 </bpmn:extensionElements>
+                               </bpmn:userTask>
+                             </bpmn:process>
+                           </bpmn:definitions>
+                           """;
+
+        var action = () => ModelParser.ParseModel(xml);
+
+        action.Should()
+            .Throw<FlowzerModelParseException>()
+            .WithMessage("User task 'Activity_UserTask'*");
     }
 
     private static void AssertFlowNodeOfTypes<T>(Process process, int? count, string? id = null, string? name = null)

--- a/src/core-engine/Exceptions/FlowzerModelParseException.cs
+++ b/src/core-engine/Exceptions/FlowzerModelParseException.cs
@@ -1,0 +1,7 @@
+namespace core_engine.Exceptions;
+
+/// <summary>
+/// Signalisiert, dass ein BPMN-Modell zwar syntaktisch lesbar ist,
+/// aber für einen unterstützten Flowzer-Pfad fachlich unvollständig oder widersprüchlich ist.
+/// </summary>
+public class FlowzerModelParseException(string? message = null) : Exception(message);

--- a/src/core-engine/ModelParser.cs
+++ b/src/core-engine/ModelParser.cs
@@ -102,23 +102,8 @@ public static class ModelParser
 
         foreach (var xmlFlowNode in xmlProcessNode.Elements())
         {
-            var inputMappings =
-                xmlFlowNode.Descendants().Where(x => x.Name.LocalName == "input")
-                    .Select(x =>
-                        new FlowzerIoMapping(
-                            x.Attribute("source")!.Value,
-                            x.Attribute("target")!.Value))
-                    .ToFlowzerList();
-            if (!inputMappings.Any()) inputMappings = null;
-
-            var outputMappings =
-                xmlFlowNode.Descendants().Where(x => x.Name.LocalName == "output")
-                    .Select(x =>
-                        new FlowzerIoMapping(
-                            x.Attribute("source")!.Value,
-                            x.Attribute("target")!.Value))
-                    .ToFlowzerList();
-            if (!outputMappings.Any()) outputMappings = null;
+            var inputMappings = ParseIoMappings(xmlFlowNode, "input");
+            var outputMappings = ParseIoMappings(xmlFlowNode, "output");
 
             switch (xmlFlowNode.Name.LocalName)
             {
@@ -564,10 +549,7 @@ public static class ModelParser
             Name = xmlFlowNode.Attribute("name")?.Value ?? "",
             // Container = process,
             DefaultId = xmlFlowNode.Attribute("default")?.Value,
-            Implementation =
-                formDefinition?.Attribute("formKey")?.Value
-                ?? formDefinition?.Attribute("formId")?.Value
-                ?? throw new Exception("No implementation found"),
+            Implementation = GetUserTaskImplementation(xmlFlowNode, formDefinition),
             FlowzerAssignee = assignmentDefinition?.Attribute("assignee")?.Value,
             FlowzerCandidateGroups = assignmentDefinition?.Attribute("candidateGroups")?.Value,
             FlowzerCandidateUsers = assignmentDefinition?.Attribute("candidateUsers")?.Value,
@@ -577,6 +559,34 @@ public static class ModelParser
             OutputMappings = outputMappings,
             LoopCharacteristics = ParseLoopCharacteristics(xmlFlowNode),
         };
+    }
+
+    private static FlowzerList<FlowzerIoMapping>? ParseIoMappings(XElement xmlFlowNode, string mappingName)
+    {
+        var mappings = xmlFlowNode.Descendants()
+            .Where(element => element.Name.LocalName == mappingName)
+            .Select(element => new FlowzerIoMapping(
+                element.Attribute("source")!.Value,
+                element.Attribute("target")!.Value))
+            .ToFlowzerList();
+
+        return mappings.Any()
+            ? mappings
+            : null;
+    }
+
+    private static string GetUserTaskImplementation(XElement xmlFlowNode, XElement? formDefinition)
+    {
+        var implementation = formDefinition?.Attribute("formKey")?.Value
+                             ?? formDefinition?.Attribute("formId")?.Value;
+
+        if (!string.IsNullOrWhiteSpace(implementation))
+        {
+            return implementation;
+        }
+
+        throw new FlowzerModelParseException(
+            $"User task '{xmlFlowNode.Attribute("id")?.Value ?? "(unknown)"}' requires either formKey or formId in formDefinition.");
     }
 
     private static bool HasDescendant(this XElement element, string name,


### PR DESCRIPTION
## Zusammenfassung

Dieser PR nimmt den nächsten kleinen Codehygiene-Slice aus `#96` auf und präzisiert Parser-Fehler im User-Task-Pfad.

## Änderungen

- neue fachliche Exception `FlowzerModelParseException` ergänzt
- generischen `Exception`-Wurf im User-Task-Parsing ersetzt
- Parsing der IO-Mappings in einen eigenen Helfer ausgelagert, um Doppelcode zu reduzieren
- neue Parser-Regressionstests für `formId`-Fallback und fehlende User-Task-Implementierung ergänzt

## Validierung

- `dotnet build core-engine.sln --configuration Release`
- `dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release`

Relates to #96
Closes #103
