### PR TITLE
Toolchain auf .NET 10 und aktuelle NuGet-Stände anheben

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Bitte lies zuerst:
 
 ### .NET
 
-Empfohlen wird aktuell **.NET 8**.
+Empfohlen wird aktuell **.NET 10 SDK**. `global.json` ist die technische Quelle für die verwendete SDK-Version; README und diese Beitragsdoku sind die dokumentarische Referenz.
 
 ```bash
 dotnet restore core-engine.sln

--- a/DEVELOPMENT-GUIDELINES.md
+++ b/DEVELOPMENT-GUIDELINES.md
@@ -2,7 +2,7 @@
 
 ## Übersicht
 
-Dieses Dokument definiert die Entwicklungsrichtlinien und Best Practices für das flowzer-bpmn-core-engine Projekt - eine BPMN 2.0 konforme Ausführungsengine in C# .NET 8.
+Dieses Dokument definiert die Entwicklungsrichtlinien und Best Practices für das flowzer-bpmn-core-engine Projekt - eine BPMN 2.0 orientierte Ausführungsengine in C# auf **.NET 10**. Maßgeblich für die konkrete SDK-Version ist `global.json`.
 
 ## Projektstruktur
 
@@ -31,7 +31,7 @@ src/
 - Klare Interface-Abgrenzungen zwischen den Schichten
 
 ### 3. Modern C# Practices
-- .NET 8 Target Framework
+- .NET 10 Target Framework
 - Nullable Reference Types aktiviert
 - Primary Constructors für einfache Klassen
 - `required` Properties für essentielle Daten

--- a/Model/Model.csproj
+++ b/Model/Model.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Mehr Details: [docs/PROJECT-STATUS.md](docs/PROJECT-STATUS.md)
 
 ### Voraussetzungen
 
-- **.NET 8 SDK** empfohlen
+- **.NET 10 SDK** (siehe `global.json`)
 - **Node.js 20+** für `/bpmn.io`
 - Git
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -110,6 +110,20 @@ Die Playwright-Konfiguration startet Web-API und Frontend standardmäßig selbst
 PLAYWRIGHT_SKIP_WEBSERVERS=1 npm --prefix tests/ui-smoke run test
 ```
 
+Wenn dieser Skip-Pfad verwendet wird, muss das Frontend unter **.NET 10** ebenfalls explizit mit der gewünschten WASM-Umgebung gestartet werden. Für den Playwright-Fall sieht ein passender manueller Start z. B. so aus:
+
+```bash
+ASPNETCORE_ENVIRONMENT=Playwright \
+dotnet run --project src/FlowzerFrontend/FlowzerFrontend.csproj \
+  --configuration Release \
+  --no-build \
+  --no-launch-profile \
+  -p:WasmApplicationEnvironmentName=Playwright \
+  --urls http://localhost:5290
+```
+
+Alternativ kann die Playwright-Konfiguration über `FLOWZER_FRONTEND_ENVIRONMENT=<env>` auf eine andere Client-Umgebung gestellt werden; wichtig ist in jedem Fall, dass `WasmApplicationEnvironmentName` und die erwartete `appsettings.<env>.json` zusammenpassen.
+
 Für verwaltete Playwright-Läufe werden absichtlich eigene Ports genutzt, damit lokale Debug-Sessions auf `5182`/`5269` nicht mit den Smoke-Tests kollidieren:
 
 - Web-API: `http://localhost:5288`

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -41,6 +41,7 @@ ASPNETCORE_ENVIRONMENT=Development \
   dotnet run --project src/FlowzerFrontend/FlowzerFrontend.csproj \
   --configuration Release \
   --no-launch-profile \
+  -p:WasmApplicationEnvironmentName=Development \
   --urls http://localhost:5269
 ```
 
@@ -113,6 +114,8 @@ Für verwaltete Playwright-Läufe werden absichtlich eigene Ports genutzt, damit
 
 - Web-API: `http://localhost:5288`
 - Frontend: `http://localhost:5290`
