### PR TITLE
Workflow-UI modernisieren, Direktstart ergänzen und Deploy-Pfad härten

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -10,15 +10,17 @@ Die Frontend-App liest ihre API-Basisadresse aus `FlowzerApi:BaseUrl`:
 
 - Standard: `src/FlowzerFrontend/wwwroot/appsettings.json`
 - lokale Entwicklung: `src/FlowzerFrontend/wwwroot/appsettings.Development.json`
+- UI-Smoke-/Playwright-Läufe: `src/FlowzerFrontend/wwwroot/appsettings.Playwright.json`
 
 Aktuell gilt damit bewusst:
 
 - **Produktion / Same-Origin:** Standardwert `/`
 - **Lokale Entwicklung:** `http://localhost:5182/`
+- **Verwaltete Playwright-Läufe:** `http://localhost:5288/`
 
 Damit lässt sich das Frontend lokal direkt gegen die Web-API starten, ohne dass im Code harte URLs verdrahtet bleiben.
 
-Zusätzlich kann `FlowzerApi:DevelopmentUserId` gesetzt werden. Wenn das Frontend selbst im `Development`-Modus läuft, sendet es diesen Wert automatisch als `X-Flowzer-UserId` an die Web-API. Damit bleiben lokal gehärtete Definition-, User-Task- und Formularpfade testbar, ohne Produktionsumgebungen wieder für freie Header-Impersonation zu öffnen.
+Zusätzlich kann `FlowzerApi:DevelopmentUserId` gesetzt werden. Wenn das Frontend selbst im `Development`- oder `Playwright`-Modus läuft, sendet es diesen Wert automatisch als `X-Flowzer-UserId` an die Web-API. Damit bleiben lokal gehärtete Definition-, User-Task- und Formularpfade testbar, ohne Produktionsumgebungen wieder für freie Header-Impersonation zu öffnen.
 
 ## Lokaler Start
 
@@ -44,6 +46,18 @@ ASPNETCORE_ENVIRONMENT=Development \
 
 Danach ist das Frontend unter [http://localhost:5269](http://localhost:5269) erreichbar.
 
+### Hinweis zu unerwarteten JavaScript-Haltepunkten
+
+Die Standard-Launch-Profile des Frontends tragen bewusst **kein** `inspectUri` mehr. Dadurch soll der normale lokale Start nicht automatisch einen JS-Debug-Proxy für die WebAssembly-App aufziehen.
+
+Wenn gezieltes JavaScript-Debugging gewünscht ist, stehen dafür jetzt separate Profile zur Verfügung:
+
+- `http-js-debug`
+- `https-js-debug`
+- `IIS Express JS Debug`
+
+Damit bleibt der normale Blazor-Start ruhiger, ohne den expliziten Debug-Pfad ganz zu verlieren.
+
 ## Automatisierte UI-Smoke-Tests
 
 Die Smoke- und kleinen Happy-Path-E2E-Tests liegen unter `tests/ui-smoke` und prüfen aktuell die Kernrouten:
@@ -63,6 +77,7 @@ Geprüft werden insbesondere:
 - sichtbare Kern-UI je Route
 - funktionierende Filter-Navigation innerhalb der Instanzliste
 - API-gesäte Happy Paths für Formulare, Modelle und Instanzverläufe
+- explizite **Open**-/`Open deployed`-/`Start instance`-Aktionen in der Modellliste für deployte Workflows
 - kein sichtbarer Blazor-Fatalfehler
 - keine fehlgeschlagenen Browser-Requests
 
@@ -94,6 +109,11 @@ Die Playwright-Konfiguration startet Web-API und Frontend standardmäßig selbst
 PLAYWRIGHT_SKIP_WEBSERVERS=1 npm --prefix tests/ui-smoke run test
 ```
 
+Für verwaltete Playwright-Läufe werden absichtlich eigene Ports genutzt, damit lokale Debug-Sessions auf `5182`/`5269` nicht mit den Smoke-Tests kollidieren:
+
+- Web-API: `http://localhost:5288`
+- Frontend: `http://localhost:5290`
+
 Der `npm test`-Pfad verwendet zusätzlich einen kleinen Prozesswächter. Dieser erkennt alte verwaiste `ms-playwright`-/`chrome-headless-shell`-Prozesse aus früheren Läufen und räumt nach dem Test auch neu entstandene Browser-Reste wieder weg. Damit bleiben keine CPU-intensiven Headless-Prozesse mehr unbemerkt liegen.
 
 Bei Bedarf kann das Verhalten angepasst werden:
@@ -108,6 +128,7 @@ Für die BPMN-Seiten gelten jetzt zusätzlich ein paar harte Erwartungswerte:
 
 - `/definition/{metaDefinitionId}` lädt Canvas **und** Properties Panel reproduzierbar
 - ein Speichern aus dem Modeler sendet den bisherigen Definitionsstand als `previousGuid`, damit Versionsketten im Backend nachvollziehbar bleiben
+- deployte Workflows lassen sich aus der Modellliste und aus der deployten Definitionsansicht direkt als neue Instanz starten
 - die Frontend-Route wechselt nach Save/Deploy auf die neu erzeugte Definition (`/definition/{metaDefinitionId}/{definitionGuid}`), damit URL und angezeigter Stand nicht auseinanderlaufen
 - ungültige Modellrouten zeigen eine sichtbare Inline-Fehlermeldung mit Retry-Button statt eines fatalen Blazor-Fehlers
 - Viewer- und Modeler-Instanzen werden beim Verlassen der Seite best-effort zerstört, damit keine veralteten Diagrammobjekte im Browser hängen bleiben
@@ -115,10 +136,11 @@ Für die BPMN-Seiten gelten jetzt zusätzlich ein paar harte Erwartungswerte:
 ### Empfohlene manuelle Checks
 
 1. `/models` öffnen und ein Modell laden
-2. prüfen, dass Diagramm **und** Properties Panel sichtbar sind
-3. einmal `Save` auslösen und kontrollieren, dass die URL auf eine konkrete Definitions-GUID springt
-4. `/instance/{guid}` für eine laufende Instanz öffnen und Diagramm plus Token-Overlay prüfen
-5. testweise eine ungültige Modellroute öffnen und die Inline-Fehlermeldung verifizieren
+2. prüfen, dass die Liste pro deploytem Workflow explizite `Open`-, `Open deployed`- und `Start instance`-Aktionen zeigt
+3. prüfen, dass Diagramm **und** Properties Panel sichtbar sind
+4. einmal `Save` auslösen und kontrollieren, dass die URL auf eine konkrete Definitions-GUID springt
+5. testweise einen deployten Workflow direkt starten und die Instanzansicht prüfen
+6. testweise eine ungültige Modellroute öffnen und die Inline-Fehlermeldung verifizieren
 
 ## Hinweise zur lokalen Datenbasis
 

--- a/src/FilesystemStorageSystem/DefinitionStorage.cs
+++ b/src/FilesystemStorageSystem/DefinitionStorage.cs
@@ -38,6 +38,17 @@ public class DefinitionStorage : IDefinitionStorage
         return File.ReadAllTextAsync(fullFileName);
     }
 
+    public Task DeleteBinary(Guid guid)
+    {
+        var fullFileName = GetBinaryPath(guid);
+        if (File.Exists(fullFileName))
+        {
+            File.Delete(fullFileName);
+        }
+
+        return Task.CompletedTask;
+    }
+
     public Task<Guid[]> GetAllBinaryDefinitions()
     {
         if (Directory.Exists(_binaryBasePath) == false)
@@ -65,6 +76,17 @@ public class DefinitionStorage : IDefinitionStorage
         var fullFileName = GetDefinitionPath(definition.Id);
         var data = JsonConvert.SerializeObject(definition,  _storage.NewtonSoftDefaultSettings);
         return File.WriteAllTextAsync(fullFileName, data);
+    }
+
+    public Task DeleteDefinition(Guid id)
+    {
+        var fullFileName = GetDefinitionPath(id);
+        if (File.Exists(fullFileName))
+        {
+            File.Delete(fullFileName);
+        }
+
+        return Task.CompletedTask;
     }
 
     public async Task<Version?> GetMaxVersionId(string modelId)

--- a/src/FlowzerFrontend.Tests/FlowzerApiOptionsTest.cs
+++ b/src/FlowzerFrontend.Tests/FlowzerApiOptionsTest.cs
@@ -307,6 +307,35 @@ public class FlowzerApiOptionsTest
         handler.LastRequestUri.Should().Be(new Uri($"http://localhost:5182/definition/deploy?previousGuid={previousGuid}"));
     }
 
+    // Testzweck: Deckt den Fall „Start Process Instance Should Use Definition Meta Instance Route“ ab.
+    [Test]
+    public async Task StartProcessInstance_ShouldUseDefinitionMetaInstanceRoute()
+    {
+        const string definitionId = "invoice-process";
+        var instanceId = Guid.NewGuid();
+        var handler = new RecordingHttpMessageHandler(CreateApiStatusResultJson(new ProcessInstanceInfoDto
+        {
+            InstanceId = instanceId,
+            DefinitionId = Guid.NewGuid(),
+            RelatedDefinitionId = definitionId,
+            RelatedDefinitionName = "Invoice workflow",
+            State = ProcessInstanceStateDto.Running
+        }));
+
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost:5182/")
+        };
+
+        var api = new FlowzerApi(httpClient);
+
+        var result = await api.StartProcessInstance(definitionId);
+
+        result.InstanceId.Should().Be(instanceId);
+        handler.LastMethod.Should().Be(HttpMethod.Post);
+        handler.LastRequestUri.Should().Be(new Uri($"http://localhost:5182/definition/meta/{definitionId}/instance"));
+    }
+
     private static string CreateApiStatusResultJson<T>(T result)
     {
         return System.Text.Json.JsonSerializer.Serialize(new ApiStatusResult<T>(result));

--- a/src/FlowzerFrontend/FlowzerApi.cs
+++ b/src/FlowzerFrontend/FlowzerApi.cs
@@ -97,6 +97,26 @@ public class FlowzerApi: ApiBase
     }
 
     /// <summary>
