### PR TITLE
Sichert Testzweck-Kommentare im CI ab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Abhängigkeiten wiederherstellen
         run: dotnet restore core-engine.sln
 
+      - name: Testzweck-Kommentare prüfen
+        run: python3 scripts/ci/check_test_purpose_comments.py
+
       - name: Solution bauen
         run: dotnet build core-engine.sln --no-restore --configuration Release
 

--- a/DEVELOPMENT-GUIDELINES.md
+++ b/DEVELOPMENT-GUIDELINES.md
@@ -189,6 +189,7 @@ public class ServiceTask : Task
 ### Test-Struktur (empfohlen)
 
 - **Jeder Test bekommt direkt oberhalb von `[Test]` einen kurzen Kommentar im Format `// Testzweck: ...`, der den Zweck des Tests erklärt.**
+- Vor PRs nach `next` sollte lokal zusätzlich `python3 scripts/ci/check_test_purpose_comments.py` laufen; derselbe Guard läuft auch im GitHub-CI-Pfad.
 
 ```csharp
 [TestFixture]

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Mehr Details: [docs/PROJECT-STATUS.md](docs/PROJECT-STATUS.md)
 
 ```bash
 dotnet restore core-engine.sln
+python3 scripts/ci/check_test_purpose_comments.py
 dotnet build core-engine.sln
 dotnet test src/core-engine-tests/core-engine-tests.csproj
 dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj

--- a/scripts/ci/check_test_purpose_comments.py
+++ b/scripts/ci/check_test_purpose_comments.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Prüft, dass jeder Test einen `// Testzweck:`-Kommentar trägt."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parents[2]
+
+CS_TEST_DIRECTORIES = [
+    ROOT / 'src' / 'core-engine-tests',
+    ROOT / 'src' / 'WebApiEngine.Tests',
+    ROOT / 'src' / 'FlowzerFrontend.Tests',
+]
+JS_TEST_DIRECTORIES = [
+    ROOT / 'tests' / 'ui-smoke' / 'tests',
+]
+
+CS_TEST_ATTRIBUTE = re.compile(r'^\s*\[(Test|TestCase|TestCaseSource|Theory|Fact)\b')
+CS_ATTRIBUTE = re.compile(r'^\s*\[[^\]]+\]\s*$')
+CS_METHOD_SIGNATURE = re.compile(r'^\s*(public|private|internal|protected)\s+')
+JS_TEST_CALL = re.compile(r'^\s*test(?:\.(?:only|skip|fixme))?\s*\(')
+PURPOSE_COMMENT = 'Testzweck:'
+
+
+class Finding:
+    def __init__(self, path: Path, line_number: int, source_line: str):
+        self.path = path
+        self.line_number = line_number
+        self.source_line = source_line.strip()
+
+    def __str__(self) -> str:
+        relative = self.path.relative_to(ROOT)
+        return f'{relative}:{self.line_number}: fehlender // Testzweck:-Kommentar vor `{self.source_line}`'
+
+
+def iter_files(directories: Iterable[Path], suffixes: tuple[str, ...]) -> Iterable[Path]:
+    for directory in directories:
+        if not directory.exists():
+            continue
+        for path in sorted(directory.rglob('*')):
+            if path.is_file() and path.suffix in suffixes:
+                yield path
+
+
+def has_purpose_comment_before_csharp_test(lines: list[str], index: int) -> bool:
+    cursor = index - 1
+    while cursor >= 0:
+        line = lines[cursor]
+        stripped = line.strip()
+
+        if PURPOSE_COMMENT in stripped:
+            return True
+
+        if not stripped or CS_ATTRIBUTE.match(line):
+            cursor -= 1
+            continue
+
+        return False
+
+    return False
+
+
+def has_purpose_comment_before_js_test(lines: list[str], index: int) -> bool:
+    cursor = index - 1
+    while cursor >= 0:
+        stripped = lines[cursor].strip()
+
+        if PURPOSE_COMMENT in stripped:
+            return True
+
+        if not stripped:
+            cursor -= 1
+            continue
+
+        return False
+
+    return False
+
+
+def check_csharp_tests() -> list[Finding]:
+    findings: list[Finding] = []
+
+    for path in iter_files(CS_TEST_DIRECTORIES, ('.cs',)):
+        lines = path.read_text(encoding='utf-8').splitlines()
+        for index, line in enumerate(lines):
+            if CS_TEST_ATTRIBUTE.match(line) and not has_purpose_comment_before_csharp_test(lines, index):
+                findings.append(Finding(path, index + 1, line))
+
+    return findings
+
+
+def check_js_tests() -> list[Finding]:
+    findings: list[Finding] = []
+
+    for path in iter_files(JS_TEST_DIRECTORIES, ('.js', '.ts')):
+        lines = path.read_text(encoding='utf-8').splitlines()
+        for index, line in enumerate(lines):
+            if JS_TEST_CALL.match(line) and not has_purpose_comment_before_js_test(lines, index):
+                findings.append(Finding(path, index + 1, line))
+
+    return findings
+
+
+def main() -> int:
+    findings = [*check_csharp_tests(), *check_js_tests()]
+
+    if findings:
+        print('Fehlende Testzweck-Kommentare gefunden:')
+        for finding in findings:
+            print(f'- {finding}')
+        return 1
+
+    print('Alle gefundenen NUnit- und Playwright-Tests tragen einen // Testzweck:-Kommentar.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/ci/check_test_purpose_comments.py
+++ b/scripts/ci/check_test_purpose_comments.py
@@ -21,9 +21,16 @@ JS_TEST_DIRECTORIES = [
 
 CS_TEST_ATTRIBUTE = re.compile(r'^\s*\[(Test|TestCase|TestCaseSource|Theory|Fact)\b')
 CS_ATTRIBUTE = re.compile(r'^\s*\[[^\]]+\]\s*$')
-CS_METHOD_SIGNATURE = re.compile(r'^\s*(public|private|internal|protected)\s+')
 JS_TEST_CALL = re.compile(r'^\s*test(?:\.(?:only|skip|fixme))?\s*\(')
-PURPOSE_COMMENT = 'Testzweck:'
+PURPOSE_COMMENT = re.compile(r'^\s*//\s*Testzweck:')
+IGNORED_DIRECTORIES = {
+    '.git',
+    'bin',
+    'obj',
+    'node_modules',
+    'playwright-report',
+    'test-results',
+}
 
 
 class Finding:
@@ -41,7 +48,11 @@ def iter_files(directories: Iterable[Path], suffixes: tuple[str, ...]) -> Iterab
     for directory in directories:
         if not directory.exists():
             continue
+
         for path in sorted(directory.rglob('*')):
+            if any(part in IGNORED_DIRECTORIES for part in path.parts):
+                continue
+
             if path.is_file() and path.suffix in suffixes:
                 yield path
 
@@ -52,7 +63,7 @@ def has_purpose_comment_before_csharp_test(lines: list[str], index: int) -> bool
         line = lines[cursor]
         stripped = line.strip()
 
-        if PURPOSE_COMMENT in stripped:
+        if PURPOSE_COMMENT.match(stripped):
             return True
 
         if not stripped or CS_ATTRIBUTE.match(line):
@@ -69,7 +80,7 @@ def has_purpose_comment_before_js_test(lines: list[str], index: int) -> bool:
     while cursor >= 0:
         stripped = lines[cursor].strip()
 
-        if PURPOSE_COMMENT in stripped:
+        if PURPOSE_COMMENT.match(stripped):
             return True
 
         if not stripped:


### PR DESCRIPTION
## Zusammenfassung

Dieser PR sichert die vorhandene Test-Kommentar-Regel technisch ab.

## Änderungen

- neues CI-/Lokalskript `scripts/ci/check_test_purpose_comments.py` ergänzt
- GitHub-Actions-Workflow prüft jetzt vor dem Build, ob NUnit- und Playwright-Tests einen `// Testzweck:`-Kommentar tragen
- README und Development Guidelines um den neuen lokalen Prüfkommando ergänzt

## Validierung

- `python3 scripts/ci/check_test_purpose_comments.py`

Closes #104
Relates to #98