+
+Seit dem Upgrade auf **.NET 10** wird die Client-Umgebung einer Standalone-Blazor-WASM-App nicht mehr zuverlässig über `launchSettings.json` bzw. nur über den Host-Prozess gesteuert. Für die UI-Smokes startet die Playwright-Konfiguration das Frontend deshalb explizit mit `-p:WasmApplicationEnvironmentName=Playwright`, damit weiterhin `appsettings.Playwright.json` statt `appsettings.Development.json` geladen wird.
 
 Der `npm test`-Pfad verwendet zusätzlich einen kleinen Prozesswächter. Dieser erkennt alte verwaiste `ms-playwright`-/`chrome-headless-shell`-Prozesse aus früheren Läufen und räumt nach dem Test auch neu entstandene Browser-Reste wieder weg. Damit bleiben keine CPU-intensiven Headless-Prozesse mehr unbemerkt liegen.
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.204",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/FilesystemStorageSystem/FilesystemStorageSystem.csproj
+++ b/src/FilesystemStorageSystem/FilesystemStorageSystem.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/Flowzer.Shared/Flowzer.Shared.csproj
+++ b/src/Flowzer.Shared/Flowzer.Shared.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.ClearScript.V8" Version="7.4.5" />
+      <PackageReference Include="Microsoft.ClearScript.V8" Version="7.5.0" />
     </ItemGroup>
 
 </Project>

--- a/src/FlowzerBPMN/FlowzerBPMN.csproj
+++ b/src/FlowzerBPMN/FlowzerBPMN.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>BPMN</RootNamespace>

--- a/src/FlowzerDemoConsole/FlowzerDemoConsole.csproj
+++ b/src/FlowzerDemoConsole/FlowzerDemoConsole.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>FlowzerDemoConsole</RootNamespace>

--- a/src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj
+++ b/src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="coverlet.collector" Version="8.0.1" />
+    <PackageReference Include="FluentAssertions" Version="8.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FlowzerFrontend/FlowzerFrontend.csproj
+++ b/src/FlowzerFrontend/FlowzerFrontend.csproj
@@ -1,18 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.6" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.6" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.10.1" />
-        <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.6.0" />
-        <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.10.0" />
-        <PackageReference Include="System.Text.Json" Version="8.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.6" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.6" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.0" />
+        <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.14.0" />
+        <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/FlowzerFrontend/_Imports.razor
+++ b/src/FlowzerFrontend/_Imports.razor
@@ -1,4 +1,4 @@
-﻿@using System.Net.Http
+@using System.Net.Http
 @using System.Net.Http.Json
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
@@ -8,3 +8,4 @@
 @using Microsoft.JSInterop
 @using FlowzerFrontend
 @using FlowzerFrontend.Layout
+@using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons

--- a/src/StorageSystemShared/StorageSystemShared.csproj
+++ b/src/StorageSystemShared/StorageSystemShared.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>StorageSystem</RootNamespace>

--- a/src/WebApiEngine.Shared/WebApiEngine.Shared.csproj
+++ b/src/WebApiEngine.Shared/WebApiEngine.Shared.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>
 
 </Project>

--- a/src/WebApiEngine.Tests/WebApiEngine.Tests.csproj
+++ b/src/WebApiEngine.Tests/WebApiEngine.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
@@ -9,13 +9,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0" />
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.4" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="NUnit" Version="3.14.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+        <PackageReference Include="coverlet.collector" Version="8.0.1" />
+        <PackageReference Include="FluentAssertions" Version="8.9.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageReference Include="NUnit" Version="4.5.1" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.12.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/WebApiEngine/WebApiEngine.csproj
+++ b/src/WebApiEngine/WebApiEngine.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
         <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.2" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
         <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
         <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/core-engine-tests/EngineTest.cs