+    /// Startet eine neue Prozessinstanz für die aktuell deployte Workflow-Version.
+    /// </summary>
+    public async Task<ProcessInstanceInfoDto> StartProcessInstance(string relatedDefinitionId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(relatedDefinitionId);
+
+        var apiStatusResult = await PostAsJsonAsyncSave<ApiStatusResult<ProcessInstanceInfoDto>>(
+            $"definition/meta/{relatedDefinitionId}/instance",
+            new { },
+            throwOnUnsuccessfulStatusCodes: false);
+
+        if (apiStatusResult.Successful)
+        {
+            return apiStatusResult.Result!;
+        }
+
+        throw new ApiException(apiStatusResult.ErrorMessage);
+    }
+
+    /// <summary>
     /// Lädt alle bekannten Prozessinstanzen.
     /// </summary>
     public async Task<List<ProcessInstanceInfoDto>> GetAllInstances()

--- a/src/FlowzerFrontend/Pages/EditDefinition.razor
+++ b/src/FlowzerFrontend/Pages/EditDefinition.razor
@@ -16,11 +16,21 @@
                 <span id="current-file-name">@CurrentMetaDefinition.Name</span>
             }
             <span id="current-file-version">Version: @(CurrentDefinition.Id == Guid.Empty ? "-" : CurrentDefinition.Version.ToString()) </span>
+            <FluentBadge Id="definition-state-badge"
+                         Appearance="@(IsCurrentDefinitionDeployed ? Appearance.Accent : Appearance.Lightweight)">
+                @CurrentDefinitionStateLabel
+            </FluentBadge>
         </LeftSide>
         <RigthSide>
             <FluentStack Class="action-button-group">
                 @* <FluentCombobox AriaLabel="Pre-selected option" Items="@AvailableVersions" @bind-Value="@CurrentDefinition" Height="200px" /> *@
 
+                <FluentButton IconStart="@(new Icons.Regular.Size16.Play())"
+                              Appearance="Appearance.Neutral"
+                              Disabled="@(!CanStartInstance)"
+                              @onclick="OnStartInstanceClick">
+                    Start instance
+                </FluentButton>
                 <FluentButton IconStart="@(new Icons.Regular.Size16.ArrowUpload())"
                               Appearance="Appearance.Accent"
                               Disabled="@(!CanPersistDefinition)"
@@ -31,9 +41,6 @@
                               Disabled="@(!CanPersistDefinition)"
                               @onclick="OnSaveClick">
                     Save
-                </FluentButton>
-                <FluentButton IconEnd="@(new Icons.Regular.Size16.Bug())" Disabled="true">
-                    Debug
                 </FluentButton>
 
                 <FluentMenuButton Text="Options"
@@ -46,6 +53,15 @@
             </FluentStack>
         </RigthSide>
     </HeaderElement>
+
+    @if (!string.IsNullOrWhiteSpace(ActionFeedbackMessage))
+    {
+        <div id="definition-action-feedback"
+             class="diagram-inline-message @(ActionFeedbackIsError ? "definition-action-feedback-error" : "definition-action-feedback-info")"
+             role="@(ActionFeedbackIsError ? "alert" : "status")">
+            @ActionFeedbackMessage
+        </div>
+    }
 
     <div class="content with-diagram" id="designer-container">
         <div class="canvas" id="js-canvas"></div>

--- a/src/FlowzerFrontend/Pages/EditDefinition.razor.cs
+++ b/src/FlowzerFrontend/Pages/EditDefinition.razor.cs
@@ -38,6 +38,8 @@ public partial class EditDefinition : IAsyncDisposable
     private string? LastFailedXmlImport { get; set; }
     private bool IsPersistingDefinition { get; set; }
     private bool NeedsEditorInitialization { get; set; } = true;
+    private string? ActionFeedbackMessage { get; set; }
+    private bool ActionFeedbackIsError { get; set; }
 
     private BpmnMetaDefinitionDto CurrentMetaDefinition { get; set; } = CreateLoadingMetaDefinition();
 
@@ -51,6 +53,14 @@ public partial class EditDefinition : IAsyncDisposable
         !IsPersistingDefinition &&
         IsEditorInitialized &&
         string.IsNullOrWhiteSpace(ErrorString);
+    private bool CanStartInstance =>
+        !IsDocumentLoading &&
+        !IsPersistingDefinition &&
+        !string.IsNullOrWhiteSpace(CurrentMetaDefinition.DefinitionId) &&
+        CurrentDefinition.DeployedOn.HasValue &&
+        string.IsNullOrWhiteSpace(ErrorString);
+    private bool IsCurrentDefinitionDeployed => CurrentDefinition.DeployedOn.HasValue;
+    private string CurrentDefinitionStateLabel => IsCurrentDefinitionDeployed ? "Deployed" : "Draft";
 
     protected override async Task OnParametersSetAsync()
     {
@@ -124,6 +134,7 @@ public partial class EditDefinition : IAsyncDisposable
     {
         IsDocumentLoading = true;
         ErrorString = null;
+        ClearActionFeedback();
         PendingXml = null;
         LastFailedXmlImport = null;
         CurrentMetaDefinition = CreateLoadingMetaDefinition(MetaDefinitionId);
@@ -181,6 +192,29 @@ public partial class EditDefinition : IAsyncDisposable
         await PersistDefinitionAsync((xml, previousGuid) => FlowzerApi.DeployDefinition(xml, previousGuid));
     }
 
+    private async Task OnStartInstanceClick()
+    {
+        if (!CanStartInstance)
+        {
+            var dialog = await DialogService.ShowErrorAsync("The currently opened version is not deployed yet.", "Error");
+            await dialog.Result;
+            return;
+        }
+
+        try
+        {
+            ClearActionFeedback();
+            var instance = await FlowzerApi.StartProcessInstance(CurrentMetaDefinition.DefinitionId);
+            NavigationManager.NavigateTo(UriHelper.GetShowInstanceUrl(instance.InstanceId));
+        }
+        catch (Exception exception)
+        {
+            ActionFeedbackIsError = true;
+            ActionFeedbackMessage = $"Could not start a process instance. {exception.Message}";
+            await SafeStateHasChangedAsync();
+        }
+    }
+
     private async Task PersistDefinitionAsync(Func<string, Guid?, Task<BpmnDefinitionDto>> persistDefinition)
     {
         if (!CanPersistDefinition)
@@ -195,6 +229,7 @@ public partial class EditDefinition : IAsyncDisposable
 
         try
         {
+            ClearActionFeedback();
             var xmlData = await GetXmlData();
             var persistedDefinition = await persistDefinition(xmlData, GetPreviousDefinitionGuid());
 
@@ -209,11 +244,15 @@ public partial class EditDefinition : IAsyncDisposable
         }
         catch (ApiException exception)
         {
+            ActionFeedbackIsError = true;
+            ActionFeedbackMessage = exception.Message;
             var dialog = await DialogService.ShowErrorAsync(exception.Message, "Error");
             await dialog.Result;
         }
         catch (Exception exception)
         {
+            ActionFeedbackIsError = true;
+            ActionFeedbackMessage = exception.Message;
             var dialog = await DialogService.ShowErrorAsync(exception.Message, "Error");
             await dialog.Result;
         }
@@ -289,6 +328,12 @@ public partial class EditDefinition : IAsyncDisposable
     private async Task SafeStateHasChangedAsync()
     {
         await InvokeAsync(StateHasChanged);
+    }
+
+    private void ClearActionFeedback()
+    {
+        ActionFeedbackMessage = null;
+        ActionFeedbackIsError = false;
     }
 
     private static BpmnMetaDefinitionDto CreateLoadingMetaDefinition(string? definitionId = null)

--- a/src/FlowzerFrontend/Pages/EditDefinition.razor.css
+++ b/src/FlowzerFrontend/Pages/EditDefinition.razor.css
@@ -27,6 +27,18 @@
     background: #f8fafc;
 }
 
+.definition-action-feedback-info {
+    border-color: #81c784;
+    background: #e8f5e9;
+    color: #1b5e20;
+}
+
+.definition-action-feedback-error {
+    border-color: #ef9a9a;
+    background: #ffebee;
+    color: #b71c1c;
+}
+
 .diagram-inline-actions {
     margin-top: 12px;
 }

--- a/src/FlowzerFrontend/Pages/Models.razor
+++ b/src/FlowzerFrontend/Pages/Models.razor
@@ -39,6 +39,14 @@
                 </div>
 
                 <FluentDivider Style="width: 100%;" Role="DividerRole.Separator"></FluentDivider>
+                @if (!string.IsNullOrWhiteSpace(ActionInfoMessage))
+                {
+                    <p id="models-action-info" class="action-message action-message-info" role="status">@ActionInfoMessage</p>
+                }
+                else if (!string.IsNullOrWhiteSpace(ActionErrorMessage))
+                {
+                    <p id="models-action-error" class="action-message action-message-error" role="alert">@ActionErrorMessage</p>
+                }
                 @if (IsLoading)
                 {
                     <p id="models-loading-state">Loading models...</p>
@@ -54,7 +62,7 @@
                 else
                 {
                     <div class="list-header">
-                        <FluentDataGrid Items="@items.AsQueryable()" style="width: 100%;" GridTemplateColumns="80px 1fr auto" ShowHover="true"  >
+                        <FluentDataGrid Items="@items.AsQueryable()" style="width: 100%;" GridTemplateColumns="80px 1fr auto auto" ShowHover="true">
                             <SelectColumn TGridItem="ExtendedBpmnMetaDefinitionDto" SelectMode="DataGridSelectMode.Multiple" @bind-SelectedItems="@SelectedItems"  />
                             <TemplateColumn Title="Workflow">
                                 <FluentLayout Orientation="Orientation.Horizontal">
@@ -86,6 +94,33 @@
                                         <FluentBadge Appearance="Appearance.Accent">@context.DeployedVersion Deployed</FluentBadge>
                                     </a>
                                 }
+                            </TemplateColumn>
+                            <TemplateColumn Title="Actions">
+                                <FluentStack Orientation="Orientation.Horizontal" Class="model-action-group">
+                                    <FluentButton Id="@($"model-open-latest-{context.DefinitionId}")"
+                                                  Appearance="Appearance.Stealth"
+                                                  @onclick="@(() => OnOpenLatestClick(context))">
+                                        Open
+                                    </FluentButton>
+                                    @if (context.DeployedId.HasValue)
+                                    {
+                                        <FluentButton Id="@($"model-open-deployed-{context.DefinitionId}")"
+                                                      Appearance="Appearance.Neutral"
+                                                      @onclick="@(() => OnOpenDeployedClick(context))">
+                                            Open deployed
+                                        </FluentButton>
+                                        <FluentButton Id="@($"model-start-instance-{context.DefinitionId}")"
+                                                      Appearance="Appearance.Accent"
+                                                      Disabled="@IsStartActionBusy(context)"
+                                                      @onclick="@(() => OnStartInstanceClickAsync(context))">
+                                            Start instance
+                                        </FluentButton>
+                                    }
+                                    else
+                                    {
+                                        <FluentBadge Appearance="Appearance.Lightweight">Deploy required</FluentBadge>
+                                    }
+                                </FluentStack>
                             </TemplateColumn>
                         </FluentDataGrid>
                     </div>

--- a/src/FlowzerFrontend/Pages/Models.razor.cs
+++ b/src/FlowzerFrontend/Pages/Models.razor.cs
@@ -17,6 +17,9 @@ public partial class Models
     private List<ExtendedBpmnMetaDefinitionDto> AllModels { get; set; } = [];
     private bool IsLoading { get; set; } = true;
     private string? LoadErrorMessage { get; set; }
+    private string? ActionErrorMessage { get; set; }
+    private string? ActionInfoMessage { get; set; }
+    private string? StartingDefinitionId { get; set; }
     public string? SearchText { get; set; }
     
     public List<Option<SortDirection>> SortDirections = new()
@@ -49,10 +52,62 @@ public partial class Models
         NavigationManager.NavigateTo(UriHelper.GetEditDefinitionUrl(newDefinitionMetaData.DefinitionId));
         
     }
+
+    private void OnOpenLatestClick(ExtendedBpmnMetaDefinitionDto model)
+    {
+        ClearActionMessages();
+        NavigationManager.NavigateTo(UriHelper.GetEditDefinitionUrl(model.DefinitionId));
+    }
+
+    private void OnOpenDeployedClick(ExtendedBpmnMetaDefinitionDto model)
+    {
+        ClearActionMessages();
+
+        if (!model.DeployedId.HasValue)
+        {
+            ActionErrorMessage = $"Workflow \"{model.Name}\" is not deployed yet.";
+            return;
+        }
+
+        NavigationManager.NavigateTo(UriHelper.GetEditDefinitionUrl(model.DefinitionId, model.DeployedId));
+    }
+
+    private async Task OnStartInstanceClickAsync(ExtendedBpmnMetaDefinitionDto model)
+    {
+        ClearActionMessages();
+
+        if (!model.DeployedId.HasValue)
+        {
+            ActionErrorMessage = $"Workflow \"{model.Name}\" must be deployed before it can be started.";
+            return;
+        }
+
+        StartingDefinitionId = model.DefinitionId;
+        try
+        {
+            var instance = await FlowzerApi.StartProcessInstance(model.DefinitionId);
+            ActionInfoMessage = $"Started instance {instance.InstanceId} for workflow \"{model.Name}\".";
+            NavigationManager.NavigateTo(UriHelper.GetShowInstanceUrl(instance.InstanceId));
+        }
+        catch (Exception exception)
+        {
+            ActionErrorMessage = $"Could not start workflow \"{model.Name}\". {exception.Message}";
+        }
+        finally
+        {
+            StartingDefinitionId = null;
+        }
+    }
+
+    private bool IsStartActionBusy(ExtendedBpmnMetaDefinitionDto model)
+    {
+        return string.Equals(StartingDefinitionId, model.DefinitionId, StringComparison.Ordinal);
+    }
     
     private async Task LoadData()
     {
         IsLoading = true;
+        ClearActionMessages();
         try
         {
             AllModels = (await FlowzerApi.GetAllBpmnMetaDefinitions()).ToList();
@@ -67,5 +122,11 @@ public partial class Models
         {
             IsLoading = false;
         }
+    }
+
+    private void ClearActionMessages()
+    {
+        ActionErrorMessage = null;
+        ActionInfoMessage = null;
     }
 }

--- a/src/FlowzerFrontend/Pages/Models.razor.css
+++ b/src/FlowzerFrontend/Pages/Models.razor.css
@@ -32,3 +32,23 @@
     width: 100%;
 }
 
+.model-action-group{
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.action-message{
+    margin: 12px 10px 0;
+    padding: 10px 12px;
+    border-radius: 8px;
+}
+
+.action-message-info{
+    background: #e8f5e9;
+    color: #1b5e20;
+}
+
+.action-message-error{
+    background: #ffebee;
+    color: #b71c1c;
+}

--- a/src/FlowzerFrontend/Program.cs
+++ b/src/FlowzerFrontend/Program.cs
@@ -11,6 +11,9 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 var flowzerApiOptions =
     builder.Configuration.GetSection(FlowzerApiOptions.SectionName).Get<FlowzerApiOptions>() ??
     new FlowzerApiOptions();
+var isDevelopmentLikeEnvironment =
+    builder.HostEnvironment.IsDevelopment() ||
+    string.Equals(builder.HostEnvironment.Environment, "Playwright", StringComparison.OrdinalIgnoreCase);
 
 builder.Services.AddSingleton<ExampleRestRequestBuilder>();
 builder.Services.AddSingleton(flowzerApiOptions);
@@ -21,13 +24,12 @@ builder.Services.AddScoped(_ =>
         BaseAddress = flowzerApiOptions.ResolveBaseAddress(builder.HostEnvironment.BaseAddress)
     };
 
-    flowzerApiOptions.ApplyDefaultHeaders(httpClient, builder.HostEnvironment.IsDevelopment());
+    flowzerApiOptions.ApplyDefaultHeaders(httpClient, isDevelopmentLikeEnvironment);
     return httpClient;
 });
 builder.Services.AddScoped<FlowzerApi>();
 builder.Services.AddFluentUIComponents();
 
 await builder.Build().RunAsync();
-
 
 

--- a/src/FlowzerFrontend/Properties/launchSettings.json
+++ b/src/FlowzerFrontend/Properties/launchSettings.json
@@ -13,13 +13,31 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "applicationUrl": "http://localhost:5269",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
     "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7113;http://localhost:5269",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "http-js-debug": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "applicationUrl": "http://localhost:5269",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https-js-debug": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