+++ b/src/core-engine-tests/EngineTest.cs
@@ -460,8 +460,8 @@ public class EngineTest
         var remainingTime = dueDate - DateTime.UtcNow;
         using (new AssertionScope())
         {
-            remainingTime.Should().BeGreaterOrEqualTo(TimeSpan.FromSeconds(1));
-            remainingTime.Should().BeLessOrEqualTo(TimeSpan.FromSeconds(2.5));
+            remainingTime.Should().BeGreaterThanOrEqualTo(TimeSpan.FromSeconds(1));
+            remainingTime.Should().BeLessThanOrEqualTo(TimeSpan.FromSeconds(2.5));
             timerSubscription.RemainingOccurrences.Should().Be(10);
         }
     }

--- a/src/core-engine-tests/JavaScriptExpressionTest.cs
+++ b/src/core-engine-tests/JavaScriptExpressionTest.cs
@@ -83,7 +83,7 @@ public class JavaScriptExpressionTest
             stopwatch.Stop();
 
             result.Should().Be("Mike");
-            TestContext.WriteLine($"FEEL-Auswertung erfolgreich in {stopwatch.ElapsedMilliseconds} ms");
+            TestContext.Out.WriteLine($"FEEL-Auswertung erfolgreich in {stopwatch.ElapsedMilliseconds} ms");
         }
         catch (Exception exception) when (IsMissingV8Dependency(exception))
         {
@@ -123,6 +123,6 @@ public class ConsoleWrapper
     public void Log(string message)
     {
         Console.WriteLine(message);
-        TestContext.WriteLine(message);
+        TestContext.Out.WriteLine(message);
     }
 }

--- a/src/core-engine-tests/core-engine-tests.csproj
+++ b/src/core-engine-tests/core-engine-tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <RootNamespace>core_engine_tests</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
@@ -12,12 +12,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Include="NUnit" Version="3.14.0"/>
-        <PackageReference Include="NUnit.Analyzers" Version="3.9.0"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0"/>
+        <PackageReference Include="coverlet.collector" Version="8.0.1"/>
+        <PackageReference Include="FluentAssertions" Version="8.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0"/>
+        <PackageReference Include="NUnit" Version="4.5.1"/>
+        <PackageReference Include="NUnit.Analyzers" Version="4.12.0"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/core-engine/InstanceEngine/InstanceEngine.cs
+++ b/src/core-engine/InstanceEngine/InstanceEngine.cs
@@ -88,7 +88,7 @@ public partial class InstanceEngine
         }
         
         // Process- und SubProcess-Tokens werden rückwärts durchlaufen, damit abgeschlossene Kindtokens
-        // zuerst ausgewertet werden und die Ausführungsreihenfolge unter .NET 8 reproduzierbar bleibt.
+        // zuerst ausgewertet werden und die Ausführungsreihenfolge unter aktuellen .NET-Laufzeiten deterministisch bleibt.
         foreach (var token in activeTokens.AsEnumerable().Reverse().Where(t => t.CurrentBaseElement is BPMN.Process.Process or SubProcess))
         {
             new ProcessFlowNodeHandler().Execute(this, token);

--- a/src/core-engine/core-engine.csproj
+++ b/src/core-engine/core-engine.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>default</LangVersion>
@@ -25,9 +25,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ClearScript.V8" Version="7.4.5" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.4.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.ClearScript.V8" Version="7.5.0" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
 </Project>

--- a/tests/ui-smoke/playwright.config.js
+++ b/tests/ui-smoke/playwright.config.js
@@ -72,11 +72,14 @@ module.exports = defineConfig({
           timeout: 120_000
         },
         {
-          command: `dotnet run --project ../../src/FlowzerFrontend/FlowzerFrontend.csproj --configuration Release --no-build --no-launch-profile --urls ${frontendServerOrigin}`,
+          // .NET 10 verwendet bei Standalone-Blazor-WASM für lokale Builds standardmäßig wieder die
+          // Development-Umgebung. Für UI-Smokes muss deshalb die gewünschte Client-Umgebung bereits
+          // beim Frontend-Build per WasmApplicationEnvironmentName fest verdrahtet werden.
+          command: `dotnet run --project ../../src/FlowzerFrontend/FlowzerFrontend.csproj --configuration Release --no-launch-profile -p:WasmApplicationEnvironmentName=${frontendEnvironmentName} --urls ${frontendServerOrigin}`,
           env: frontendWebServerEnvironment,
           url: frontendServerOrigin,
           reuseExistingServer,
-          timeout: 120_000
+          timeout: 180_000
         }
       ]
 });