@@ -30,6 +48,13 @@
       }
     },
     "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express JS Debug": {
       "commandName": "IISExpress",
       "launchBrowser": true,
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",

--- a/src/FlowzerFrontend/wwwroot/appsettings.Playwright.json
+++ b/src/FlowzerFrontend/wwwroot/appsettings.Playwright.json
@@ -1,0 +1,6 @@
+{
+  "FlowzerApi": {
+    "BaseUrl": "http://localhost:5288/",
+    "DevelopmentUserId": "F70DD76D-D4A3-44D2-8A28-7547E84B7A91"
+  }
+}

--- a/src/StorageSystemShared/IDefinitionStorage.cs
+++ b/src/StorageSystemShared/IDefinitionStorage.cs
@@ -8,9 +8,11 @@ public interface IDefinitionStorage
     Task StoreBinary(Guid guid, string data);
 
     Task<string> GetBinary(Guid guid);
+    Task DeleteBinary(Guid guid) => Task.CompletedTask;
     Task<Guid[]> GetAllBinaryDefinitions();
     Task<BpmnDefinition[]> GetAllDefinitions();
     Task StoreDefinition(BpmnDefinition definition);
+    Task DeleteDefinition(Guid id) => Task.CompletedTask;
     Task<Version?> GetMaxVersionId(string modelId);
 
     Task<BpmnDefinition> GetDefinitionById(Guid id);

--- a/src/WebApiEngine.Tests/DefinitionControllerIntegrationTest.cs
+++ b/src/WebApiEngine.Tests/DefinitionControllerIntegrationTest.cs
@@ -1,0 +1,501 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using BPMN.Common;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Model;
+using StorageSystem;
+using WebApiEngine.Auth;
+using WebApiEngine.Shared;
+
+namespace WebApiEngine.Tests;
+
+[NonParallelizable]
+public class DefinitionControllerIntegrationTest
+{
+    // Testzweck: Prüft, dass für eine deployte Plain-Start-Definition direkt über die API eine Instanz gestartet und persistiert werden kann.
+    [Test]
+    public async Task StartInstance_ShouldCreatePersistedInstance_ForDeployedPlainStartDefinition()
+    {
+        const string definitionId = "workflow-ui-start";
+        var deployedDefinitionGuid = Guid.NewGuid();
+        var storage = TestStorage.Create();
+        storage.DefinitionStorageSeed.MetaDefinitions.Add(new ExtendedBpmnMetaDefinition
+        {
+            DefinitionId = definitionId,
+            Name = "Workflow UI Start"
+        });
+        storage.DefinitionStorageSeed.Definitions.Add(new BpmnDefinition
+        {
+            Id = deployedDefinitionGuid,
+            DefinitionId = definitionId,
+            Hash = "hash-start",
+            SavedByUser = Guid.NewGuid(),
+            SavedOn = DateTime.UtcNow,
+            Version = new Model.Version(1, 0),
+            IsActive = true,
+            DeployedOn = DateTime.UtcNow
+        });
+        storage.DefinitionStorageSeed.Binaries[deployedDefinitionGuid] = CreatePlainStartXml(definitionId);
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync($"/definition/meta/{definitionId}/instance", new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<ProcessInstanceInfoDto>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeTrue();
+        payload.Result.Should().NotBeNull();
+        payload.Result!.RelatedDefinitionId.Should().Be(definitionId);
+        payload.Result.RelatedDefinitionName.Should().Be("Workflow UI Start");
+        payload.Result.State.Should().Be(ProcessInstanceStateDto.Completed);
+        storage.InstanceStorageSeed.Instances.Should().ContainKey(payload.Result.InstanceId);
+    }
+
+    // Testzweck: Prüft, dass UI-Direktstarts für rein nachrichtengetriebene Prozesse kontrolliert mit BadRequest abgelehnt werden.
+    [Test]
+    public async Task StartInstance_ShouldReturnBadRequest_WhenDefinitionHasNoPlainStartEvent()
+    {
+        const string definitionId = "workflow-message-start-only";
+        var deployedDefinitionGuid = Guid.NewGuid();
+        var storage = TestStorage.Create();
+        storage.DefinitionStorageSeed.MetaDefinitions.Add(new ExtendedBpmnMetaDefinition
+        {
+            DefinitionId = definitionId,
+            Name = "Message only"
+        });
+        storage.DefinitionStorageSeed.Definitions.Add(new BpmnDefinition
+        {
+            Id = deployedDefinitionGuid,
+            DefinitionId = definitionId,
+            Hash = "hash-message",
+            SavedByUser = Guid.NewGuid(),
+            SavedOn = DateTime.UtcNow,
+            Version = new Model.Version(1, 0),
+            IsActive = true,
+            DeployedOn = DateTime.UtcNow
+        });
+        storage.DefinitionStorageSeed.Binaries[deployedDefinitionGuid] = CreateMessageStartXml(definitionId);
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync($"/definition/meta/{definitionId}/instance", new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<ProcessInstanceInfoDto>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeFalse();
+        payload.ErrorMessage.Should().Contain("cannot be started directly from the UI");
+    }
+
+    // Testzweck: Prüft, dass ein fehlgeschlagener Deploy-Versuch keine halb persistierte Definitionsversion zurücklässt.
+    [Test]
+    public async Task DeployDefinition_ShouldCleanupStoredVersion_WhenSubscriptionSetupFails()
+    {
+        const string definitionId = "workflow-deploy-cleanup";
+        var storage = TestStorage.Create(throwOnMessageSubscriptionAdd: true);
+
+        await using var factory = new TestWebApplicationFactory(storage);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync(
+            "/definition/deploy",
+            new StringContent(CreateMessageStartXml(definitionId), Encoding.UTF8, "text/plain"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var payload = await response.Content.ReadFromJsonAsync<ApiStatusResult<BpmnDefinitionDto>>();
+        payload.Should().NotBeNull();
+        payload!.Successful.Should().BeFalse();
+        payload.ErrorMessage.Should().Contain("message subscriptions");
+        storage.DefinitionStorageSeed.Definitions.Should().BeEmpty();
+        storage.DefinitionStorageSeed.Binaries.Should().BeEmpty();
+    }
+
+    private sealed class TestWebApplicationFactory(TestStorage storage) : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureAppConfiguration((_, configBuilder) =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["TimerScheduler:Enabled"] = "false"
+                });
+            });
+
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IStorageSystem>();
+                services.RemoveAll<ITransactionalStorageProvider>();
+                services.RemoveAll<ICurrentUserContextAccessor>();
+
+                services.AddSingleton<IStorageSystem>(storage);
+                services.AddSingleton<ITransactionalStorageProvider>(new TestTransactionalStorageProvider(storage));
+                services.AddSingleton<ICurrentUserContextAccessor>(new StubCurrentUserContextAccessor());
+            });
+        }
+    }
+
+    private sealed class TestTransactionalStorageProvider(TestStorage storage) : ITransactionalStorageProvider
+    {
+        public ITransactionalStorage GetTransactionalStorage()
+        {
+            return storage;
+        }
+    }
+
+    private sealed class StubCurrentUserContextAccessor : ICurrentUserContextAccessor
+    {
+        public CurrentUserContext GetCurrentUser()
+        {
+            return new CurrentUserContext(Guid.Parse("9AB0E5C5-A5B4-4F87-A857-EB821D12AF6E"), "test", false);
+        }
+    }
+
+    private sealed class TestStorage : ITransactionalStorage
+    {
+        private readonly TestDefinitionStorage _definitionStorage;
+        private readonly TestSubscriptionStorage _subscriptionStorage;
+        private readonly TestInstanceStorage _instanceStorage;
+
+        private TestStorage(
+            TestDefinitionStorage definitionStorage,
+            TestSubscriptionStorage subscriptionStorage,
+            TestInstanceStorage instanceStorage)
+        {
+            _definitionStorage = definitionStorage;
+            _subscriptionStorage = subscriptionStorage;
+            _instanceStorage = instanceStorage;
+            DefinitionStorageSeed = definitionStorage;
+            SubscriptionStorageSeed = subscriptionStorage;
+            InstanceStorageSeed = instanceStorage;
+        }
+
+        public static TestStorage Create(bool throwOnMessageSubscriptionAdd = false)
+        {
+            var definitionStorage = new TestDefinitionStorage();
+            var subscriptionStorage = new TestSubscriptionStorage(throwOnMessageSubscriptionAdd);
+            var instanceStorage = new TestInstanceStorage();
+
+            return new TestStorage(definitionStorage, subscriptionStorage, instanceStorage);
+        }
+
+        public TestDefinitionStorage DefinitionStorageSeed { get; }
+        public TestSubscriptionStorage SubscriptionStorageSeed { get; }
+        public TestInstanceStorage InstanceStorageSeed { get; }
+
+        public IDefinitionStorage DefinitionStorage => _definitionStorage;
+        public IMessageSubscriptionStorage SubscriptionStorage => _subscriptionStorage;
+        public IInstanceStorage InstanceStorage => _instanceStorage;
+        public IFormStorage FormStorage { get; } = new NoOpFormStorage();
+
+        public void CommitChanges()
+        {
+        }
+
+        public void RollbackTransaction()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class TestDefinitionStorage : IDefinitionStorage
+    {
+        public List<BpmnDefinition> Definitions { get; } = [];
+        public Dictionary<Guid, string> Binaries { get; } = [];
+        public List<ExtendedBpmnMetaDefinition> MetaDefinitions { get; } = [];
+
+        public Task StoreBinary(Guid guid, string data)
+        {
+            Binaries[guid] = data;
+            return Task.CompletedTask;
+        }
+
+        public Task<string> GetBinary(Guid guid)
+        {
+            return Task.FromResult(Binaries[guid]);
+        }
+
+        public Task DeleteBinary(Guid guid)
+        {
+            Binaries.Remove(guid);
+            return Task.CompletedTask;
+        }
+
+        public Task<Guid[]> GetAllBinaryDefinitions()
+        {
+            return Task.FromResult(Binaries.Keys.ToArray());
+        }
+
+        public Task<BpmnDefinition[]> GetAllDefinitions()
+        {
+            return Task.FromResult(Definitions.ToArray());
+        }
+
+        public Task StoreDefinition(BpmnDefinition definition)
+        {
+            Definitions.RemoveAll(existing => existing.Id == definition.Id);
+            Definitions.Add(definition);
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteDefinition(Guid id)
+        {
+            Definitions.RemoveAll(definition => definition.Id == id);
+            return Task.CompletedTask;
+        }
+
+        public Task<Model.Version?> GetMaxVersionId(string modelId)
+        {
+            var versions = Definitions
+                .Where(definition => definition.DefinitionId == modelId)
+                .Select(definition => definition.Version)
+                .ToArray();
+
+            return Task.FromResult<Model.Version?>(versions.Length == 0 ? null : versions.Max());
+        }
+
+        public Task<BpmnDefinition> GetDefinitionById(Guid id)
+        {
+            return Task.FromResult(Definitions.Single(definition => definition.Id == id));
+        }
+
+        public Task<BpmnDefinition> GetLatestDefinition(string definitionId)
+        {
+            return Task.FromResult(Definitions
+                .Where(definition => definition.DefinitionId == definitionId)
+                .MaxBy(definition => definition.Version)!);
+        }
+
+        public Task<BpmnDefinition?> GetDeployedDefinition(string definitionDefinitionId)
+        {
+            return Task.FromResult(Definitions.SingleOrDefault(definition =>
+                definition.DefinitionId == definitionDefinitionId &&
+                definition.IsActive));
+        }
+
+        public Task<ExtendedBpmnMetaDefinition[]> GetAllMetaDefinitions()
+        {
+            return Task.FromResult(MetaDefinitions.ToArray());
+        }
+
+        public Task StoreMetaDefinition(BpmnMetaDefinition metaDefinition)
+        {
+            MetaDefinitions.RemoveAll(existing => existing.DefinitionId == metaDefinition.DefinitionId);
+            MetaDefinitions.Add(new ExtendedBpmnMetaDefinition
+            {
+                DefinitionId = metaDefinition.DefinitionId,
+                Name = metaDefinition.Name,
+                Description = metaDefinition.Description
+            });
+            return Task.CompletedTask;
+        }
+
+        public Task UpdateMetaDefinition(BpmnMetaDefinition metaDefinition)
+        {
+            MetaDefinitions.RemoveAll(existing => existing.DefinitionId == metaDefinition.DefinitionId);
+            MetaDefinitions.Add(new ExtendedBpmnMetaDefinition
+            {
+                DefinitionId = metaDefinition.DefinitionId,
+                Name = metaDefinition.Name,
+                Description = metaDefinition.Description
+            });
+            return Task.CompletedTask;
+        }
+
+        public Task<BpmnMetaDefinition> GetMetaDefinitionById(string id)
+        {
+            var metadata = MetaDefinitions.Single(existing => existing.DefinitionId == id);
+            return Task.FromResult<BpmnMetaDefinition>(new BpmnMetaDefinition
+            {
+                DefinitionId = metadata.DefinitionId,
+                Name = metadata.Name,
+                Description = metadata.Description
+            });
+        }
+    }
+
+    private sealed class TestSubscriptionStorage(bool throwOnMessageSubscriptionAdd) : IMessageSubscriptionStorage
+    {
+        public List<MessageSubscription> MessageSubscriptions { get; } = [];
+
+        public Task<IEnumerable<MessageSubscription>> GetAllMessageSubscriptions() =>
+            Task.FromResult(MessageSubscriptions.AsEnumerable());
+
+        public Task<IEnumerable<MessageSubscription>> GetMessageSubscription(string messageName, string? correlationKey, Guid? messageInstanceId) =>
+            Task.FromResult(Enumerable.Empty<MessageSubscription>());
+
+        public Task<IEnumerable<MessageSubscription>> GetMessageSubscription(Guid instanceId) =>
+            Task.FromResult(MessageSubscriptions.Where(subscription => subscription.ProcessInstanceId == instanceId).AsEnumerable());
+
+        public Task AddMessageSubscription(MessageSubscription messageSubscription)
+        {
+            if (throwOnMessageSubscriptionAdd)
+            {
+                throw new InvalidOperationException("Adding message subscriptions failed.");
+            }
+
+            MessageSubscriptions.Add(messageSubscription);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveProcessMessageSubscriptionsByProcessInstanceId(Guid instanceId)
+        {
+            MessageSubscriptions.RemoveAll(subscription => subscription.ProcessInstanceId == instanceId);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveAllProcessMessageSubscriptionsWithNoInstancedId(string metaDefinitionId)
+        {
+            MessageSubscriptions.RemoveAll(subscription =>
+                subscription.ProcessInstanceId == null &&
+                subscription.RelatedDefinitionId == metaDefinitionId);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveAllProcessSignalSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
+        public void AddSignalSubscription(SignalSubscription signalSubscription) { }
+        public Task<IEnumerable<SignalSubscription>> GetSignalSubscriptions(Guid instanceId) =>
+            Task.FromResult(Enumerable.Empty<SignalSubscription>());
+        public void RemoveProcessSingalSubscriptionsByProcessInstanceId(Guid instanceId) { }
+        public Task<IEnumerable<UserTaskSubscription>> GetAllUserTasks(Guid instanceId) =>
+            Task.FromResult(Enumerable.Empty<UserTaskSubscription>());
+        public Task<IEnumerable<ExtendedUserTaskSubscription>> GetAllUserTasksExtended(Guid userId) =>
+            Task.FromResult(Enumerable.Empty<ExtendedUserTaskSubscription>());
+        public Task AddUserTaskSubscription(UserTaskSubscription userTasks) => Task.CompletedTask;
+        public Task RemoveUserTaskSubscription(Guid userTaskSubscriptionId) => Task.CompletedTask;
+        public void RemoveAllUserTaskSubscriptionsByInstanceId(Guid instanceId) { }
+        public Task RemoveAllUserTaskSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
+        public Task<IEnumerable<TimerSubscription>> GetAllTimerSubscriptions() =>
+            Task.FromResult(Enumerable.Empty<TimerSubscription>());
+        public Task<IEnumerable<TimerSubscription>> GetTimerSubscriptions(Guid instanceId) =>
+            Task.FromResult(Enumerable.Empty<TimerSubscription>());
+        public Task AddTimerSubscription(TimerSubscription timerSubscription) => Task.CompletedTask;
+        public Task RemoveTimerSubscription(Guid timerSubscriptionId) => Task.CompletedTask;
+        public Task RemoveProcessTimerSubscriptionsByProcessInstanceId(Guid instanceId) => Task.CompletedTask;
+        public Task RemoveAllProcessTimerSubscriptionsWithNoInstanceId(string relatedDefinitionId) => Task.CompletedTask;
+    }
+
+    private sealed class TestInstanceStorage : IInstanceStorage
+    {
+        public Dictionary<Guid, ProcessInstanceInfo> Instances { get; } = [];
+
+        public Task<ProcessInstanceInfo> GetProcessInstance(Guid processInstanceId)
+        {
+            return Task.FromResult(Instances[processInstanceId]);
+        }
+
+        public Task AddOrUpdateInstance(ProcessInstanceInfo processInstanceInfo)
+        {
+            Instances[processInstanceInfo.InstanceId] = processInstanceInfo;
+            return Task.CompletedTask;
+        }
+
+        public Task<IEnumerable<ProcessInstanceInfo>> GetAllActiveInstances() =>
+            Task.FromResult(Instances.Values.Where(instance => !instance.IsFinished).AsEnumerable());
+
+        public Task<IEnumerable<ProcessInstanceInfo>> GetAllInstances() =>
+            Task.FromResult(Instances.Values.AsEnumerable());
+    }
+
+    private sealed class NoOpFormStorage : IFormStorage
+    {
+        public Task SaveFormMetaData(FormMetadata formMetadata) => Task.CompletedTask;
+        public Task<FormMetadata> GetFormMetaData(Guid formId) => throw new NotSupportedException();
+        public Task<IEnumerable<FormMetadata>> GetFormMetadatas() => Task.FromResult(Enumerable.Empty<FormMetadata>());
+        public Task UpdateFormMetaData(FormMetadata formMetaData) => Task.CompletedTask;
+        public Task DeleteFormMetaData(Guid formId) => Task.CompletedTask;
+        public Task SaveForm(Form form) => Task.CompletedTask;
+        public Task<Form> GetForm(Guid id) => throw new NotSupportedException();
+        public Task<IEnumerable<Form>> GetForms(Guid formId) => Task.FromResult(Enumerable.Empty<Form>());
+        public Task DeleteForm(Guid id) => Task.CompletedTask;
+        public Task<Model.Version> GetMaxVersion(Guid formId) => Task.FromResult(new Model.Version());
+    }
+
+    private static string CreatePlainStartXml(string definitionId)
+    {
+        return $"""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                                  id="{definitionId}"
+                                  targetNamespace="http://bpmn.io/schema/bpmn">
+                  <bpmn:process id="Process_{definitionId}" isExecutable="true">
+                    <bpmn:startEvent id="StartEvent_1">
+                      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+                    </bpmn:startEvent>
+                    <bpmn:endEvent id="EndEvent_1">
+                      <bpmn:incoming>Flow_1</bpmn:incoming>
+                    </bpmn:endEvent>
+                    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
+                  </bpmn:process>
+                  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+                    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_{definitionId}">
+                      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+                        <dc:Bounds x="179" y="99" width="36" height="36" />
+                      </bpmndi:BPMNShape>
+                      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+                        <dc:Bounds x="332" y="99" width="36" height="36" />
+                      </bpmndi:BPMNShape>
+                      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+                        <di:waypoint x="215" y="117" />
+                        <di:waypoint x="332" y="117" />
+                      </bpmndi:BPMNEdge>
+                    </bpmndi:BPMNPlane>
+                  </bpmndi:BPMNDiagram>
+                </bpmn:definitions>
+                """;
+    }
+
+    private static string CreateMessageStartXml(string definitionId)
+    {
+        return $"""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                                  id="{definitionId}"
+                                  targetNamespace="http://bpmn.io/schema/bpmn">
+                  <bpmn:message id="Message_1" name="StartMessage" />
+                  <bpmn:process id="Process_{definitionId}" isExecutable="true">
+                    <bpmn:startEvent id="StartEvent_Message">
+                      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+                      <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_1" />
+                    </bpmn:startEvent>
+                    <bpmn:endEvent id="EndEvent_1">
+                      <bpmn:incoming>Flow_1</bpmn:incoming>
+                    </bpmn:endEvent>
+                    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_Message" targetRef="EndEvent_1" />
+                  </bpmn:process>
+                  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+                    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_{definitionId}">
+                      <bpmndi:BPMNShape id="StartEvent_Message_di" bpmnElement="StartEvent_Message">
+                        <dc:Bounds x="179" y="99" width="36" height="36" />
+                      </bpmndi:BPMNShape>
+                      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+                        <dc:Bounds x="332" y="99" width="36" height="36" />
+                      </bpmndi:BPMNShape>
+                      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+                        <di:waypoint x="215" y="117" />
+                        <di:waypoint x="332" y="117" />
+                      </bpmndi:BPMNEdge>
+                    </bpmndi:BPMNPlane>
+                  </bpmndi:BPMNDiagram>
+                </bpmn:definitions>
+                """;
+    }
+}

--- a/src/WebApiEngine/BusinessLogic/BpmnBusinessLogic.cs
+++ b/src/WebApiEngine/BusinessLogic/BpmnBusinessLogic.cs
@@ -1,6 +1,8 @@
 using BPMN.HumanInteraction;
 using BPMN.Process;
 using BPMN.Flowzer.Events;
+using BPMN.Events;
+using BPMN.Infrastructure;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace WebApiEngine.BusinessLogic;
@@ -292,6 +294,42 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider, IL
         return instance;
     }
 
+    public async Task<ProcessInstanceInfo> StartProcessInstance(string relatedDefinitionId, string? processId = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(relatedDefinitionId);
+
+        using var storageSystem = storageProvider.GetTransactionalStorage();
+
+        var deployedDefinition = await storageSystem.DefinitionStorage.GetDeployedDefinition(relatedDefinitionId)
+            ?? throw new InvalidOperationException(
+                $"No deployed definition is available for workflow \"{relatedDefinitionId}\".");
+
+        var xmlData = await storageSystem.DefinitionStorage.GetBinary(deployedDefinition.Id);
+        var model = ModelParser.ParseModel(xmlData);
+        var process = ResolveDirectStartProcess(model, deployedDefinition, processId);
+
+        var processEngine = new ProcessEngine(process);
+        var instance = processEngine.StartProcess();
+        var processInstanceInfo = CreateProcessInstanceInfo(
+            deployedDefinition.Id,
+            relatedDefinitionId,
+            process.Id,
+            instance);
+
+        await SaveSubscriptions(
+            storageSystem,
+            instance,
+            relatedDefinitionId,
+            deployedDefinition.Id,
+            process.Id,
+            instance.InstanceId);
+        await storageSystem.InstanceStorage.AddOrUpdateInstance(processInstanceInfo);
+
+        storageSystem.CommitChanges();
+
+        return processInstanceInfo;
+    }
+
     private async Task SaveInstance(ITransactionalStorage storageSystem, InstanceEngine instance, string relatedDefinitionId, Guid definitionId, string processId)
     {
         await SaveSubscriptions(storageSystem, instance, relatedDefinitionId, definitionId, processId, instance.InstanceId);
@@ -325,20 +363,7 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider, IL
         ITransactionalStorage storageSystem, InstanceEngine instance)
     {
         await storageSystem.InstanceStorage.AddOrUpdateInstance(
-            new ProcessInstanceInfo()
-            {
-                InstanceId = instance.InstanceId,
-                metaDefinitionId = relatedDefinitionId,
-                DefinitionId = definitionId,
-                ProcessId = processId,
-                Tokens = instance.Tokens,
-                IsFinished = instance.IsFinished,
-                State = instance.State,
-                MessageSubscriptionCount = instance.ActiveCatchMessages.Count,
-                SignalSubscriptionCount = instance.ActiveCatchSignals.Count,
-                UserTaskSubscriptionCount = instance.GetActiveUserTasks().Count(),
-                ServiceSubscriptionCount = instance.GetActiveServiceTasks().Count()
-            });
+            CreateProcessInstanceInfo(definitionId, relatedDefinitionId, processId, instance));
     }
 
     private async Task RestoreInstanceTimerSubscriptions()
@@ -471,6 +496,72 @@ public class BpmnBusinessLogic(ITransactionalStorageProvider storageProvider, IL
             RemainingOccurrences = nextSchedule.RemainingOccurrences
         };
         return true;
+    }
+
+    private static Process ResolveDirectStartProcess(
+        Definitions model,
+        BpmnDefinition deployedDefinition,
+        string? processId)
+    {
+        var executableProcesses = model
+            .GetProcesses()
+            .Where(process => process.IsExecutable)
+            .ToArray();
+
+        if (executableProcesses.Length == 0)
+        {
+            throw new InvalidOperationException(
+                $"The deployed definition \"{deployedDefinition.DefinitionId}\" does not contain an executable process.");
+        }
+
+        var process = string.IsNullOrWhiteSpace(processId)
+            ? executableProcesses.Length switch
+            {
+                1 => executableProcesses[0],
+                _ => throw new InvalidOperationException(
+                    $"The deployed definition \"{deployedDefinition.DefinitionId}\" contains multiple executable processes. Manual UI starts currently require exactly one executable process.")
+            }
+            : executableProcesses.SingleOrDefault(candidate =>
+                  string.Equals(candidate.Id, processId, StringComparison.Ordinal))
+              ?? throw new InvalidOperationException(
+                  $"The executable process \"{processId}\" was not found in deployed definition \"{deployedDefinition.DefinitionId}\".");
+
+        var directStartFlowNodes = process.GetStartFlowNodes()
+            .Where(flowNode =>
+                flowNode.GetType() == typeof(StartEvent) ||
+                flowNode.GetType() == typeof(BPMN.Activities.Activity))
+            .ToArray();
+
+        return directStartFlowNodes.Length switch
+        {
+            0 => throw new InvalidOperationException(
+                $"The process \"{process.Id}\" cannot be started directly from the UI because it has no plain start event."),
+            1 => process,
+            _ => throw new InvalidOperationException(
+                $"The process \"{process.Id}\" contains multiple plain start entries. Manual UI starts currently require exactly one plain start path.")
+        };
+    }
+
+    private static ProcessInstanceInfo CreateProcessInstanceInfo(
+        Guid definitionId,
+        string relatedDefinitionId,
+        string processId,
+        InstanceEngine instance)
+    {
+        return new ProcessInstanceInfo
+        {
+            InstanceId = instance.InstanceId,
+            metaDefinitionId = relatedDefinitionId,
+            DefinitionId = definitionId,
+            ProcessId = processId,
+            Tokens = instance.Tokens,
+            IsFinished = instance.IsFinished,
+            State = instance.State,
+            MessageSubscriptionCount = instance.ActiveCatchMessages.Count,
+            SignalSubscriptionCount = instance.ActiveCatchSignals.Count,
+            UserTaskSubscriptionCount = instance.GetActiveUserTasks().Count(),
+            ServiceSubscriptionCount = instance.GetActiveServiceTasks().Count()
+        };
     }
 
 

--- a/src/WebApiEngine/Controller/DefinitionController.cs
+++ b/src/WebApiEngine/Controller/DefinitionController.cs
@@ -21,20 +21,43 @@ public class DefinitionController(
     [HttpPost("deploy")]
     public async Task<ActionResult<ApiStatusResult<BpmnDefinitionDto>>> DeployDefinition([FromQuery] Guid? previousGuid)
     {
+        BpmnDefinition? definition = null;
+
         try
         {
             var rawContent = await GetRawContent();
-            var definition = await definitionBusinessLogic.StoreDefinition(rawContent, previousGuid, true);
+            definition = await definitionBusinessLogic.StoreDefinition(rawContent, previousGuid, true);
             await bpmnBusinessLogic.DeployDefinition(definition);
             return Ok(new ApiStatusResult<BpmnDefinitionDto>(definition.ToDto()));
         }
         catch (UnauthorizedAccessException)
         {
+            await CleanupFailedDeployVersionAsync(definition);
             throw;
         }
         catch (Exception e)
         {
+            await CleanupFailedDeployVersionAsync(definition);
             return BadRequest(new ApiStatusResult<BpmnDefinitionDto>(e.Message));
+        }
+    }
+
+    [HttpPost("meta/{id}/instance")]
+    public async Task<ActionResult<ApiStatusResult<ProcessInstanceInfoDto>>> StartInstance([FromRoute] string id)
+    {
+        try
+        {
+            var processInstance = await bpmnBusinessLogic.StartProcessInstance(id);
+            var processInstanceDto = await processInstance.ToDtoAsync(storageSystem.DefinitionStorage);
+            return Ok(new ApiStatusResult<ProcessInstanceInfoDto>(processInstanceDto));
+        }
+        catch (UnauthorizedAccessException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            return BadRequest(new ApiStatusResult<ProcessInstanceInfoDto>(exception.Message));
         }
     }
 
@@ -141,5 +164,23 @@ public class DefinitionController(
 
  
     #endregion
-    
+
+    private async Task CleanupFailedDeployVersionAsync(BpmnDefinition? definition)
+    {
+        if (definition == null)
+        {
+            return;
+        }
+
+        try
+        {
+            await storageSystem.DefinitionStorage.DeleteBinary(definition.Id);
+            await storageSystem.DefinitionStorage.DeleteDefinition(definition.Id);
+        }
+        catch
+        {
+            // Best effort only: the original deploy error is more relevant for the caller
+            // than cleanup follow-up problems in the date-based storage fallback.
+        }
+    }
 }

--- a/src/WebApiEngine/Controller/InstanceController.cs
+++ b/src/WebApiEngine/Controller/InstanceController.cs
@@ -14,33 +14,8 @@ public class InstanceController(
     public async Task<ActionResult<IEnumerable<ProcessInstanceInfoDto>>> GetAllInstances()
     {
         var instances = await storageSystem.InstanceStorage.GetAllInstances();
-        return Ok(await MapInstances(instances));
-    }
-
-    private async Task<ApiStatusResult<List<ProcessInstanceInfoDto>>> MapInstances(IEnumerable<ProcessInstanceInfo> instances)
-    {
-        var data = await Task.WhenAll(instances.Select(MapInstance));
-        var apiStatusResult = new ApiStatusResult<List<ProcessInstanceInfoDto>>(data.ToList());
-        return apiStatusResult;
-    }
-
-    private async Task<ProcessInstanceInfoDto> MapInstance(ProcessInstanceInfo processInstanceInfo)
-    {
-        return new ProcessInstanceInfoDto()
-        {
-            InstanceId = processInstanceInfo.InstanceId,
-            DefinitionId = processInstanceInfo.DefinitionId,
-            RelatedDefinitionId = processInstanceInfo.metaDefinitionId,
-            RelatedDefinitionName =
-                (await storageSystem.DefinitionStorage.GetMetaDefinitionById(processInstanceInfo.metaDefinitionId))
-                .Name,
-            MessageSubscriptionCount = processInstanceInfo.MessageSubscriptionCount,
-            SignalSubscriptionCount = processInstanceInfo.SignalSubscriptionCount,
-            UserTaskSubscriptionCount = processInstanceInfo.UserTaskSubscriptionCount,
-            ServiceSubscriptionCount = processInstanceInfo.ServiceSubscriptionCount,
-            State = (ProcessInstanceStateDto)processInstanceInfo.State,
-            Tokens = processInstanceInfo.Tokens.Select(token => token.ToDto()).ToList(),
-        };
+        var mappedInstances = await instances.ToDtosAsync(storageSystem.DefinitionStorage);
+        return Ok(new ApiStatusResult<List<ProcessInstanceInfoDto>>(mappedInstances));
     }
 
 
@@ -49,8 +24,8 @@ public class InstanceController(
     public async Task<ActionResult<ProcessInstanceInfoDto>> GetInstanceById(Guid instanceId)
     {
         var instance = await storageSystem.InstanceStorage.GetProcessInstance(instanceId);
-        var mapInstance = await MapInstance(instance);
-        return Ok(new ApiStatusResult<ProcessInstanceInfoDto>(mapInstance));
+        var mappedInstance = await instance.ToDtoAsync(storageSystem.DefinitionStorage);
+        return Ok(new ApiStatusResult<ProcessInstanceInfoDto>(mappedInstance));
     }
     
     [HttpGet("{instanceId}/subscription/messages")]

--- a/src/WebApiEngine/Mappers/ProcessInstanceMappingExtensions.cs
+++ b/src/WebApiEngine/Mappers/ProcessInstanceMappingExtensions.cs
@@ -1,0 +1,46 @@
+using WebApiEngine.Shared;
+
+namespace WebApiEngine.Mappers;
+
+/// <summary>
+/// Bündelt das Mapping von gespeicherten Prozessinstanzen in API-DTOs.
+/// </summary>
+public static class ProcessInstanceMappingExtensions
+{
+    public static async Task<ProcessInstanceInfoDto> ToDtoAsync(
+        this ProcessInstanceInfo processInstanceInfo,
+        IDefinitionStorage definitionStorage)
+    {
+        ArgumentNullException.ThrowIfNull(processInstanceInfo);
+        ArgumentNullException.ThrowIfNull(definitionStorage);
+
+        var definitionMetadata = await definitionStorage.GetMetaDefinitionById(processInstanceInfo.metaDefinitionId);
+
+        return new ProcessInstanceInfoDto
+        {
+            InstanceId = processInstanceInfo.InstanceId,
+            DefinitionId = processInstanceInfo.DefinitionId,
+            RelatedDefinitionId = processInstanceInfo.metaDefinitionId,
+            RelatedDefinitionName = definitionMetadata.Name,
+            MessageSubscriptionCount = processInstanceInfo.MessageSubscriptionCount,
+            SignalSubscriptionCount = processInstanceInfo.SignalSubscriptionCount,
+            UserTaskSubscriptionCount = processInstanceInfo.UserTaskSubscriptionCount,
+            ServiceSubscriptionCount = processInstanceInfo.ServiceSubscriptionCount,
+            State = (ProcessInstanceStateDto)processInstanceInfo.State,
+            Tokens = processInstanceInfo.Tokens.Select(token => token.ToDto()).ToList()
+        };
+    }
+
+    public static async Task<List<ProcessInstanceInfoDto>> ToDtosAsync(
+        this IEnumerable<ProcessInstanceInfo> processInstances,
+        IDefinitionStorage definitionStorage)
+    {
+        ArgumentNullException.ThrowIfNull(processInstances);
+        ArgumentNullException.ThrowIfNull(definitionStorage);
+
+        var mappedInstances = await Task.WhenAll(
+            processInstances.Select(instance => instance.ToDtoAsync(definitionStorage)));
+
+        return mappedInstances.ToList();
+    }
+}

--- a/tests/ui-smoke/playwright.config.js
+++ b/tests/ui-smoke/playwright.config.js
@@ -2,8 +2,8 @@ const fs = require('fs');
 const path = require('path');
 const { defineConfig } = require('@playwright/test');
 
-const frontendUrl = process.env.FLOWZER_FRONTEND_URL || 'http://localhost:5269';
-const apiUrl = process.env.FLOWZER_API_URL || 'http://localhost:5182';
+const frontendUrl = process.env.FLOWZER_FRONTEND_URL || 'http://localhost:5290';
+const apiUrl = process.env.FLOWZER_API_URL || 'http://localhost:5288';
 const frontendServerOrigin = new URL(frontendUrl).origin;
 const apiServerOrigin = new URL(apiUrl).origin;
 const playwrightTempRoot = path.resolve(__dirname, '.tmp');
@@ -11,6 +11,8 @@ const managedStorageRoot = path.resolve(
   process.env.PLAYWRIGHT_MANAGED_STORAGE_ROOT || path.join(playwrightTempRoot, 'storage')
 );
 const reuseExistingServer = !process.env.CI && process.env.PLAYWRIGHT_REUSE_EXISTING_SERVER === '1';
+const apiEnvironmentName = process.env.FLOWZER_API_ENVIRONMENT || 'Development';
+const frontendEnvironmentName = process.env.FLOWZER_FRONTEND_ENVIRONMENT || 'Playwright';
 
 function isPathWithin(parentPath, childPath)
 {
@@ -31,10 +33,19 @@ if (!process.env.PLAYWRIGHT_SKIP_WEBSERVERS)
   fs.mkdirSync(managedStorageRoot, { recursive: true });
 }
 
-const webServerEnvironment = {
+const sharedWebServerEnvironment = {
   ...process.env,
-  ASPNETCORE_ENVIRONMENT: process.env.ASPNETCORE_ENVIRONMENT || 'Development',
   FLOWZER_STORAGE_ROOT: managedStorageRoot
+};
+
+const apiWebServerEnvironment = {
+  ...sharedWebServerEnvironment,
+  ASPNETCORE_ENVIRONMENT: apiEnvironmentName
+};
+
+const frontendWebServerEnvironment = {
+  ...sharedWebServerEnvironment,
+  ASPNETCORE_ENVIRONMENT: frontendEnvironmentName
 };
 
 module.exports = defineConfig({
@@ -55,14 +66,14 @@ module.exports = defineConfig({
     : [
         {
           command: `dotnet run --project ../../src/WebApiEngine/WebApiEngine.csproj --configuration Release --no-build --no-launch-profile --urls ${apiServerOrigin}`,
-          env: webServerEnvironment,
+          env: apiWebServerEnvironment,
           url: `${apiServerOrigin}/swagger/index.html`,
           reuseExistingServer,
           timeout: 120_000
         },
         {
           command: `dotnet run --project ../../src/FlowzerFrontend/FlowzerFrontend.csproj --configuration Release --no-build --no-launch-profile --urls ${frontendServerOrigin}`,
-          env: webServerEnvironment,
+          env: frontendWebServerEnvironment,
           url: frontendServerOrigin,
           reuseExistingServer,
           timeout: 120_000

--- a/tests/ui-smoke/support/flowzer-api.js
+++ b/tests/ui-smoke/support/flowzer-api.js
@@ -1,6 +1,6 @@
 const { randomUUID } = require('crypto');
 
-const apiUrl = process.env.FLOWZER_API_URL || 'http://localhost:5182';
+const apiUrl = process.env.FLOWZER_API_URL || 'http://localhost:5288';
 const developmentUserIdHeaderName = 'X-Flowzer-UserId';
 const developmentUserId =
   process.env.FLOWZER_DEVELOPMENT_USER_ID ||
@@ -125,6 +125,48 @@ function buildMessageStartUserTaskXml({
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
+  </bpmn:definitions>`;
+}
+
+function buildPlainStartXml({ definitionId }) {
+  const safeDefinitionId = toSafeId(definitionId);
+  const processId = `Process_${safeDefinitionId}`;
+  const startEventId = `StartEvent_${safeDefinitionId}`;
+  const endEventId = `EndEvent_${safeDefinitionId}`;
+  const flowId = `Flow_${safeDefinitionId}_1`;
+  const diagramId = `BPMNDiagram_${safeDefinitionId}`;
+  const planeId = `BPMNPlane_${safeDefinitionId}`;
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  id="${definitionId}"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="${processId}" isExecutable="true">
+    <bpmn:startEvent id="${startEventId}" name="Start">
+      <bpmn:outgoing>${flowId}</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="${endEventId}" name="Done">
+      <bpmn:incoming>${flowId}</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="${flowId}" sourceRef="${startEventId}" targetRef="${endEventId}" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="${diagramId}">
+    <bpmndi:BPMNPlane id="${planeId}" bpmnElement="${processId}">
+      <bpmndi:BPMNShape id="${startEventId}_di" bpmnElement="${startEventId}">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="${endEventId}_di" bpmnElement="${endEventId}">
+        <dc:Bounds x="332" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="${flowId}_di" bpmnElement="${flowId}">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="332" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
 </bpmn:definitions>`;
 }
 
@@ -189,6 +231,24 @@ async function deployDefinition(request, { xml }) {
   };
 }
 
+async function startProcessInstance(request, { definitionId }) {
+  const response = await request.post(
+    buildApiUrl(`/definition/meta/${definitionId}/instance`),
+    buildRequestOptions({
+      data: {}
+    })
+  );
+
+  const instance = ensureApiSuccess(
+    await readJson(response, 'Starting process instance'),
+    'Starting process instance');
+
+  return {
+    instanceId: instance?.instanceId || instance?.InstanceId,
+    relatedDefinitionId: instance?.relatedDefinitionId || instance?.RelatedDefinitionId
+  };
+}
+
 async function sendMessage(request, { name, correlationKey = null, variables = {}, instanceId = null }) {
   const response = await request.post(buildApiUrl('/message'), buildRequestOptions({
     data: {
@@ -221,6 +281,7 @@ async function completeUserTask(request, userTask, data = {}) {
 }
 
 module.exports = {
+  buildPlainStartXml,
   buildMessageStartUserTaskXml,
   createDefinitionMeta,
   createFormSchema,
@@ -228,6 +289,7 @@ module.exports = {
   getUserTasks,
   saveForm,
   sendMessage,
+  startProcessInstance,
   completeUserTask,
   randomUUID
 };

--- a/tests/ui-smoke/tests/core-paths.spec.js
+++ b/tests/ui-smoke/tests/core-paths.spec.js
@@ -1,5 +1,6 @@
 const { test, expect } = require('@playwright/test');
 const {
+  buildPlainStartXml,
   buildMessageStartUserTaskXml,
   createDefinitionMeta,
   createFormSchema,
@@ -7,6 +8,7 @@ const {
   getUserTasks,
   saveForm,
   sendMessage,
+  startProcessInstance,
   completeUserTask
 } = require('../support/flowzer-api');
 
@@ -16,6 +18,7 @@ function createSuffix(prefix) {
 
 let runtimeScenarioPromise;
 let modelerScenarioPromise;
+let directStartScenarioPromise;
 
 async function ensureRuntimeScenario(request) {
   if (runtimeScenarioPromise) {
@@ -88,6 +91,32 @@ async function ensureModelerScenario(request) {
   })();
 
   return modelerScenarioPromise;
+}
+
+async function ensureDirectStartScenario(request) {
+  if (directStartScenarioPromise) {
+    return directStartScenarioPromise;
+  }
+
+  directStartScenarioPromise = (async () => {
+    const modelName = createSuffix('UI Smoke Direct Start');
+    const definitionId = await createDefinitionMeta(request, {
+      name: modelName,
+      description: 'Playwright direct-start workflow path.'
+    });
+
+    const deployedDefinition = await deployDefinition(request, {
+      xml: buildPlainStartXml({ definitionId })
+    });
+
+    return {
+      definitionId,
+      definitionGuid: deployedDefinition.definitionGuid,
+      modelName
+    };
+  })();
+
+  return directStartScenarioPromise;
 }
 
 // Testzweck: Prüft, dass ein per API angelegtes Formular in Liste und Detailansicht des Frontends stabil geladen wird.
@@ -167,6 +196,31 @@ test('Der Modeler speichert mit Versionsbezug und aktualisiert die Definitionsro
   await expect(page.locator('#definition-load-error')).toHaveCount(0);
 });
 
+// Testzweck: Prüft, dass die Modellliste explizite Öffnen-/Starten-Aktionen anbietet und ein Direktstart in die Instanzansicht navigiert.
+test('Die Modellliste bietet Öffnen und Direktstart für deployte Workflows', async ({ page, request }) => {
+  const directStartScenario = await ensureDirectStartScenario(request);
+  const { definitionId, definitionGuid, modelName } = directStartScenario;
+
+  await page.goto('/models', { waitUntil: 'networkidle' });
+
+  await expect(page.locator(`#model-open-latest-${definitionId}`)).toBeVisible();
+  await expect(page.locator(`#model-open-deployed-${definitionId}`)).toBeVisible();
+  await expect(page.locator(`#model-start-instance-${definitionId}`)).toBeVisible();
+
+  await page.locator(`#model-open-deployed-${definitionId}`).click();
+  await expect(page).toHaveURL(new RegExp(`/definition/${definitionId}/${definitionGuid}$`));
+  await expect(page.locator('#definition-state-badge')).toContainText('Deployed');
+  await expect(page.getByRole('button', { name: 'Start instance' })).toBeVisible();
+  await expect(page.locator('#blazor-error-ui')).toBeHidden();
+
+  await page.goto('/models', { waitUntil: 'networkidle' });
+  await page.locator(`#model-start-instance-${definitionId}`).click();
+
+  await expect(page).toHaveURL(/\/instance\/[0-9a-f-]+$/);
+  await expect(page.locator('#instance-name')).toContainText(modelName);
+  await expect(page.locator('#js-canvas .djs-container')).toBeVisible();
+});
+
 // Testzweck: Prüft den UI-Happy-Path von Message-Start über offenen User-Task bis zur abgeschlossenen Instanzansicht.
 test('Message-Start-Prozess wandert von offenem Task zu Done Instances', async ({ page, request }) => {
   const runtimeScenario = await ensureRuntimeScenario(request);
@@ -203,4 +257,16 @@ test('Message-Start-Prozess wandert von offenem Task zu Done Instances', async (
 
   await page.goto('/instances/done', { waitUntil: 'networkidle' });
   await expect(page.getByRole('link', { name: modelName })).toBeVisible();
+});
+
+// Testzweck: Prüft, dass der neue Direktstart-Endpunkt auch außerhalb der UI einen manuellen Startpfad für deployte Workflows bietet.
+test('Deployte Plain-Start-Workflows lassen sich per API direkt starten', async ({ request }) => {
+  const directStartScenario = await ensureDirectStartScenario(request);
+
+  const startedInstance = await startProcessInstance(request, {
+    definitionId: directStartScenario.definitionId
+  });
+
+  expect(startedInstance.instanceId).toBeTruthy();
+  expect(startedInstance.relatedDefinitionId).toBe(directStartScenario.definitionId);
 });


### PR DESCRIPTION
## Zusammenfassung

Dieser PR modernisiert den Workflow-Einstieg im Frontend, ergänzt einen direkten Instanzstart aus der UI und härtet den Speichern-/Deploy-Pfad im Backend.

## Was wurde umgesetzt?

### Frontend / UX
- explizite Aktionen in der Modellliste statt reinem Klick auf den Titel
  - `Open`
  - `Open deployed`
  - `Start instance`
- direkter Instanzstart auch aus der Definitionsansicht für deployte Workflows
- klarere Inline-Statusmeldungen für Aktionen auf Modell- und Definitionsseiten
- ruhigere Standard-Launch-Profile ohne automatisches JS-Debugging über `inspectUri`
- separate JS-Debug-Profile bleiben für explizites Debugging erhalten

### Backend / API
- neuer Endpunkt zum direkten Starten einer Prozessinstanz aus einer deployten Workflow-Definition
- gemeinsames Mapping für Prozessinstanz-DTOs
- best-effort Cleanup, falls ein Deploy nach dem Speichern fehlschlägt, damit keine halbgültige Definitionsversion liegen bleibt
- Delete-Support im dateibasierten Definition-Storage ergänzt

### Test- und Smoke-Pfad
- neue Web-API-Integrationstests für Direktstart und Deploy-Rollback
- neue Frontend-/API-Helfer für den Direktstart-Pfad
- UI-Smokes um die neuen Workflow-Aktionen ergänzt
- Playwright nutzt jetzt standardmäßig einen eigenen, konfliktarmen Stack:
  - API: `http://localhost:5288`
  - Frontend: `http://localhost:5290`
- das Frontend bekommt dafür eine eigene `Playwright`-Konfiguration, damit lokale Debug-Sessions auf `5182`/`5269` nicht versehentlich mit den Smoke-Tests vermischt werden

## Warum?

- der bisherige UX-Pfad über einen Klick auf den Workflow-Titel war unnötig versteckt
- der vom Nutzer beobachtete erste Deploy-Fehler konnte zu inkonsistentem Speichern/Deploy-Verhalten führen
- lokale UI-Smokes konnten bislang versehentlich gegen laufende Debug-Instanzen sprechen
- normale Frontend-Starts sollten nicht automatisch in JS-Haltepunkte laufen

## Validierung

```bash
python3 scripts/ci/check_test_purpose_comments.py
dotnet build core-engine.sln --configuration Release
dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'
dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'
dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-build --logger 'console;verbosity=minimal'
npm --prefix tests/ui-smoke run test
```

## Bezug

- Bezieht sich auf #108