### PR DESCRIPTION
## Zusammenfassung

Dieses PR hebt die Solution auf **.NET 10** und aktualisiert alle aktuell eingebundenen **Top-Level-NuGet-Pakete** auf den neuesten stabilen Stand.

Closes #112

## Was umgesetzt wurde

- `global.json` auf **10.0.100** angehoben
- alle Projekte von `net8.0` auf `net10.0` migriert
- NuGets auf aktuelle stabile Versionen aktualisiert, u. a.:
  - `Microsoft.AspNetCore.*` auf `10.0.6`
  - `Swashbuckle.AspNetCore` auf `10.1.7`
  - `Microsoft.ClearScript.V8` auf `7.5.0`
  - `Newtonsoft.Json` auf `13.0.4`
  - `FluentAssertions` auf `8.9.0`
  - `NUnit` auf `4.5.1`
  - `Microsoft.NET.Test.Sdk` auf `18.4.0`
  - `coverlet.collector` auf `8.0.1`
  - `Microsoft.FluentUI.AspNetCore.Components*` auf `4.14.0`
- nicht mehr benötigte explizite `System.Text.Json`-Referenz im Frontend entfernt
- Frontend nach FluentUI-Icons-Paketupdate wieder sauber verdrahtet (`@using Icons = ...`)
- FluentAssertions-Breaking-Change in `EngineTest` nachgezogen (`BeGreaterThanOrEqualTo` / `BeLessThanOrEqualTo`)
- UI-Smoke-Konfiguration an das .NET-10-WASM-Verhalten angepasst

## Breaking-Changes / technische Bewertung

### .NET 10 / Standalone Blazor WASM
Unter .NET 10 wird die Client-Umgebung für Standalone-Blazor-WASM-Builds nicht mehr wie bisher über `launchSettings.json` bzw. nur über den Host-Prozess gesteuert. Dadurch lief das Frontend in den UI-Smokes trotz `ASPNETCORE_ENVIRONMENT=Playwright` wieder mit `appsettings.Development.json` an.

Fix:
- Playwright startet das Frontend jetzt mit `-p:WasmApplicationEnvironmentName=Playwright`
- die Doku wurde entsprechend ergänzt

### NUnit 4
Für unsere Testbasis waren keine Migrationen auf `ClassicAssert` nötig. Die bestehenden `Assert.That(...)`- und FluentAssertions-Pfade bleiben kompatibel.

### FluentAssertions 8
Ein veralteter API-Name in den Engine-Tests wurde angepasst:
- `BeGreaterOrEqualTo` → `BeGreaterThanOrEqualTo`
- `BeLessOrEqualTo` → `BeLessThanOrEqualTo`

### Swashbuckle 10
Die Web-API nutzt kein `WithOpenApi()`, daher war hier keine zusätzliche Quellcode-Migration nötig. Die bestehende Swagger-Konfiguration bleibt mit ASP.NET Core 10 lauffähig.

## Validierung

Lokal erfolgreich ausgeführt:

```bash
dotnet restore core-engine.sln
dotnet build core-engine.sln --configuration Release --no-restore
dotnet test src/core-engine-tests/core-engine-tests.csproj --configuration Release --no-restore --no-build --logger 'console;verbosity=minimal'
dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-restore --no-build --logger 'console;verbosity=minimal'
dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-restore --no-build --logger 'console;verbosity=minimal'
python3 scripts/ci/check_test_purpose_comments.py
npm --prefix tests/ui-smoke run test
dotnet list core-engine.sln package --outdated
```

Ergebnis:
- Build grün
- Core-Engine-Tests: **74/74**
- Web-API-Tests: **71/71**
- Frontend-Tests: **44/44**
- UI-Smokes: **17/17**
- `dotnet list ... --outdated`: **keine offenen Paketupdates mehr**

## Doku

Aktualisiert:
- `README.md`
- `docs/FRONTEND.md`
