### PR TITLE
UI-Rundumschlag und Design-Preview vorbereiten

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(grep -n \"::deep\" /Users/christian/Projekte/BPMN/flowzer-bpmn-core-engine/src/FlowzerFrontend/Pages/*.razor.css)",
-      "Bash(grep -rn \"console.log\\\\|console.error\\\\|console.warn\" /Users/christian/Projekte/BPMN/flowzer-bpmn-core-engine/src/FlowzerFrontend/Pages/*.razor)",
-      "Bash(git checkout:*)"
-    ]
-  }
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(grep -n \"::deep\" /Users/christian/Projekte/BPMN/flowzer-bpmn-core-engine/src/FlowzerFrontend/Pages/*.razor.css)",
+      "Bash(grep -rn \"console.log\\\\|console.error\\\\|console.warn\" /Users/christian/Projekte/BPMN/flowzer-bpmn-core-engine/src/FlowzerFrontend/Pages/*.razor)",
+      "Bash(git checkout:*)"
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,11 @@ jobs:
         timeout-minutes: 15
         run: npm test
 
+      - name: UI-Design-Preview-Screenshots erzeugen
+        working-directory: tests/ui-smoke
+        timeout-minutes: 10
+        run: npm run preview:screenshots
+
       - name: Playwright-Artefakte hochladen
         if: always()
         uses: actions/upload-artifact@v4
@@ -196,13 +201,22 @@ jobs:
             tests/ui-smoke/test-results
           if-no-files-found: ignore
 
+      - name: UI-Design-Preview hochladen
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-design-preview
+          path: tests/ui-smoke/design-preview
+          if-no-files-found: ignore
+
       - name: CI-Zusammenfassung schreiben
         if: always()
         run: |
           cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
           ## UI-Smoke-Tests
 
-          - Playwright prüft die Kernrouten `/`, `/models`, `/forms` und `/instances`.
+          - Playwright prüft die Kernrouten `/`, `/tasks`, `/models`, `/forms` und `/instances`.
           - Web-API und Blazor-Frontend werden im Testjob reproduzierbar lokal gestartet.
           - Artefakte mit HTML-Report und Testresultaten werden bei Bedarf hochgeladen.
+          - Zusätzlich erzeugt der Job ein Artefakt `ui-design-preview` mit Screenshots der wichtigsten UI-Seiten für visuelle PR-Reviews.
           EOF

--- a/.gitignore
+++ b/.gitignore
@@ -253,6 +253,8 @@ orleans.codegen.cs
 **/node_modules/
 tests/ui-smoke/playwright-report/
 tests/ui-smoke/test-results/
+tests/ui-smoke/design-preview/
+.claude/
 
 # RIA/Silverlight projects
 Generated_Code/

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -64,6 +64,7 @@ Damit bleibt der normale Blazor-Start ruhiger, ohne den expliziten Debug-Pfad ga
 Die Smoke- und kleinen Happy-Path-E2E-Tests liegen unter `tests/ui-smoke` und prüfen aktuell die Kernrouten:
 
 - `/`
+- `/tasks`
 - `/models`
 - `/forms`
 - `/instances`
@@ -76,6 +77,7 @@ Geprüft werden insbesondere:
 
 - erfolgreiche Seitennavigation
 - sichtbare Kern-UI je Route
+- direkte Task-Inbox als klarer Einstieg für offene User Tasks und startbare Workflows
 - funktionierende Filter-Navigation innerhalb der Instanzliste
 - API-gesäte Happy Paths für Formulare, Modelle und Instanzverläufe
 - explizite **Open**-/`Open deployed`-/`Start instance`-Aktionen in der Modellliste für deployte Workflows
@@ -88,7 +90,8 @@ Geprüft werden insbesondere:
 
 Der aktuelle Stand auf `next` enthält einen größeren UX-Rundumschlag für die wichtigsten Frontend-Flächen. Ziel war nicht nur optische Politur, sondern vor allem eine klarere Bedienlogik:
 
-- **einheitliche App-Shell** mit klarer Hauptnavigation und stärkerem Produktcharakter
+- **einheitliche App-Shell** mit Sidebar-Navigation, klarer Hauptnavigation und stärkerem Produktcharakter
+- **dedizierte Task-Inbox** als täglicher Einstieg für offene User Tasks und startbare Workflows
 - **explizite Primäraktionen** statt versteckter Titel-Links
 - **bessere Empty-/Error-/Loading-States** auf Listen- und Detailseiten
 - **konsistentere List-/Detailmuster** für Workflows, Formulare und Runtime-Instanzen
@@ -115,6 +118,17 @@ npm --prefix tests/ui-smoke run install:browsers
 dotnet build core-engine.sln --configuration Release
 npm --prefix tests/ui-smoke run test
 ```
+
+### Design-Preview-Screenshots erzeugen
+
+Eine echte gehostete Preview-Umgebung gibt es aktuell noch nicht. Für PR-Reviews erzeugt die CI aber ein schlankes Artefakt `ui-design-preview` mit Screenshots der wichtigsten Kernseiten sowie zwei mobilen Einstiegen. Lokal kann dasselbe Artefakt so erzeugt werden:
+
+```bash
+dotnet build core-engine.sln --configuration Release
+npm --prefix tests/ui-smoke run preview:screenshots
+```
+
+Die Screenshots landen unter `tests/ui-smoke/design-preview/` und werden nicht versioniert.
 
 Die Playwright-Konfiguration startet Web-API und Frontend standardmäßig selbst. Wenn beide Prozesse bereits laufen, kann der automatische Start übersprungen werden:
 
@@ -171,7 +185,8 @@ Für die BPMN-Seiten gelten jetzt zusätzlich ein paar harte Erwartungswerte:
 5. einmal `Save draft` auslösen und kontrollieren, dass die URL auf eine konkrete Definitions-GUID springt
 6. testweise einen deployten Workflow direkt starten und die Instanzansicht prüfen
 7. Dashboard-Übersicht öffnen und prüfen, dass die Summary-Cards direkt auf Workflows, aktive Instanzen, Fehlerinstanzen und Formulare verzweigen
-8. testweise eine ungültige Modellroute öffnen und die Inline-Fehlermeldung verifizieren
+8. Task-Inbox öffnen und prüfen, dass offene Aufgaben und startbare Workflows als getrennte Arbeitsbereiche sichtbar sind
+9. testweise eine ungültige Modellroute öffnen und die Inline-Fehlermeldung verifizieren
 
 ## Hinweise zur lokalen Datenbasis
 

--- a/docs/UI-UX-AUDIT-2026-04.md
+++ b/docs/UI-UX-AUDIT-2026-04.md
@@ -35,8 +35,8 @@ Das Frontend war funktional nutzbar, fühlte sich aber in mehreren Kernflächen 
 
 ## 1. App-Shell und Navigation
 
-- modernisierte Topbar mit stärkerer Flowzer-Identität
-- klarere Primärnavigation
+- modernisierte Sidebar mit stärkerer Flowzer-Identität
+- klarere Primärnavigation mit separatem Einstieg in die tägliche Task-Arbeit
 - user-facing Bezeichnung **Workflows** statt rein technischem **Models** in der Hauptnavigation
 - stabilere Workspace-Struktur statt sperrigem Splitter-Gefühl
 
@@ -45,11 +45,19 @@ Das Frontend war funktional nutzbar, fühlte sich aber in mehreren Kernflächen 
 - klareres Intro mit direkten Einstiegsaktionen
 - Summary-Cards für offene Aufgaben, Workflows, aktive Instanzen und Formulare
 - Summary-Cards zusätzlich als **direkte Navigationskacheln** für Kernbereiche nutzbar
+- offene Aufgaben verweisen jetzt konsequent auf die dedizierte Task-Inbox, statt als versteckter Anker innerhalb des Dashboards zu wirken
 - Fehlerinstanzen als eigener sichtbarer Einstieg in die Runtime ergänzt
 - offenere Task-Karten statt rein technischer Listenwirkung
 - nach abgeschlossener User-Task wird die Karte direkt aus der Übersicht entfernt
 
-## 3. Workflow-Katalog
+## 3. Task-Inbox
+
+- eigene Seite **My tasks** für die operative Tagesarbeit ergänzt
+- offene User Tasks und startbare Workflows sind getrennte, klar benannte Arbeitsbereiche
+- Dashboard bleibt Übersicht und Einstieg, die eigentliche Aufgabenbearbeitung hat aber einen fokussierten Ort
+- Refresh- und Start-Aktionen sind explizit sichtbar
+
+## 4. Workflow-Katalog
 
 - Seite fachlich klarer als **Workflow-Katalog** inszeniert
 - explizite Aktionen pro Workflow:
@@ -60,14 +68,14 @@ Das Frontend war funktional nutzbar, fühlte sich aber in mehreren Kernflächen 
 - konsistentere Search-/Sort-Toolbar
 - expliziter **Clear search**-Pfad und kontextabhängige Empty States für Treffer- vs. Leer-Katalog-Fälle
 
-## 4. Formular-Katalog
+## 5. Formular-Katalog
 
 - explizite **Open form**-Aktionen statt versteckter Zeileninteraktion
 - bessere Such- und Ergebnisrückmeldung
 - klarere Empty States
 - expliziter **Clear search**-Pfad bei aktiver Filterung
 
-## 5. Instanzliste
+## 6. Instanzliste
 
 - Filter-Navigation bleibt prominent in der Sidebar
 - zusätzliche **Suche nach Workflowname, Workflow-Key oder Instanz-ID**
@@ -75,7 +83,7 @@ Das Frontend war funktional nutzbar, fühlte sich aber in mehreren Kernflächen 
 - explizite **Open instance**-Aktion pro Zeile
 - kontextabhängige Empty States und expliziter **Clear search**-Pfad
 
-## 6. Instanzdetailansicht
+## 7. Instanzdetailansicht
 
 - deutlich stärkere Kopfzeile mit Status, Workflow-Referenz und Aktionen
 - direkte Aktionen:
@@ -87,7 +95,7 @@ Das Frontend war funktional nutzbar, fühlte sich aber in mehreren Kernflächen 
 - Subscription-Panel klarer strukturiert; wartende Messages lassen sich gezielt auslösen
 - Fehlerzustände getrennt nach **Headline + Detail**, damit Diagramm- und Ladefehler nicht mehr doppelt oder missverständlich erscheinen
 
-## 7. Workflow-Editor
+## 8. Workflow-Editor
 
 - bessere Kontextdarstellung für Workflow-Key, Version, Status und zuletzt gespeicherten Stand
 - verständlichere Aktionen:
@@ -97,11 +105,15 @@ Das Frontend war funktional nutzbar, fühlte sich aber in mehreren Kernflächen 
 - Diagramm und Properties-Panel bleiben als zusammengehörige Arbeitsfläche besser lesbar
 - Workflow-Fehlermeldungen verwenden konsistent die Endnutzer-Sprache **Workflow** statt gemischter Model-/Workflow-Begriffe
 
-## 8. Form-Editor
+## 9. Form-Editor
 
 - ruhigere visuelle Rahmung des Builders
 - konsistentere Feedback-Fläche für Save/Test-Aktionen
 - Version und Metadaten sichtbarer im Kopfbereich
+
+## Preview-Status
+
+Eine echte gehostete Preview-CI/CD-Umgebung existiert aktuell noch nicht. Als pragmatische Zwischenstufe erzeugt der UI-Smoke-Job jetzt ein Artefakt `ui-design-preview` mit Desktop-Screenshots von Dashboard, Task-Inbox, Workflow-Katalog, Instanzen und Formularen sowie mobilen Screenshots der wichtigsten Einstiege. Damit lassen sich Design-Änderungen im PR visuell prüfen, ohne bereits Hosting-Infrastruktur vorauszusetzen.
 
 ## Strukturelle Codeverbesserungen
 
@@ -123,6 +135,7 @@ Der Rundumschlag bringt die Kernpfade deutlich nach vorn, aber ein paar sinnvoll
 3. **noch klarere Domain-Sprache** (intern weiter `Models`, außen noch konsistenter `Workflows`)  
 4. **Keyboard-/Power-User-Flows** für Autoren und Operatoren  
 5. **Design-Tokens/Theme-Schicht** weiter systematisieren, damit spätere UI-Arbeit weniger ad hoc wird
+6. **echte Preview-Umgebung** pro PR, sobald Hosting-Ziel, Secrets und Persistenzmodell geklärt sind
 
 ## Fazit
 

--- a/src/FlowzerFrontend/Components/FormComponent.razor
+++ b/src/FlowzerFrontend/Components/FormComponent.razor
@@ -1,6 +1,6 @@
 
 
-<iframe id="iframe_viewer" src="/formioViewer" allowtransparency = "true"></iframe>
+<iframe id="iframe_viewer" src="/formioViewer"></iframe>
 
 
 <script>
@@ -14,7 +14,7 @@
     }
 
     function messageHandler(event){
-        if (event.data.type === "event" && event.data.eventTyp === "formChanged" && window.dotNetRef){
+        if (event.data.type === "event" && event.data.eventType === "formChanged" && window.dotNetRef){
             console.log("sending formchange to dotnet");
             window.dotNetRef.invokeMethodAsync('OnFormChange',  event.data);
         }

--- a/src/FlowzerFrontend/Components/FormComponent.razor
+++ b/src/FlowzerFrontend/Components/FormComponent.razor
@@ -15,7 +15,6 @@
 
     function messageHandler(event){
         if (event.data.type === "event" && event.data.eventType === "formChanged" && window.dotNetRef){
-            console.log("sending formchange to dotnet");
             window.dotNetRef.invokeMethodAsync('OnFormChange',  event.data);
         }
         

--- a/src/FlowzerFrontend/Components/FormComponent.razor.css
+++ b/src/FlowzerFrontend/Components/FormComponent.razor.css
@@ -1,5 +1,7 @@
-
-#iframe_viewer{
+#iframe_viewer {
     width: 100%;
-    height: 65%;
+    height: calc(80vh - 140px);
+    min-height: 320px;
+    border: none;
+    display: block;
 }

--- a/src/FlowzerFrontend/Components/HeaderElement.razor
+++ b/src/FlowzerFrontend/Components/HeaderElement.razor
@@ -2,8 +2,8 @@
     <div class="detail-header-main">
         @if (!string.IsNullOrWhiteSpace(BackLink))
         {
-            <a class="detail-back-link" href="@BackLink" aria-label="Back">
-                <i class="fa-solid fa-chevron-left"></i>
+            <a class="detail-back-link" href="@BackLink">
+                <i class="fa-solid fa-chevron-left" aria-hidden="true"></i>
                 <span>Back</span>
             </a>
         }
@@ -13,10 +13,10 @@
         </div>
     </div>
 
-    @if (RigthSide != null)
+    @if (RightSide != null)
     {
         <div class="detail-header-actions">
-            @RigthSide
+            @RightSide
         </div>
     }
 </header>

--- a/src/FlowzerFrontend/Components/HeaderElement.razor.cs
+++ b/src/FlowzerFrontend/Components/HeaderElement.razor.cs
@@ -16,6 +16,6 @@ public partial class HeaderElement : ComponentBase
     public RenderFragment? LeftSide { get; set; }
 
     [Parameter]
-    public RenderFragment? RigthSide { get; set; }
+    public RenderFragment? RightSide { get; set; }
 
 }

--- a/src/FlowzerFrontend/Components/LabelWithEdit.razor
+++ b/src/FlowzerFrontend/Components/LabelWithEdit.razor
@@ -1,11 +1,17 @@
 @using Microsoft.FluentUI.AspNetCore.Components
 
-@if (TitleEditMode)
-{
-    <FluentTextField @bind-Value=@Label AriaLabel="No label" @onkeyup="OnTitleEditKeyUp"></FluentTextField>
-}
-else
-{
-    <span id="current-file-name">@Label</span>
-}
-<button class="button-flat" aria-label="Edit name" @onclick="ToggleTitleEditMode"><i class="fa-solid fa-pencil" aria-hidden="true"></i></button>
+<div class="label-edit-row">
+    @if (TitleEditMode)
+    {
+        <FluentTextField @bind-Value=@Label AriaLabel="Edit name" @onkeyup="OnTitleEditKeyUp" autofocus></FluentTextField>
+    }
+    else
+    {
+        <span id="current-file-name">@Label</span>
+    }
+    <button class="label-edit-btn @(TitleEditMode ? "label-edit-btn-save" : "")"
+            title="@(TitleEditMode ? "Save name" : "Edit name")"
+            @onclick="ToggleTitleEditMode">
+        <i class="fa-solid @(TitleEditMode ? "fa-check" : "fa-pencil")"></i>
+    </button>
+</div>

--- a/src/FlowzerFrontend/Components/LabelWithEdit.razor
+++ b/src/FlowzerFrontend/Components/LabelWithEdit.razor
@@ -8,4 +8,4 @@ else
 {
     <span id="current-file-name">@Label</span>
 }
-<button class="button-flat" @onclick="ToggleTitleEditMode"><i class="fa-solid fa-pencil"></i></button>
+<button class="button-flat" aria-label="Edit name" @onclick="ToggleTitleEditMode"><i class="fa-solid fa-pencil" aria-hidden="true"></i></button>

--- a/src/FlowzerFrontend/Components/LabelWithEdit.razor
+++ b/src/FlowzerFrontend/Components/LabelWithEdit.razor
@@ -9,9 +9,10 @@
     {
         <span id="current-file-name">@Label</span>
     }
-    <button class="label-edit-btn @(TitleEditMode ? "label-edit-btn-save" : "")"
+    <button type="button"
+            class="label-edit-btn @(TitleEditMode ? "label-edit-btn-save" : "")"
             title="@(TitleEditMode ? "Save name" : "Edit name")"
             @onclick="ToggleTitleEditMode">
-        <i class="fa-solid @(TitleEditMode ? "fa-check" : "fa-pencil")"></i>
+        <i class="fa-solid @(TitleEditMode ? "fa-check" : "fa-pencil")" aria-hidden="true"></i>
     </button>
 </div>

--- a/src/FlowzerFrontend/Components/LabelWithEdit.razor.css
+++ b/src/FlowzerFrontend/Components/LabelWithEdit.razor.css
@@ -1,0 +1,38 @@
+.label-edit-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.label-edit-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 0.8rem;
+    flex-shrink: 0;
+    transition: background 0.14s ease, color 0.14s ease, border-color 0.14s ease;
+}
+
+.label-edit-btn:hover {
+    background: var(--neutral-bg);
+    border-color: var(--surface-border);
+    color: var(--brand-strong);
+}
+
+.label-edit-btn-save {
+    background: var(--success-bg);
+    border-color: #a5d6a7;
+    color: var(--success-text);
+}
+
+.label-edit-btn-save:hover {
+    background: #c8e6c9;
+    color: var(--success-text);
+}

--- a/src/FlowzerFrontend/Layout/LayoutWithLeftMenu.razor.css
+++ b/src/FlowzerFrontend/Layout/LayoutWithLeftMenu.razor.css
@@ -10,7 +10,7 @@
     flex-direction: column;
     gap: 16px;
     position: sticky;
-    top: 104px;
+    top: 24px;
 }
 
 .workspace-main {

--- a/src/FlowzerFrontend/Layout/MainLayout.razor
+++ b/src/FlowzerFrontend/Layout/MainLayout.razor
@@ -3,22 +3,50 @@
 
 <FluentBodyContent>
     <div class="app-shell">
-        <header class="app-topbar">
+        <nav class="app-sidenav" aria-label="Primary navigation">
             <a class="app-brand-link" href="/">
-                <span class="app-brand-title">Flowzer</span>
-                <span class="app-brand-subtitle">BPMN workflow studio</span>
+                <i class="fa-solid fa-circle-nodes app-brand-icon"></i>
+                <div class="app-brand-text">
+                    <span class="app-brand-title">Flowzer</span>
+                    <span class="app-brand-subtitle">BPMN Studio</span>
+                </div>
             </a>
 
-            <nav class="app-topnav" aria-label="Primary navigation">
-                <NavLink class="app-nav-link" href="" Match="NavLinkMatch.All">Home</NavLink>
-                <NavLink class="app-nav-link" href="/models">Workflows</NavLink>
-                <NavLink class="app-nav-link" href="/instances">Instances</NavLink>
-                <NavLink class="app-nav-link" href="/forms">Forms</NavLink>
-            </nav>
-        </header>
+            <div class="app-sidenav-items">
+                <NavLink class="app-nav-link" href="/tasks">
+                    <i class="fa-solid fa-inbox"></i>
+                    <span>Tasks</span>
+                </NavLink>
 
-        <main class="app-page">
-            @Body
+                <div class="app-sidenav-section-label">Admin</div>
+
+                <NavLink class="app-nav-link" href="" Match="NavLinkMatch.All">
+                    <i class="fa-solid fa-house"></i>
+                    <span>Dashboard</span>
+                </NavLink>
+                <NavLink class="app-nav-link" href="/models">
+                    <i class="fa-solid fa-diagram-project"></i>
+                    <span>Workflows</span>
+                </NavLink>
+                <NavLink class="app-nav-link" href="/instances">
+                    <i class="fa-solid fa-play"></i>
+                    <span>Instances</span>
+                </NavLink>
+                <NavLink class="app-nav-link" href="/forms">
+                    <i class="fa-solid fa-file-lines"></i>
+                    <span>Forms</span>
+                </NavLink>
+            </div>
+
+            <div class="app-sidenav-footer">
+                <span>BPMN workflow studio</span>
+            </div>
+        </nav>
+
+        <main class="app-main">
+            <div class="app-page">
+                @Body
+            </div>
         </main>
     </div>
 

--- a/src/FlowzerFrontend/Layout/MainLayout.razor
+++ b/src/FlowzerFrontend/Layout/MainLayout.razor
@@ -5,7 +5,7 @@
     <div class="app-shell">
         <nav class="app-sidenav" aria-label="Primary navigation">
             <a class="app-brand-link" href="/">
-                <i class="fa-solid fa-circle-nodes app-brand-icon"></i>
+                <i class="fa-solid fa-circle-nodes app-brand-icon" aria-hidden="true"></i>
                 <div class="app-brand-text">
                     <span class="app-brand-title">Flowzer</span>
                     <span class="app-brand-subtitle">BPMN Studio</span>
@@ -14,26 +14,26 @@
 
             <div class="app-sidenav-items">
                 <NavLink class="app-nav-link" href="/tasks">
-                    <i class="fa-solid fa-inbox"></i>
+                    <i class="fa-solid fa-inbox" aria-hidden="true"></i>
                     <span>Tasks</span>
                 </NavLink>
 
                 <div class="app-sidenav-section-label">Admin</div>
 
                 <NavLink class="app-nav-link" href="" Match="NavLinkMatch.All">
-                    <i class="fa-solid fa-house"></i>
+                    <i class="fa-solid fa-house" aria-hidden="true"></i>
                     <span>Dashboard</span>
                 </NavLink>
                 <NavLink class="app-nav-link" href="/models">
-                    <i class="fa-solid fa-diagram-project"></i>
+                    <i class="fa-solid fa-diagram-project" aria-hidden="true"></i>
                     <span>Workflows</span>
                 </NavLink>
                 <NavLink class="app-nav-link" href="/instances">
-                    <i class="fa-solid fa-play"></i>
+                    <i class="fa-solid fa-play" aria-hidden="true"></i>
                     <span>Instances</span>
                 </NavLink>
                 <NavLink class="app-nav-link" href="/forms">
-                    <i class="fa-solid fa-file-lines"></i>
+                    <i class="fa-solid fa-file-lines" aria-hidden="true"></i>
                     <span>Forms</span>
                 </NavLink>
             </div>

--- a/src/FlowzerFrontend/Layout/MainLayout.razor.css
+++ b/src/FlowzerFrontend/Layout/MainLayout.razor.css
@@ -1,3 +1,7 @@
 .app-shell {
     min-height: 100vh;
 }
+
+.app-main {
+    background: #f3f6fb;
+}

--- a/src/FlowzerFrontend/Pages/EditDefinition.razor
+++ b/src/FlowzerFrontend/Pages/EditDefinition.razor
@@ -32,7 +32,7 @@
                 </div>
             </div>
         </LeftSide>
-        <RigthSide>
+        <RightSide>
             <FluentStack Orientation="Orientation.Horizontal" Class="definition-action-group">
                 <FluentButton IconStart="@(new Icons.Regular.Size16.Play())"
                               Appearance="Appearance.Neutral"
@@ -60,7 +60,7 @@
                     <FluentMenuItem Id="SaveAs">Save copy...</FluentMenuItem>
                 </FluentMenuButton>
             </FluentStack>
-        </RigthSide>
+        </RightSide>
     </HeaderElement>
 
     @if (!IsDocumentLoading && !HasError)

--- a/src/FlowzerFrontend/Pages/EditForm.razor
+++ b/src/FlowzerFrontend/Pages/EditForm.razor
@@ -51,15 +51,8 @@
     else
     {
         <section class="surface-panel form-editor-surface">
-            <div class="section-header">
-                <div class="section-title-group">
-                    <h2 class="section-title">Builder canvas</h2>
-                    <p class="section-subtitle">Adjust fields, layout and validation rules directly inside the embedded form designer.</p>
-                </div>
-            </div>
-
             <div class="iframe-container">
-                <iframe src="/formio" width="100%" height="100%" title="Form builder"></iframe>
+                <iframe src="/formio" title="Form builder"></iframe>
             </div>
         </section>
     }

--- a/src/FlowzerFrontend/Pages/EditForm.razor
+++ b/src/FlowzerFrontend/Pages/EditForm.razor
@@ -18,7 +18,7 @@
                 </div>
             </div>
         </LeftSide>
-        <RigthSide>
+        <RightSide>
             <FluentStack Orientation="Orientation.Horizontal" Class="edit-form-actions">
                 <FluentButton IconStart="new Icons.Regular.Size20.Save()" Appearance="Appearance.Accent" OnClick="SaveFormClicked">
                     Save form
@@ -30,7 +30,7 @@
                     <FluentMenuItem Id="SaveAs">Save Copy...</FluentMenuItem>
                 </FluentMenuButton>
             </FluentStack>
-        </RigthSide>
+        </RightSide>
     </HeaderElement>
 
     @if (!string.IsNullOrWhiteSpace(ActionFeedbackMessage))
@@ -39,14 +39,6 @@
             @ActionFeedbackMessage
         </div>
     }
-
-    <section class="surface-panel page-intro edit-form-intro">
-        <div class="page-intro-copy">
-            <span class="page-eyebrow">Form design</span>
-            <h1 class="page-title">Form editor</h1>
-            <p class="page-subtitle">Keep the form builder focused on the schema itself while surfacing version context and save actions around it.</p>
-        </div>
-    </section>
 
     @if (IsLoading)
     {
@@ -67,7 +59,7 @@
             </div>
 
             <div class="iframe-container">
-                <iframe src="/formio" width="100%" height="100%"></iframe>
+                <iframe src="/formio" width="100%" height="100%" title="Form builder"></iframe>
             </div>
         </section>
     }

--- a/src/FlowzerFrontend/Pages/EditForm.razor.cs
+++ b/src/FlowzerFrontend/Pages/EditForm.razor.cs
@@ -184,13 +184,13 @@ public partial class EditForm : FlowzerComponentBase
     {
         DialogParameters parameters = new()
         {
-            Title = $"Test Form",
-            Width = "80%",
-            Height = "90%",
+            Title = "Form preview",
+            Width = "min(860px, 92vw)",
+            Height = "auto",
             TrapFocus = true,
             Modal = true,
             PreventScroll = true,
-            ShowTitle = false,
+            ShowTitle = true,
             SecondaryActionEnabled = false,
             SecondaryAction = "",
             PrimaryAction = ""

--- a/src/FlowzerFrontend/Pages/EditForm.razor.css
+++ b/src/FlowzerFrontend/Pages/EditForm.razor.css
@@ -3,7 +3,21 @@
     flex-wrap: wrap;
 }
 
+.form-editor-surface {
+    overflow: hidden;
+    padding-bottom: 0;
+}
+
 .iframe-container {
-    height: 64vh;
-    min-height: 480px;
+    height: clamp(520px, 72vh, 900px);
+    overflow: hidden;
+    border-radius: 0 0 12px 12px;
+    margin: 0 -20px -20px;
+}
+
+.iframe-container iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+    display: block;
 }

--- a/src/FlowzerFrontend/Pages/EditForm.razor.css
+++ b/src/FlowzerFrontend/Pages/EditForm.razor.css
@@ -3,10 +3,7 @@
     flex-wrap: wrap;
 }
 
-.form-editor-surface {
-    min-height: 70vh;
-}
-
 .iframe-container {
-    min-height: 64vh;
+    height: 64vh;
+    min-height: 480px;
 }

--- a/src/FlowzerFrontend/Pages/FormIoModeler.razor
+++ b/src/FlowzerFrontend/Pages/FormIoModeler.razor
@@ -29,7 +29,6 @@
         }
 
         window.addEventListener('message', async function(event) {
-            console.log("Executing " + event.data.func + " " + JSON.stringify(event.data.arguments)); // Message received from child
             let ret = callFunctionWithoutCaching(event.data.func, ...event.data.arguments);
 
             // Check if ret is a Promise

--- a/src/FlowzerFrontend/Pages/FormIoViewer.razor
+++ b/src/FlowzerFrontend/Pages/FormIoViewer.razor
@@ -42,14 +42,13 @@
             .then((form) => {
                 window.formViewer = form;
                 form.on('change', function () {
-                    window.parent.postMessage({ type: "event", eventTyp: "formChanged" }, '*');
+                    window.parent.postMessage({ type: "event", eventType: "formChanged" }, '*');
                 });
             });
     }
 
     function setSubmission(data)
     {
-        console.log("got setSubmission from dotnet");
         window.formViewer.submission.data = data;
         window.formViewer.redraw();
     }
@@ -66,7 +65,6 @@
 
     if (!window.messageHandlerSet) {
         window.addEventListener('message', async function(event) {
-            console.log("Executing " + event.data.func + " " + JSON.stringify(event.data.arguments)); // Message received from child
             let ret = callFunctionWithoutCaching(event.data.func, ...event.data.arguments);
 
             // Check if ret is a Promise
@@ -79,6 +77,6 @@
         window.messageHandlerSet = true;
     }
 
-    console.log("Formio Viewer loaded");
+
 </script>
 

--- a/src/FlowzerFrontend/Pages/Forms.razor
+++ b/src/FlowzerFrontend/Pages/Forms.razor
@@ -35,11 +35,17 @@
             {
                 <div class="summary-grid">
                     <article class="summary-card">
+                        <div class="summary-card-badge summary-card-badge-info">
+                            <i class="fa-solid fa-file-lines"></i>
+                        </div>
                         <span class="summary-label">Total forms</span>
                         <strong class="summary-value">@TotalFormCount</strong>
                         <span class="summary-hint">Reusable building blocks for user tasks</span>
                     </article>
                     <article class="summary-card">
+                        <div class="summary-card-badge summary-card-badge-neutral">
+                            <i class="fa-solid fa-filter"></i>
+                        </div>
                         <span class="summary-label">Visible results</span>
                         <strong class="summary-value">@VisibleFormCount</strong>
                         <span class="summary-hint">Filtered with the current search input</span>
@@ -101,17 +107,17 @@
                 }
                 else
                 {
-                    <FluentDataGrid Items="@items.AsQueryable()" style="width: 100%;" GridTemplateColumns="minmax(0, 1.6fr) minmax(260px, 1fr) auto" ShowHover="true">
+                    <FluentDataGrid Items="@items.AsQueryable()" style="width: 100%;" GridTemplateColumns="minmax(0, 1fr) minmax(240px, 0.6fr) auto" ShowHover="true">
                         <TemplateColumn Title="Form">
                             <div class="entity-row-stack">
                                 <div class="entity-row-title"><a href="@UriHelper.GetShowFormUrl(context.FormId)">@context.Name</a></div>
-                                <div class="entity-row-subtitle">Form @context.FormId</div>
+                                <div class="entity-row-subtitle">@context.FormId</div>
                             </div>
                         </TemplateColumn>
-                        <TemplateColumn Title="Usage hint">
+                        <TemplateColumn Title="Form key (for BPMN)">
                             <div class="entity-row-stack">
-                                <div class="entity-row-metric">Ready for user task mapping</div>
-                                <div class="entity-row-hint">Use the form name or explicit version binding inside workflow definitions.</div>
+                                <div class="entity-row-metric">@context.Name</div>
+                                <div class="entity-row-hint">Use in task 'Form key' field</div>
                             </div>
                         </TemplateColumn>
                         <TemplateColumn Title="Actions">

--- a/src/FlowzerFrontend/Pages/Home.razor
+++ b/src/FlowzerFrontend/Pages/Home.razor
@@ -13,9 +13,10 @@
         </div>
 
         <div class="page-actions">
-            <a class="cta-link cta-link-primary" href="/models">
-                <i class="fa-solid fa-diagram-project"></i> Manage workflows
+            <a class="cta-link cta-link-primary" href="/tasks">
+                <i class="fa-solid fa-inbox"></i> Open task inbox
             </a>
+            <a class="cta-link cta-link-secondary" href="/models">Manage workflows</a>
             <a class="cta-link cta-link-secondary" href="/instances/active">Active instances</a>
             <a class="cta-link cta-link-secondary" href="/forms">Forms</a>
         </div>
@@ -24,13 +25,13 @@
     @if (!IsLoading && string.IsNullOrWhiteSpace(LoadErrorMessage))
     {
         <div class="summary-grid">
-            <a id="home-summary-open-tasks" class="summary-card summary-card-link" href="#home-user-task-section">
+            <a id="home-summary-open-tasks" class="summary-card summary-card-link" href="/tasks">
                 <div class="summary-card-badge @(OpenTaskCount > 0 ? "summary-card-badge-warning" : "summary-card-badge-success")">
                     <i class="fa-solid @(OpenTaskCount > 0 ? "fa-user-clock" : "fa-user-check")"></i>
                 </div>
                 <span class="summary-label">Open user tasks</span>
                 <strong class="summary-value">@OpenTaskCount</strong>
-                <span class="summary-hint">Need action from a human right now</span>
+                <span class="summary-hint">Open the dedicated task inbox</span>
             </a>
             <a id="home-summary-workflows" class="summary-card summary-card-link" href="/models">
                 <div class="summary-card-badge summary-card-badge-info">
@@ -73,9 +74,9 @@
                 <h2 class="section-title">
                     <i class="fa-solid fa-inbox"></i> Open user tasks
                 </h2>
-                <p class="section-subtitle">Directly continue work that currently waits for a user interaction.</p>
+                <p class="section-subtitle">The dashboard shows a compact preview. Use the task inbox for focused work.</p>
             </div>
-            <a class="cta-link cta-link-secondary" href="/instances/active">See runtime details</a>
+            <a class="cta-link cta-link-secondary" href="/tasks">Open task inbox</a>
         </div>
 
         @if (IsLoading)

--- a/src/FlowzerFrontend/Pages/Home.razor
+++ b/src/FlowzerFrontend/Pages/Home.razor
@@ -6,17 +6,18 @@
     <section class="surface-panel page-intro">
         <div class="page-intro-copy">
             <span class="page-eyebrow">Overview</span>
-            <h1 class="page-title">Welcome to Flowzer</h1>
+            <h1 class="page-title">Dashboard</h1>
             <p class="page-subtitle">
-                Keep workflow design, runtime monitoring and form maintenance close together.
-                The dashboard highlights where users need action right now.
+                All open tasks, workflow status and runtime health at a glance.
             </p>
         </div>
 
         <div class="page-actions">
-            <a class="cta-link cta-link-primary" href="/models">Manage workflows</a>
-            <a class="cta-link cta-link-secondary" href="/instances/active">Open active instances</a>
-            <a class="cta-link cta-link-secondary" href="/forms">Manage forms</a>
+            <a class="cta-link cta-link-primary" href="/models">
+                <i class="fa-solid fa-diagram-project"></i> Manage workflows
+            </a>
+            <a class="cta-link cta-link-secondary" href="/instances/active">Active instances</a>
+            <a class="cta-link cta-link-secondary" href="/forms">Forms</a>
         </div>
     </section>
 
@@ -24,26 +25,41 @@
     {
         <div class="summary-grid">
             <a id="home-summary-open-tasks" class="summary-card summary-card-link" href="#home-user-task-section">
+                <div class="summary-card-badge @(OpenTaskCount > 0 ? "summary-card-badge-warning" : "summary-card-badge-success")">
+                    <i class="fa-solid @(OpenTaskCount > 0 ? "fa-user-clock" : "fa-user-check")"></i>
+                </div>
                 <span class="summary-label">Open user tasks</span>
                 <strong class="summary-value">@OpenTaskCount</strong>
                 <span class="summary-hint">Need action from a human right now</span>
             </a>
             <a id="home-summary-workflows" class="summary-card summary-card-link" href="/models">
+                <div class="summary-card-badge summary-card-badge-info">
+                    <i class="fa-solid fa-diagram-project"></i>
+                </div>
                 <span class="summary-label">Workflows</span>
                 <strong class="summary-value">@WorkflowCount</strong>
                 <span class="summary-hint">@DeployedWorkflowCount deployed and available</span>
             </a>
             <a id="home-summary-active-instances" class="summary-card summary-card-link" href="/instances/active">
+                <div class="summary-card-badge summary-card-badge-info">
+                    <i class="fa-solid fa-play"></i>
+                </div>
                 <span class="summary-label">Active instances</span>
                 <strong class="summary-value">@ActiveInstanceCount</strong>
                 <span class="summary-hint">Running, waiting or otherwise in progress</span>
             </a>
             <a id="home-summary-failed-instances" class="summary-card summary-card-link" href="/instances/error">
+                <div class="summary-card-badge @(FailedInstanceCount > 0 ? "summary-card-badge-danger" : "summary-card-badge-success")">
+                    <i class="fa-solid @(FailedInstanceCount > 0 ? "fa-triangle-exclamation" : "fa-circle-check")"></i>
+                </div>
                 <span class="summary-label">Failed instances</span>
-                <strong class="summary-value">@FailedInstanceCount</strong>
-                <span class="summary-hint">Jump straight into runtime issues that currently need attention</span>
+                <strong class="summary-value @(FailedInstanceCount > 0 ? "summary-value-danger" : "")">@FailedInstanceCount</strong>
+                <span class="summary-hint">@(FailedInstanceCount == 0 ? "All instances running healthy" : "Jump straight into runtime issues")</span>
             </a>
             <a id="home-summary-forms" class="summary-card summary-card-link" href="/forms">
+                <div class="summary-card-badge summary-card-badge-neutral">
+                    <i class="fa-solid fa-file-lines"></i>
+                </div>
                 <span class="summary-label">Forms</span>
                 <strong class="summary-value">@FormCount</strong>
                 <span class="summary-hint">Reusable user-facing building blocks</span>
@@ -54,8 +70,10 @@
     <section id="home-user-task-section" class="surface-panel">
         <div class="section-header">
             <div class="section-title-group">
-                <h2 class="section-title">Open user tasks</h2>
-                <p class="section-subtitle">Directly continue the work that currently waits for a user interaction.</p>
+                <h2 class="section-title">
+                    <i class="fa-solid fa-inbox"></i> Open user tasks
+                </h2>
+                <p class="section-subtitle">Directly continue work that currently waits for a user interaction.</p>
             </div>
             <a class="cta-link cta-link-secondary" href="/instances/active">See runtime details</a>
         </div>
@@ -71,7 +89,8 @@
         else if (_tasks.Length == 0)
         {
             <div id="home-empty-state" class="empty-state">
-                <div class="empty-state-title">No open tasks at the moment</div>
+                <div class="home-empty-icon"><i class="fa-solid fa-circle-check"></i></div>
+                <div class="empty-state-title">No open tasks right now</div>
                 <p class="empty-state-description">Once a workflow reaches a user task, it will show up here as a direct call to action.</p>
                 <a class="cta-link cta-link-primary" href="/models">Open workflows</a>
             </div>
@@ -83,11 +102,19 @@
                 {
                     <button type="button" class="dashboard-task-card user-task-card" @onclick="() => OnCardClick(userTaskSubscriptionDto)">
                         <div class="dashboard-task-card-header">
-                            <span class="dashboard-task-workflow">@userTaskSubscriptionDto.DefinitionMetaName</span>
-                            <span class="pill-chip">Open task</span>
+                            <span class="dashboard-task-workflow">
+                                <i class="fa-solid fa-diagram-project"></i>
+                                @userTaskSubscriptionDto.DefinitionMetaName
+                            </span>
+                            <span class="pill-chip pill-chip-action">
+                                <i class="fa-regular fa-circle-dot"></i> Open task
+                            </span>
                         </div>
                         <strong class="dashboard-task-title">@userTaskSubscriptionDto.Name</strong>
-                        <span class="dashboard-task-description">Open the linked form and continue the workflow with the latest runtime data.</span>
+                        <span class="dashboard-task-description">Click to open the linked form and continue the workflow.</span>
+                        <div class="dashboard-task-footer">
+                            <span class="dashboard-task-cta">Open form <i class="fa-solid fa-arrow-right"></i></span>
+                        </div>
                     </button>
                 }
             </div>

--- a/src/FlowzerFrontend/Pages/Home.razor.cs
+++ b/src/FlowzerFrontend/Pages/Home.razor.cs
@@ -64,108 +64,108 @@ public partial class Home : FlowzerComponentBase
     {
         try
         {
-        var formName = TokenDisplayHelper.GetImplementation(userTaskSubscription.Token);
-        if (string.IsNullOrWhiteSpace(formName))
-        {
-
-            ErrorDialog($"The user task \"{userTaskSubscription.Name}\" has no form configured. Set the 'Form key' (Implementation) in the BPMN task properties.");
-            return;
-        }
-
-        string? version = null;
-        if (formName.Contains(':'))
-        {
-            var parts = formName.Split(':');
-            formName = parts[0];
-            version = parts[1];
-        }
-
-        FormMetaDataDto? formMeta;
-        try
-        {
-            formMeta = (await FlowzerApi.GetFormMetaByName(formName)).SingleOrDefault();
-        }
-        catch (Exception ex)
-        {
-            ErrorDialog($"Could not look up form \"{formName}\": {ex.Message}");
-            return;
-        }
-
-        if (formMeta == null)
-        {
-            ErrorDialog($"No form named \"{formName}\" found in the form catalog. Create the form first or fix the task configuration.");
-            return;
-        }
-
-        FormDto form;
-        try
-        {
-        if (version == null)
-        {
-            form = await FlowzerApi.GetLatestForm(formMeta.FormId);
-        }
-        else
-        {
-            form = await FlowzerApi.GetForm(formMeta.FormId, VersionDto.FromString(version));
-        }
-        }
-        catch (Exception ex)
-        {
-            ErrorDialog($"Could not load form \"{formName}\": {ex.Message}");
-            return;
-        }
-
-        if (string.IsNullOrEmpty(form.FormData))
-        {
-            ErrorDialog($"The form \"{formName}\" exists but has no content. Open the form editor and save it first.");
-            return;
-        }
-
-        DialogParameters parameters = new()
-        {
-            Title = userTaskSubscription.Name,
-
-            Width = "min(860px, 92vw)",
-            Height = "auto",
-            TrapFocus = true,
-            Modal = true,
-            PreventScroll = true,
-            ShowTitle = true,
-            SecondaryActionEnabled = true,
-            SecondaryAction = "Cancel",
-            PrimaryAction = "Submit"
-        };
-
-        var data = new FilloutFormParameter()
-        {
-            Schema = form.FormData,
-            Data = JsonConvert.SerializeObject(userTaskSubscription.Token.Variables)
-        };
-
-        IDialogReference dialog = await DialogService.ShowDialogAsync<FilloutForm>(data, parameters);
-        DialogResult? result = await dialog.Result;
-
-        if (!result.Cancelled && result.Data is FilloutFormParameter formResult && !string.IsNullOrWhiteSpace(formResult.OutData))
-        {
-            var dataObj = JsonConvert.DeserializeObject<ExpandoObject>(formResult.OutData) ?? new ExpandoObject();
-            var flowNodeId = TokenDisplayHelper.GetFlowElementId(userTaskSubscription.Token);
-            if (string.IsNullOrWhiteSpace(flowNodeId))
+            var formName = TokenDisplayHelper.GetImplementation(userTaskSubscription.Token);
+            if (string.IsNullOrWhiteSpace(formName))
             {
-                ErrorDialog("FlowNode Id is missing in token data.");
+                ErrorDialog($"The user task \"{userTaskSubscription.Name}\" has no form configured. Set the 'Form key' (Implementation) in the BPMN task properties.");
                 return;
             }
 
-            var userTaskResult = new UserTaskResultDto()
+            string? version = null;
+            if (formName.Contains(':'))
             {
-                FlowNodeId = flowNodeId,
-                TokenId = userTaskSubscription.Token.Id,
-                ProcessInstanceId = userTaskSubscription.ProcessInstanceId,
-                Data = dataObj
+                var parts = formName.Split(':');
+                formName = parts[0];
+                version = parts[1];
+            }
+
+            List<FormMetaDataDto> formMetas;
+            try
+            {
+                formMetas = await FlowzerApi.GetFormMetaByName(formName);
+            }
+            catch (Exception ex)
+            {
+                ErrorDialog($"Could not look up form \"{formName}\": {ex.Message}");
+                return;
+            }
+
+            if (formMetas.Count > 1)
+            {
+                ErrorDialog($"Multiple forms named \"{formName}\" were found in the form catalog. Rename duplicate forms or use a unique form key before completing this task.");
+                return;
+            }
+
+            var formMeta = formMetas.SingleOrDefault();
+            if (formMeta == null)
+            {
+                ErrorDialog($"No form named \"{formName}\" found in the form catalog. Create the form first or fix the task configuration.");
+                return;
+            }
+
+            FormDto form;
+            try
+            {
+                form = version == null
+                    ? await FlowzerApi.GetLatestForm(formMeta.FormId)
+                    : await FlowzerApi.GetForm(formMeta.FormId, VersionDto.FromString(version));
+            }
+            catch (Exception ex)
+            {
+                ErrorDialog($"Could not load form \"{formName}\": {ex.Message}");
+                return;
+            }
+
+            if (string.IsNullOrEmpty(form.FormData))
+            {
+                ErrorDialog($"The form \"{formName}\" exists but has no content. Open the form editor and save it first.");
+                return;
+            }
+
+            DialogParameters parameters = new()
+            {
+                Title = userTaskSubscription.Name,
+                Width = "min(860px, 92vw)",
+                Height = "auto",
+                TrapFocus = true,
+                Modal = true,
+                PreventScroll = true,
+                ShowTitle = true,
+                SecondaryActionEnabled = true,
+                SecondaryAction = "Cancel",
+                PrimaryAction = "Submit"
             };
-            await FlowzerApi.CompleteUserTask(userTaskResult);
-            _tasks = _tasks.Where(task => task.Token.Id != userTaskSubscription.Token.Id).ToArray();
-            await InvokeAsync(StateHasChanged);
-        }
+
+            var data = new FilloutFormParameter()
+            {
+                Schema = form.FormData,
+                Data = JsonConvert.SerializeObject(userTaskSubscription.Token.Variables)
+            };
+
+            IDialogReference dialog = await DialogService.ShowDialogAsync<FilloutForm>(data, parameters);
+            DialogResult? result = await dialog.Result;
+
+            if (!result.Cancelled && result.Data is FilloutFormParameter formResult && !string.IsNullOrWhiteSpace(formResult.OutData))
+            {
+                var dataObj = JsonConvert.DeserializeObject<ExpandoObject>(formResult.OutData) ?? new ExpandoObject();
+                var flowNodeId = TokenDisplayHelper.GetFlowElementId(userTaskSubscription.Token);
+                if (string.IsNullOrWhiteSpace(flowNodeId))
+                {
+                    ErrorDialog("FlowNode Id is missing in token data.");
+                    return;
+                }
+
+                var userTaskResult = new UserTaskResultDto()
+                {
+                    FlowNodeId = flowNodeId,
+                    TokenId = userTaskSubscription.Token.Id,
+                    ProcessInstanceId = userTaskSubscription.ProcessInstanceId,
+                    Data = dataObj
+                };
+                await FlowzerApi.CompleteUserTask(userTaskResult);
+                _tasks = _tasks.Where(task => task.Token.Id != userTaskSubscription.Token.Id).ToArray();
+                await InvokeAsync(StateHasChanged);
+            }
         }
         catch (Exception ex)
         {

--- a/src/FlowzerFrontend/Pages/Home.razor.cs
+++ b/src/FlowzerFrontend/Pages/Home.razor.cs
@@ -65,7 +65,7 @@ public partial class Home : FlowzerComponentBase
         var formName = TokenDisplayHelper.GetImplementation(userTaskSubscription.Token);
         if (string.IsNullOrWhiteSpace(formName))
         {
-            ErrorDialog("Form Name ('Implementation') is missing in BPMNN file");
+            ErrorDialog("Form Name ('Implementation') is missing in BPMN file");
             return;
         }
 
@@ -103,13 +103,13 @@ public partial class Home : FlowzerComponentBase
 
         DialogParameters parameters = new()
         {
-            Title = $"Test Form",
+            Title = userTaskSubscription.Name,
             Width = "80%",
             Height = "90%",
             TrapFocus = true,
             Modal = true,
             PreventScroll = true,
-            ShowTitle = false,
+            ShowTitle = true,
             SecondaryActionEnabled = true,
             SecondaryAction = "Cancel",
             PrimaryAction = "Submit"

--- a/src/FlowzerFrontend/Pages/Home.razor.cs
+++ b/src/FlowzerFrontend/Pages/Home.razor.cs
@@ -62,10 +62,13 @@ public partial class Home : FlowzerComponentBase
 
     private async Task OnCardClick(ExtendedUserTaskSubscriptionDto userTaskSubscription)
     {
+        try
+        {
         var formName = TokenDisplayHelper.GetImplementation(userTaskSubscription.Token);
         if (string.IsNullOrWhiteSpace(formName))
         {
-            ErrorDialog("Form Name ('Implementation') is missing in BPMN file");
+
+            ErrorDialog($"The user task \"{userTaskSubscription.Name}\" has no form configured. Set the 'Form key' (Implementation) in the BPMN task properties.");
             return;
         }
 
@@ -77,15 +80,26 @@ public partial class Home : FlowzerComponentBase
             version = parts[1];
         }
 
-        var formMeta = (await FlowzerApi.GetFormMetaByName(formName)).SingleOrDefault();
+        FormMetaDataDto? formMeta;
+        try
+        {
+            formMeta = (await FlowzerApi.GetFormMetaByName(formName)).SingleOrDefault();
+        }
+        catch (Exception ex)
+        {
+            ErrorDialog($"Could not look up form \"{formName}\": {ex.Message}");
+            return;
+        }
 
         if (formMeta == null)
         {
-            ErrorDialog($"Could not find any form Named with '{formName}'");
+            ErrorDialog($"No form named \"{formName}\" found in the form catalog. Create the form first or fix the task configuration.");
             return;
         }
 
         FormDto form;
+        try
+        {
         if (version == null)
         {
             form = await FlowzerApi.GetLatestForm(formMeta.FormId);
@@ -94,18 +108,25 @@ public partial class Home : FlowzerComponentBase
         {
             form = await FlowzerApi.GetForm(formMeta.FormId, VersionDto.FromString(version));
         }
+        }
+        catch (Exception ex)
+        {
+            ErrorDialog($"Could not load form \"{formName}\": {ex.Message}");
+            return;
+        }
 
         if (string.IsNullOrEmpty(form.FormData))
         {
-            ErrorDialog("Form Data is missing in Formulardata");
+            ErrorDialog($"The form \"{formName}\" exists but has no content. Open the form editor and save it first.");
             return;
         }
 
         DialogParameters parameters = new()
         {
             Title = userTaskSubscription.Name,
-            Width = "80%",
-            Height = "90%",
+
+            Width = "min(860px, 92vw)",
+            Height = "auto",
             TrapFocus = true,
             Modal = true,
             PreventScroll = true,
@@ -144,6 +165,11 @@ public partial class Home : FlowzerComponentBase
             await FlowzerApi.CompleteUserTask(userTaskResult);
             _tasks = _tasks.Where(task => task.Token.Id != userTaskSubscription.Token.Id).ToArray();
             await InvokeAsync(StateHasChanged);
+        }
+        }
+        catch (Exception ex)
+        {
+            ErrorDialog($"An unexpected error occurred: {ex.Message}");
         }
     }
 }

--- a/src/FlowzerFrontend/Pages/Home.razor.css
+++ b/src/FlowzerFrontend/Pages/Home.razor.css
@@ -16,6 +16,7 @@
     gap: 12px;
     text-align: left;
     cursor: pointer;
+    transition: transform 0.18s ease, box-shadow 0.18s ease;
 }
 
 .dashboard-task-card:hover {

--- a/src/FlowzerFrontend/Pages/Home.razor.css
+++ b/src/FlowzerFrontend/Pages/Home.razor.css
@@ -1,47 +1,92 @@
 .dashboard-task-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 16px;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 14px;
 }
 
 .dashboard-task-card {
     width: 100%;
     border: 1px solid var(--surface-border);
-    border-radius: 16px;
-    background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
-    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
-    padding: 18px;
+    border-left: 4px solid var(--brand-accent);
+    border-radius: 14px;
+    background: white;
+    box-shadow: 0 2px 8px rgba(15, 23, 42, 0.05);
+    padding: 16px;
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 10px;
     text-align: left;
     cursor: pointer;
-    transition: transform 0.18s ease, box-shadow 0.18s ease;
+
+    transition: transform 0.14s ease, box-shadow 0.14s ease, border-color 0.14s ease;
+
 }
 
 .dashboard-task-card:hover {
     transform: translateY(-2px);
-    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.1);
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.1);
+    border-left-color: #0a4d8e;
 }
 
 .dashboard-task-card-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 12px;
+    gap: 10px;
 }
 
 .dashboard-task-workflow {
     color: var(--text-muted);
-    font-size: 0.92rem;
+    font-size: 0.85rem;
     font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.dashboard-task-workflow .fa-diagram-project {
+    color: var(--brand-accent);
+    opacity: 0.8;
 }
 
 .dashboard-task-title {
-    font-size: 1.05rem;
+    font-size: 1rem;
     color: var(--brand-strong);
+    line-height: 1.3;
 }
 
 .dashboard-task-description {
     color: var(--text-muted);
+    font-size: 0.88rem;
+    line-height: 1.4;
+}
+
+.dashboard-task-footer {
+    margin-top: auto;
+    padding-top: 4px;
+}
+
+.dashboard-task-cta {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--brand-accent);
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.pill-chip-action {
+    background: rgba(15, 108, 189, 0.1);
+    color: var(--brand-accent);
+}
+
+.summary-value-danger {
+    color: var(--danger-text);
+}
+
+.home-empty-icon {
+    font-size: 2.5rem;
+    color: var(--success-text);
+    opacity: 0.7;
+    margin-bottom: 4px;
 }

--- a/src/FlowzerFrontend/Pages/Home.razor.css
+++ b/src/FlowzerFrontend/Pages/Home.razor.css
@@ -80,10 +80,6 @@
     color: var(--brand-accent);
 }
 
-.summary-value-danger {
-    color: var(--danger-text);
-}
-
 .home-empty-icon {
     font-size: 2.5rem;
     color: var(--success-text);

--- a/src/FlowzerFrontend/Pages/Instance.razor
+++ b/src/FlowzerFrontend/Pages/Instance.razor
@@ -42,21 +42,33 @@
     {
         <div class="summary-grid">
             <article class="summary-card">
+                <div class="summary-card-badge summary-card-badge-info">
+                    <i class="fa-solid fa-circle-dot"></i>
+                </div>
                 <span class="summary-label">Tokens</span>
                 <strong class="summary-value">@TokenCount</strong>
                 <span class="summary-hint">@ActiveTokenCount active and visualized in the live diagram.</span>
             </article>
             <article class="summary-card">
+                <div class="summary-card-badge summary-card-badge-warning">
+                    <i class="fa-solid fa-hourglass-half"></i>
+                </div>
                 <span class="summary-label">Waiting subscriptions</span>
                 <strong class="summary-value">@WaitingSubscriptionCount</strong>
                 <span class="summary-hint">Messages, signals, user tasks and service callbacks currently blocking progress.</span>
             </article>
             <article class="summary-card">
+                <div class="summary-card-badge @(_instance.UserTaskSubscriptionCount > 0 ? "summary-card-badge-warning" : "summary-card-badge-neutral")">
+                    <i class="fa-regular fa-user"></i>
+                </div>
                 <span class="summary-label">Open user tasks</span>
                 <strong class="summary-value">@(_instance.UserTaskSubscriptionCount)</strong>
                 <span class="summary-hint">Human interactions that can be handled from the task inbox or this runtime view.</span>
             </article>
             <article class="summary-card">
+                <div class="summary-card-badge summary-card-badge-neutral">
+                    <i class="fa-regular fa-envelope"></i>
+                </div>
                 <span class="summary-label">Message subscriptions</span>
                 <strong class="summary-value">@(_instance.MessageSubscriptionCount)</strong>
                 <span class="summary-hint">Use the subscription panel to inspect or trigger waiting messages.</span>

--- a/src/FlowzerFrontend/Pages/Instance.razor
+++ b/src/FlowzerFrontend/Pages/Instance.razor
@@ -26,7 +26,7 @@
                 </div>
             </div>
         </LeftSide>
-        <RigthSide>
+        <RightSide>
             <FluentStack Orientation="Orientation.Horizontal" Class="instance-header-actions">
                 <FluentButton Appearance="Appearance.Neutral" Disabled="@(_instance == null)" @onclick="OnOpenWorkflowClick">
                     Open workflow
@@ -35,7 +35,7 @@
                     Refresh runtime
                 </FluentButton>
             </FluentStack>
-        </RigthSide>
+        </RightSide>
     </HeaderElement>
 
     @if (_instance != null && !HasError)

--- a/src/FlowzerFrontend/Pages/Instance.razor.css
+++ b/src/FlowzerFrontend/Pages/Instance.razor.css
@@ -8,11 +8,12 @@
 }
 
 .diagram-content {
-    min-height: 420px;
+    height: clamp(420px, 58vh, 700px);
     border: 1px solid var(--surface-border);
     border-radius: 16px;
     background: #f8fafc;
     overflow: hidden;
+    position: relative;
 }
 
 .token-browser {
@@ -57,9 +58,10 @@
 }
 
 ::deep .diagram-content .canvas {
+    position: absolute;
+    inset: 0;
     width: 100%;
     height: 100%;
-    min-height: 420px;
 }
 
 ::deep .tree-button {

--- a/src/FlowzerFrontend/Pages/Instances.razor
+++ b/src/FlowzerFrontend/Pages/Instances.razor
@@ -39,23 +39,35 @@
             {
                 <div class="summary-grid">
                     <article class="summary-card">
+                        <div class="summary-card-badge summary-card-badge-neutral">
+                            <i class="fa-solid fa-layer-group"></i>
+                        </div>
                         <span class="summary-label">All instances</span>
                         <strong class="summary-value">@AllCount</strong>
                         <span class="summary-hint">Every known runtime instance</span>
                     </article>
                     <article class="summary-card">
+                        <div class="summary-card-badge summary-card-badge-info">
+                            <i class="fa-solid fa-play"></i>
+                        </div>
                         <span class="summary-label">Active</span>
                         <strong class="summary-value">@ActiveCount</strong>
                         <span class="summary-hint">Running, waiting or otherwise in progress</span>
                     </article>
                     <article class="summary-card">
+                        <div class="summary-card-badge summary-card-badge-success">
+                            <i class="fa-solid fa-flag-checkered"></i>
+                        </div>
                         <span class="summary-label">Done</span>
                         <strong class="summary-value">@DoneCount</strong>
                         <span class="summary-hint">Completed, terminated or compensated</span>
                     </article>
                     <article class="summary-card">
+                        <div class="summary-card-badge @(ErrorCount > 0 ? "summary-card-badge-danger" : "summary-card-badge-success")">
+                            <i class="fa-solid @(ErrorCount > 0 ? "fa-triangle-exclamation" : "fa-circle-check")"></i>
+                        </div>
                         <span class="summary-label">Failed</span>
-                        <strong class="summary-value">@ErrorCount</strong>
+                        <strong class="summary-value @(ErrorCount > 0 ? "summary-value-danger" : "")">@ErrorCount</strong>
                         <span class="summary-hint">Require troubleshooting or replay decisions</span>
                     </article>
                 </div>

--- a/src/FlowzerFrontend/Pages/Instances.razor
+++ b/src/FlowzerFrontend/Pages/Instances.razor
@@ -125,22 +125,22 @@
                         </TemplateColumn>
                         <TemplateColumn Title="Runtime signals">
                             <div class="pill-cluster">
-                                <span class="pill-chip"><i class="fa-solid fa-diagram-project"></i> @context.Tokens.Count Tokens</span>
+                                <span class="pill-chip"><i class="fa-solid fa-diagram-project" aria-hidden="true"></i> @context.Tokens.Count Tokens</span>
                                 @if (context.MessageSubscriptionCount > 0)
                                 {
-                                    <span class="pill-chip"><i class="fa-regular fa-envelope"></i> @context.MessageSubscriptionCount Messages</span>
+                                    <span class="pill-chip"><i class="fa-regular fa-envelope" aria-hidden="true"></i> @context.MessageSubscriptionCount Messages</span>
                                 }
                                 @if (context.SignalSubscriptionCount > 0)
                                 {
-                                    <span class="pill-chip"><i class="fa-solid fa-tower-broadcast"></i> @context.SignalSubscriptionCount Signals</span>
+                                    <span class="pill-chip"><i class="fa-solid fa-tower-broadcast" aria-hidden="true"></i> @context.SignalSubscriptionCount Signals</span>
                                 }
                                 @if (context.UserTaskSubscriptionCount > 0)
                                 {
-                                    <span class="pill-chip"><i class="fa-regular fa-user"></i> @context.UserTaskSubscriptionCount User tasks</span>
+                                    <span class="pill-chip"><i class="fa-regular fa-user" aria-hidden="true"></i> @context.UserTaskSubscriptionCount User tasks</span>
                                 }
                                 @if (context.ServiceSubscriptionCount > 0)
                                 {
-                                    <span class="pill-chip"><i class="fa-solid fa-robot"></i> @context.ServiceSubscriptionCount Services</span>
+                                    <span class="pill-chip"><i class="fa-solid fa-robot" aria-hidden="true"></i> @context.ServiceSubscriptionCount Services</span>
                                 }
                             </div>
                         </TemplateColumn>

--- a/src/FlowzerFrontend/Pages/Instances.razor.css
+++ b/src/FlowzerFrontend/Pages/Instances.razor.css
@@ -1,7 +1,3 @@
 .instances-toolbar-group {
     flex: 1 1 420px;
 }
-
-.summary-value-danger {
-    color: var(--danger-text);
-}

--- a/src/FlowzerFrontend/Pages/Instances.razor.css
+++ b/src/FlowzerFrontend/Pages/Instances.razor.css
@@ -1,3 +1,7 @@
 .instances-toolbar-group {
     flex: 1 1 420px;
 }
+
+.summary-value-danger {
+    color: var(--danger-text);
+}

--- a/src/FlowzerFrontend/Pages/Models.razor
+++ b/src/FlowzerFrontend/Pages/Models.razor
@@ -36,16 +36,25 @@
             {
                 <div class="summary-grid">
                     <article class="summary-card">
+                        <div class="summary-card-badge summary-card-badge-info">
+                            <i class="fa-solid fa-diagram-project"></i>
+                        </div>
                         <span class="summary-label">Total workflows</span>
                         <strong class="summary-value">@TotalModelCount</strong>
                         <span class="summary-hint">All known workflow definitions</span>
                     </article>
                     <article class="summary-card">
+                        <div class="summary-card-badge summary-card-badge-success">
+                            <i class="fa-solid fa-circle-check"></i>
+                        </div>
                         <span class="summary-label">Live workflows</span>
                         <strong class="summary-value">@DeployedModelCount</strong>
                         <span class="summary-hint">Deployable and startable from the UI</span>
                     </article>
                     <article class="summary-card">
+                        <div class="summary-card-badge summary-card-badge-warning">
+                            <i class="fa-solid fa-pen-to-square"></i>
+                        </div>
                         <span class="summary-label">Draft-only workflows</span>
                         <strong class="summary-value">@DraftModelCount</strong>
                         <span class="summary-hint">Still need a first deployment</span>

--- a/src/FlowzerFrontend/Pages/RestDialog.razor
+++ b/src/FlowzerFrontend/Pages/RestDialog.razor
@@ -6,7 +6,7 @@
         <FluentTextField Class="rest-input-field" Label="Url" @bind-Value="@Content.RestExampleRequest.Url" ></FluentTextField>
         <FluentTextArea  Class="rest-input-field" Label="Body" @bind-Value="@Content.RestExampleRequest.Body" Rows="12"></FluentTextArea>
 
-        <FluentButton @onclick="SendRequst">Send</FluentButton>
+        <FluentButton @onclick="SendRequest">Send</FluentButton>
         
         @if(Result != null)
         {

--- a/src/FlowzerFrontend/Pages/RestDialog.razor.cs
+++ b/src/FlowzerFrontend/Pages/RestDialog.razor.cs
@@ -17,7 +17,7 @@ public partial class RestDialog
 
     public string? Result { get; set; }
     
-    private async Task SendRequst()
+    private async Task SendRequest()
     {
         var respContent = "";
         try

--- a/src/FlowzerFrontend/Pages/Tasks.razor
+++ b/src/FlowzerFrontend/Pages/Tasks.razor
@@ -11,8 +11,8 @@
             <p class="page-subtitle">Complete open tasks assigned to you and start new workflow instances.</p>
         </div>
         <div class="page-actions">
-            <button class="cta-link cta-link-secondary" @onclick="RefreshAsync">
-                <i class="fa-solid fa-rotate-right"></i> Refresh
+            <button type="button" class="cta-link cta-link-secondary" @onclick="RefreshAsync">
+                <i class="fa-solid fa-rotate-right" aria-hidden="true"></i> Refresh
             </button>
         </div>
     </section>

--- a/src/FlowzerFrontend/Pages/Tasks.razor
+++ b/src/FlowzerFrontend/Pages/Tasks.razor
@@ -1,0 +1,141 @@
+@page "/tasks"
+@using Microsoft.FluentUI.AspNetCore.Components
+@inherits FlowzerComponentBase
+
+<div class="page-stack">
+
+    <section class="surface-panel page-intro">
+        <div class="page-intro-copy">
+            <span class="page-eyebrow">Task inbox</span>
+            <h1 class="page-title">My tasks</h1>
+            <p class="page-subtitle">Complete open tasks assigned to you and start new workflow instances.</p>
+        </div>
+        <div class="page-actions">
+            <button class="cta-link cta-link-secondary" @onclick="RefreshAsync">
+                <i class="fa-solid fa-rotate-right"></i> Refresh
+            </button>
+        </div>
+    </section>
+
+    @if (IsLoading)
+    {
+        <div class="inline-state-message inline-state-message-info">Loading tasks...</div>
+    }
+    else if (!string.IsNullOrWhiteSpace(LoadErrorMessage))
+    {
+        <div class="inline-state-message inline-state-message-error" role="alert">@LoadErrorMessage</div>
+    }
+    else
+    {
+        <div class="summary-grid">
+            <article class="summary-card">
+                <div class="summary-card-badge @(OpenTaskCount > 0 ? "summary-card-badge-warning" : "summary-card-badge-success")">
+                    <i class="fa-solid @(OpenTaskCount > 0 ? "fa-user-clock" : "fa-user-check")"></i>
+                </div>
+                <span class="summary-label">Open tasks</span>
+                <strong class="summary-value">@OpenTaskCount</strong>
+                <span class="summary-hint">Waiting for your input</span>
+            </article>
+            <article class="summary-card">
+                <div class="summary-card-badge summary-card-badge-info">
+                    <i class="fa-solid fa-diagram-project"></i>
+                </div>
+                <span class="summary-label">Startable workflows</span>
+                <strong class="summary-value">@StartableWorkflowCount</strong>
+                <span class="summary-hint">Deployed and ready to start</span>
+            </article>
+        </div>
+    }
+
+    <!-- Task Inbox -->
+    <section class="surface-panel">
+        <div class="section-header">
+            <div class="section-title-group">
+                <h2 class="section-title"><i class="fa-solid fa-inbox"></i> Open tasks</h2>
+                <p class="section-subtitle">Click a task to open the form and complete the step.</p>
+            </div>
+        </div>
+
+        @if (IsLoading)
+        {
+            <div class="inline-state-message inline-state-message-info">Loading tasks...</div>
+        }
+        else if (_tasks.Length == 0)
+        {
+            <div class="empty-state">
+                <div class="home-empty-icon"><i class="fa-solid fa-circle-check"></i></div>
+                <div class="empty-state-title">No open tasks</div>
+                <p class="empty-state-description">You're all caught up. Once a workflow reaches a user task, it will appear here.</p>
+            </div>
+        }
+        else
+        {
+            <div class="tasks-task-grid">
+                @foreach (var task in _tasks)
+                {
+                    <button type="button" class="tasks-task-card" @onclick="() => OnTaskClick(task)">
+                        <div class="tasks-task-header">
+                            <span class="tasks-task-workflow">
+                                <i class="fa-solid fa-diagram-project"></i>
+                                @task.DefinitionMetaName
+                            </span>
+                            <span class="pill-chip tasks-pill-open">
+                                <i class="fa-regular fa-circle-dot"></i> Open
+                            </span>
+                        </div>
+                        <strong class="tasks-task-title">@task.Name</strong>
+                        <div class="tasks-task-cta">Open form <i class="fa-solid fa-arrow-right"></i></div>
+                    </button>
+                }
+            </div>
+        }
+    </section>
+
+    <!-- Start new workflow -->
+    <section class="surface-panel">
+        <div class="section-header">
+            <div class="section-title-group">
+                <h2 class="section-title"><i class="fa-solid fa-rocket"></i> Start a workflow</h2>
+                <p class="section-subtitle">Deployed workflows you can start a new instance of.</p>
+            </div>
+        </div>
+
+        @if (IsLoading)
+        {
+            <div class="inline-state-message inline-state-message-info">Loading workflows...</div>
+        }
+        else if (_deployedWorkflows.Length == 0)
+        {
+            <div class="empty-state">
+                <div class="empty-state-title">No deployed workflows</div>
+                <p class="empty-state-description">No workflows are currently deployed. An administrator needs to deploy a workflow before it can be started here.</p>
+            </div>
+        }
+        else
+        {
+            <div class="tasks-workflow-grid">
+                @foreach (var wf in _deployedWorkflows)
+                {
+                    <div class="tasks-workflow-card @(_busyWorkflows.Contains(wf.DefinitionId) ? "tasks-workflow-card-busy" : "")">
+                        <div class="tasks-workflow-icon">
+                            <i class="fa-solid fa-diagram-project"></i>
+                        </div>
+                        <div class="tasks-workflow-info">
+                            <strong class="tasks-workflow-name">@wf.Name</strong>
+                            @if (!string.IsNullOrWhiteSpace(wf.Description))
+                            {
+                                <p class="tasks-workflow-description">@wf.Description</p>
+                            }
+                        </div>
+                        <FluentButton Appearance="Appearance.Accent"
+                                      Disabled="@_busyWorkflows.Contains(wf.DefinitionId)"
+                                      @onclick="@(() => OnStartWorkflowAsync(wf))">
+                            @(_busyWorkflows.Contains(wf.DefinitionId) ? "Starting..." : "Start")
+                        </FluentButton>
+                    </div>
+                }
+            </div>
+        }
+    </section>
+
+</div>

--- a/src/FlowzerFrontend/Pages/Tasks.razor.cs
+++ b/src/FlowzerFrontend/Pages/Tasks.razor.cs
@@ -1,0 +1,164 @@
+using System.Dynamic;
+using FlowzerFrontend.BusinessLogic;
+using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components;
+using Newtonsoft.Json;
+using WebApiEngine.Shared;
+
+namespace FlowzerFrontend.Pages;
+
+public partial class Tasks : FlowzerComponentBase
+{
+    [Inject] public required FlowzerApi FlowzerApi { get; set; }
+    [Inject] public required NavigationManager NavigationManager { get; set; }
+
+    private ExtendedUserTaskSubscriptionDto[] _tasks = [];
+    private ExtendedBpmnMetaDefinitionDto[] _deployedWorkflows = [];
+    private readonly HashSet<string> _busyWorkflows = [];
+    private bool IsLoading { get; set; } = true;
+    private string? LoadErrorMessage { get; set; }
+    private int OpenTaskCount => _tasks.Length;
+    private int StartableWorkflowCount => _deployedWorkflows.Length;
+
+    protected override async Task OnInitializedAsync() => await RefreshAsync();
+
+    private async Task RefreshAsync()
+    {
+        IsLoading = true;
+        LoadErrorMessage = null;
+        StateHasChanged();
+
+        try
+        {
+            var tasksTask = FlowzerApi.GetAllUserTasks();
+            var workflowsTask = FlowzerApi.GetAllBpmnMetaDefinitions();
+            await Task.WhenAll(tasksTask, workflowsTask);
+
+            _tasks = tasksTask.Result;
+            _deployedWorkflows = workflowsTask.Result
+                .Where(w => w.DeployedId.HasValue)
+                .OrderBy(w => w.Name)
+                .ToArray();
+        }
+        catch (Exception ex)
+        {
+            LoadErrorMessage = $"Could not load data: {ex.Message}";
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    private async Task OnTaskClick(ExtendedUserTaskSubscriptionDto task)
+    {
+        try
+        {
+            var formName = TokenDisplayHelper.GetImplementation(task.Token);
+            if (string.IsNullOrWhiteSpace(formName))
+            {
+                ErrorDialog($"Task \"{task.Name}\" has no form configured. Set the 'Form key' in the BPMN task properties.");
+                return;
+            }
+
+            string? version = null;
+            if (formName.Contains(':'))
+            {
+                var parts = formName.Split(':');
+                formName = parts[0];
+                version = parts[1];
+            }
+
+            List<FormMetaDataDto> formMetas;
+            try { formMetas = await FlowzerApi.GetFormMetaByName(formName); }
+            catch (Exception ex) { ErrorDialog($"Could not look up form \"{formName}\": {ex.Message}"); return; }
+
+            var formMeta = formMetas.SingleOrDefault();
+            if (formMeta == null)
+            {
+                ErrorDialog($"No form named \"{formName}\" found. Create the form first or fix the task configuration.");
+                return;
+            }
+
+            FormDto form;
+            try { form = version == null ? await FlowzerApi.GetLatestForm(formMeta.FormId) : await FlowzerApi.GetForm(formMeta.FormId, VersionDto.FromString(version)); }
+            catch (Exception ex) { ErrorDialog($"Could not load form \"{formName}\": {ex.Message}"); return; }
+
+            if (string.IsNullOrEmpty(form.FormData))
+            {
+                ErrorDialog($"Form \"{formName}\" exists but has no content. Open the form editor and save it first.");
+                return;
+            }
+
+            var parameters = new DialogParameters
+            {
+                Title = task.Name,
+                Width = "min(860px, 92vw)",
+                Height = "auto",
+                TrapFocus = true,
+                Modal = true,
+                PreventScroll = true,
+                ShowTitle = true,
+                SecondaryActionEnabled = true,
+                SecondaryAction = "Cancel",
+                PrimaryAction = "Submit"
+            };
+
+            var data = new FilloutFormParameter
+            {
+                Schema = form.FormData,
+                Data = JsonConvert.SerializeObject(task.Token.Variables)
+            };
+
+            var dialog = await DialogService.ShowDialogAsync<FilloutForm>(data, parameters);
+            var result = await dialog.Result;
+
+            if (!result.Cancelled && result.Data is FilloutFormParameter formResult && !string.IsNullOrWhiteSpace(formResult.OutData))
+            {
+                var dataObj = JsonConvert.DeserializeObject<ExpandoObject>(formResult.OutData) ?? new ExpandoObject();
+                var flowNodeId = TokenDisplayHelper.GetFlowElementId(task.Token);
+                if (string.IsNullOrWhiteSpace(flowNodeId))
+                {
+                    ErrorDialog("FlowNode Id is missing in token data.");
+                    return;
+                }
+
+                await FlowzerApi.CompleteUserTask(new UserTaskResultDto
+                {
+                    FlowNodeId = flowNodeId,
+                    TokenId = task.Token.Id,
+                    ProcessInstanceId = task.ProcessInstanceId,
+                    Data = dataObj
+                });
+
+                _tasks = _tasks.Where(t => t.Token.Id != task.Token.Id).ToArray();
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+        catch (Exception ex)
+        {
+            ErrorDialog($"An unexpected error occurred: {ex.Message}");
+        }
+    }
+
+    private async Task OnStartWorkflowAsync(ExtendedBpmnMetaDefinitionDto workflow)
+    {
+        _busyWorkflows.Add(workflow.DefinitionId);
+        StateHasChanged();
+
+        try
+        {
+            var instance = await FlowzerApi.StartProcessInstance(workflow.DefinitionId);
+            NavigationManager.NavigateTo(UriHelper.GetShowInstanceUrl(instance.InstanceId));
+        }
+        catch (Exception ex)
+        {
+            ErrorDialog($"Could not start \"{workflow.Name}\": {ex.Message}");
+        }
+        finally
+        {
+            _busyWorkflows.Remove(workflow.DefinitionId);
+            StateHasChanged();
+        }
+    }
+}

--- a/src/FlowzerFrontend/Pages/Tasks.razor.cs
+++ b/src/FlowzerFrontend/Pages/Tasks.razor.cs
@@ -70,8 +70,21 @@ public partial class Tasks : FlowzerComponentBase
             }
 
             List<FormMetaDataDto> formMetas;
-            try { formMetas = await FlowzerApi.GetFormMetaByName(formName); }
-            catch (Exception ex) { ErrorDialog($"Could not look up form \"{formName}\": {ex.Message}"); return; }
+            try
+            {
+                formMetas = await FlowzerApi.GetFormMetaByName(formName);
+            }
+            catch (Exception ex)
+            {
+                ErrorDialog($"Could not look up form \"{formName}\": {ex.Message}");
+                return;
+            }
+
+            if (formMetas.Count > 1)
+            {
+                ErrorDialog($"Multiple forms named \"{formName}\" were found. Rename duplicate forms or use a unique form key before completing this task.");
+                return;
+            }
 
             var formMeta = formMetas.SingleOrDefault();
             if (formMeta == null)
@@ -81,8 +94,17 @@ public partial class Tasks : FlowzerComponentBase
             }
 
             FormDto form;
-            try { form = version == null ? await FlowzerApi.GetLatestForm(formMeta.FormId) : await FlowzerApi.GetForm(formMeta.FormId, VersionDto.FromString(version)); }
-            catch (Exception ex) { ErrorDialog($"Could not load form \"{formName}\": {ex.Message}"); return; }
+            try
+            {
+                form = version == null
+                    ? await FlowzerApi.GetLatestForm(formMeta.FormId)
+                    : await FlowzerApi.GetForm(formMeta.FormId, VersionDto.FromString(version));
+            }
+            catch (Exception ex)
+            {
+                ErrorDialog($"Could not load form \"{formName}\": {ex.Message}");
+                return;
+            }
 
             if (string.IsNullOrEmpty(form.FormData))
             {

--- a/src/FlowzerFrontend/Pages/Tasks.razor.css
+++ b/src/FlowzerFrontend/Pages/Tasks.razor.css
@@ -1,0 +1,136 @@
+.tasks-task-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 12px;
+}
+
+.tasks-task-card {
+    width: 100%;
+    border: 1px solid var(--surface-border);
+    border-left: 4px solid var(--brand-accent);
+    border-radius: 12px;
+    background: white;
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    text-align: left;
+    cursor: pointer;
+    transition: transform 0.14s ease, box-shadow 0.14s ease;
+}
+
+.tasks-task-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.1);
+}
+
+.tasks-task-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.tasks-task-workflow {
+    color: var(--text-muted);
+    font-size: 0.82rem;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.tasks-pill-open {
+    background: rgba(15, 108, 189, 0.1);
+    color: var(--brand-accent);
+    font-size: 0.76rem;
+}
+
+.tasks-task-title {
+    font-size: 0.95rem;
+    color: var(--brand-strong);
+    line-height: 1.3;
+}
+
+.tasks-task-cta {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: var(--brand-accent);
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 2px;
+}
+
+/* Workflow start grid */
+
+.tasks-workflow-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+
+.tasks-workflow-card {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 12px 4px;
+    border-bottom: 1px solid var(--surface-border);
+    transition: background 0.12s ease;
+}
+
+.tasks-workflow-card:last-child {
+    border-bottom: none;
+}
+
+.tasks-workflow-card:hover {
+    background: #f8fafc;
+    border-radius: 8px;
+    padding-left: 8px;
+}
+
+.tasks-workflow-card-busy {
+    opacity: 0.6;
+}
+
+.tasks-workflow-icon {
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    background: rgba(15, 108, 189, 0.1);
+    color: var(--brand-accent);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    font-size: 0.9rem;
+}
+
+.tasks-workflow-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.tasks-workflow-name {
+    color: var(--brand-strong);
+    font-size: 0.95rem;
+}
+
+.tasks-workflow-description {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    line-height: 1.4;
+    margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.home-empty-icon {
+    font-size: 2rem;
+    color: var(--success-text);
+    opacity: 0.7;
+}

--- a/src/FlowzerFrontend/wwwroot/css/app.css
+++ b/src/FlowzerFrontend/wwwroot/css/app.css
@@ -263,6 +263,16 @@ a {
     color: var(--brand-strong);
 }
 
+.page-title:focus,
+.page-title:focus-visible {
+    /*
+     * FocusOnNavigate fokussiert die Seitenüberschrift nach Routenwechseln
+     * für Screenreader. Die Überschrift selbst ist kein interaktives Element,
+     * daher wirkt ein sichtbarer Ring hier wie eine versehentliche Auswahl.
+     */
+    outline: none;
+}
+
 .page-subtitle {
     color: var(--text-muted);
     font-size: 0.9rem;
@@ -890,6 +900,10 @@ fluent-dialog [slot="footer"] {
         padding: 6px 8px;
         gap: 2px;
         overflow-x: auto;
+    }
+
+    .app-sidenav-section-label {
+        display: none;
     }
 
     .app-sidenav-footer {

--- a/src/FlowzerFrontend/wwwroot/css/app.css
+++ b/src/FlowzerFrontend/wwwroot/css/app.css
@@ -17,7 +17,7 @@ body {
     --control-gray: #f1f5f9;
     --header-tile-size: 1.35rem;
     --surface-border: #dbe3ef;
-    --surface-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+    --surface-shadow: 0 4px 16px rgba(15, 23, 42, 0.07);
     --text-muted: #526075;
     --brand-strong: #0f172a;
     --brand-accent: #0f6cbd;
@@ -29,6 +29,8 @@ body {
     --danger-text: #b71c1c;
     --neutral-bg: #eef2f7;
     --neutral-text: #334155;
+    --sidenav-width: 220px;
+    --sidenav-bg: #0f172a;
 }
 
 body {
@@ -61,73 +63,149 @@ a {
     color: inherit;
 }
 
+/* ─── App Shell ─────────────────────────────────────────────────── */
+
 .app-shell {
     min-height: 100vh;
     display: grid;
-    grid-template-rows: auto 1fr;
+    grid-template-columns: var(--sidenav-width) 1fr;
 }
 
-.app-topbar {
+/* ─── Side Navigation ────────────────────────────────────────────── */
+
+.app-sidenav {
     position: sticky;
     top: 0;
-    z-index: 100;
+    height: 100vh;
+    background: var(--sidenav-bg);
     display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 24px;
-    padding: 18px 28px;
-    background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
-    color: white;
-    box-shadow: 0 14px 30px rgba(15, 23, 42, 0.22);
+    flex-direction: column;
+    gap: 0;
+    border-right: 1px solid rgba(255, 255, 255, 0.06);
+    box-shadow: 4px 0 24px rgba(15, 23, 42, 0.18);
+    overflow: hidden;
+    z-index: 100;
 }
 
 .app-brand-link {
     display: flex;
-    flex-direction: column;
-    gap: 2px;
+    align-items: center;
+    gap: 11px;
+    padding: 20px 16px;
     text-decoration: none;
     color: white;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    flex-shrink: 0;
+}
+
+.app-brand-icon {
+    font-size: 1.5rem;
+    color: #60a5fa;
+    flex-shrink: 0;
+}
+
+.app-brand-text {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
 }
 
 .app-brand-title {
-    font-size: 1.2rem;
+    font-size: 1.05rem;
     font-weight: 700;
     letter-spacing: 0.02em;
+    line-height: 1.2;
 }
 
 .app-brand-subtitle {
-    font-size: 0.82rem;
-    color: rgba(255, 255, 255, 0.72);
+    font-size: 0.72rem;
+    color: rgba(255, 255, 255, 0.5);
+    line-height: 1.2;
 }
 
-.app-topnav {
+.app-sidenav-items {
+    flex: 1;
     display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
+    flex-direction: column;
+    padding: 12px 8px;
+    gap: 2px;
+    overflow-y: auto;
 }
 
 .app-nav-link {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 9px 12px;
+    border-radius: 10px;
     text-decoration: none;
-    color: rgba(255, 255, 255, 0.84);
-    padding: 10px 14px;
-    border-radius: 999px;
-    font-weight: 600;
-    transition: background-color 0.18s ease, color 0.18s ease, transform 0.18s ease;
+    color: rgba(255, 255, 255, 0.65);
+    font-weight: 500;
+    font-size: 0.925rem;
+    transition: background 0.14s ease, color 0.14s ease;
+    line-height: 1.3;
+}
+
+.app-nav-link i {
+    width: 17px;
+    text-align: center;
+    font-size: 0.9rem;
+    flex-shrink: 0;
+    opacity: 0.85;
 }
 
 .app-nav-link:hover {
-    background: rgba(255, 255, 255, 0.12);
-    color: white;
+    background: rgba(255, 255, 255, 0.09);
+    color: rgba(255, 255, 255, 0.92);
 }
 
 .app-nav-link.active {
-    background: white;
-    color: var(--brand-strong);
+    background: rgba(96, 165, 250, 0.18);
+    color: #93c5fd;
+    font-weight: 600;
+}
+
+.app-nav-link.active i {
+    opacity: 1;
+    color: #60a5fa;
+}
+
+.app-sidenav-section-label {
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: rgba(255, 255, 255, 0.28);
+    padding: 14px 12px 4px;
+    user-select: none;
+}
+
+.app-sidenav-footer {
+    padding: 14px 16px;
+    border-top: 1px solid rgba(255, 255, 255, 0.07);
+    font-size: 0.72rem;
+    color: rgba(255, 255, 255, 0.3);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    flex-shrink: 0;
+}
+
+/* ─── Main Content ───────────────────────────────────────────────── */
+
+.app-main {
+    min-width: 0;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
 }
 
 .app-page {
     padding: 24px;
+    flex: 1;
 }
+
+/* ─── Page Layout ────────────────────────────────────────────────── */
 
 .page-stack {
     display: flex;
@@ -141,7 +219,7 @@ a {
 .empty-state {
     background: white;
     border: 1px solid var(--surface-border);
-    border-radius: 18px;
+    border-radius: 16px;
     box-shadow: var(--surface-shadow);
 }
 
@@ -150,112 +228,173 @@ a {
     padding: 20px;
 }
 
+/* ─── Page Intro ─────────────────────────────────────────────────── */
+
 .page-intro {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     justify-content: space-between;
-    gap: 20px;
+    gap: 16px;
+    padding: 16px 20px;
 }
 
 .page-intro-copy {
     display: flex;
     flex-direction: column;
-    gap: 8px;
-    max-width: 70ch;
+    gap: 4px;
+    min-width: 0;
 }
 
 .page-eyebrow {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    font-size: 0.78rem;
+    font-size: 0.74rem;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.09em;
     color: var(--brand-accent);
 }
 
 .page-title {
-    font-size: clamp(1.9rem, 2vw, 2.5rem);
-    line-height: 1.15;
+    font-size: 1.45rem;
+    line-height: 1.2;
+    font-weight: 700;
     color: var(--brand-strong);
 }
 
 .page-subtitle {
     color: var(--text-muted);
+    font-size: 0.9rem;
     max-width: 68ch;
 }
 
 .page-actions {
     display: flex;
-    gap: 12px;
+    gap: 10px;
     flex-wrap: wrap;
     justify-content: flex-end;
+    flex-shrink: 0;
 }
+
+/* ─── CTA Links ──────────────────────────────────────────────────── */
 
 .cta-link {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: 8px;
-    min-height: 42px;
-    padding: 0 16px;
-    border-radius: 12px;
+    min-height: 32px;
+    padding: 0 12px;
+    border-radius: 4px;
     border: 1px solid transparent;
     text-decoration: none;
     font-weight: 600;
-    transition: transform 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
+    font-size: 0.875rem;
+    transition: filter 0.1s ease, background-color 0.1s ease;
+    white-space: nowrap;
+    cursor: pointer;
+    line-height: 1;
 }
 
 .cta-link:hover {
-    transform: translateY(-1px);
+    filter: brightness(0.95);
 }
 
 .cta-link-primary {
     background: var(--brand-accent);
     color: white;
-    box-shadow: 0 10px 18px rgba(15, 108, 189, 0.22);
+}
+
+.cta-link-primary:hover {
+    filter: brightness(1.08);
+    color: white;
 }
 
 .cta-link-secondary {
-    background: #eef4fb;
-    color: #174a7c;
-    border-color: #cfe1f5;
+    background: transparent;
+    color: var(--brand-strong);
+    border-color: var(--surface-border);
 }
+
+.cta-link-secondary:hover {
+    background: var(--neutral-bg);
+    filter: none;
+}
+
+/* ─── Summary Grid & Cards ───────────────────────────────────────── */
 
 .summary-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
-    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 14px;
 }
 
 .summary-card {
-    padding: 18px;
+    padding: 16px;
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 6px;
 }
 
 .summary-card-link {
     text-decoration: none;
-    transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
 }
 
 .summary-card-link:hover,
 .summary-card-link:focus-visible {
     transform: translateY(-2px);
-    box-shadow: 0 16px 34px rgba(15, 23, 42, 0.12);
+    box-shadow: 0 10px 28px rgba(15, 23, 42, 0.11);
     border-color: #bfd3ea;
     outline: none;
 }
 
+.summary-card-badge {
+    width: 38px;
+    height: 38px;
+    border-radius: 11px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+    margin-bottom: 4px;
+    flex-shrink: 0;
+}
+
+.summary-card-badge-info {
+    background: rgba(15, 108, 189, 0.1);
+    color: var(--brand-accent);
+}
+
+.summary-card-badge-success {
+    background: var(--success-bg);
+    color: var(--success-text);
+}
+
+.summary-card-badge-warning {
+    background: var(--warning-bg);
+    color: var(--warning-text);
+}
+
+.summary-card-badge-danger {
+    background: var(--danger-bg);
+    color: var(--danger-text);
+}
+
+.summary-card-badge-neutral {
+    background: var(--neutral-bg);
+    color: var(--neutral-text);
+}
+
 .summary-label {
     color: var(--text-muted);
-    font-size: 0.9rem;
+    font-size: 0.88rem;
+    font-weight: 500;
 }
 
 .summary-value {
-    font-size: 2rem;
+    font-size: 1.9rem;
     line-height: 1;
     font-weight: 700;
     color: var(--brand-strong);
@@ -263,20 +402,28 @@ a {
 
 .summary-hint {
     color: var(--text-muted);
-    font-size: 0.9rem;
+    font-size: 0.84rem;
+    line-height: 1.4;
 }
+
+.summary-value-danger {
+    color: var(--danger-text);
+}
+
+/* ─── Toolbar Panel ──────────────────────────────────────────────── */
 
 .toolbar-panel {
     display: flex;
-    align-items: end;
+    align-items: center;
     justify-content: space-between;
-    gap: 16px;
+    gap: 12px;
     flex-wrap: wrap;
+    padding: 14px 20px;
 }
 
 .toolbar-group {
     display: flex;
-    gap: 12px;
+    gap: 10px;
     flex-wrap: wrap;
     align-items: center;
 }
@@ -284,7 +431,11 @@ a {
 .results-label {
     color: var(--text-muted);
     font-weight: 500;
+    font-size: 0.9rem;
+    white-space: nowrap;
 }
+
+/* ─── Section Header ─────────────────────────────────────────────── */
 
 .section-header {
     display: flex;
@@ -292,29 +443,34 @@ a {
     justify-content: space-between;
     gap: 16px;
     margin-bottom: 16px;
+    padding-bottom: 14px;
+    border-bottom: 1px solid var(--surface-border);
 }
 
 .section-title-group {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 3px;
 }
 
 .section-title {
-    font-size: 1.15rem;
+    font-size: 1.05rem;
     font-weight: 700;
     color: var(--brand-strong);
 }
 
 .section-subtitle {
     color: var(--text-muted);
-    font-size: 0.95rem;
+    font-size: 0.88rem;
 }
 
+/* ─── Inline State Messages ──────────────────────────────────────── */
+
 .inline-state-message {
-    padding: 14px 16px;
-    border-radius: 12px;
+    padding: 12px 16px;
+    border-radius: 10px;
     border: 1px solid transparent;
+    font-size: 0.9rem;
 }
 
 .inline-state-message-info {
@@ -329,12 +485,15 @@ a {
     border-color: #ef9a9a;
 }
 
+/* ─── Empty State ────────────────────────────────────────────────── */
+
 .empty-state {
-    padding: 28px;
+    padding: 36px 28px;
     display: flex;
     flex-direction: column;
     gap: 10px;
-    align-items: flex-start;
+    align-items: center;
+    text-align: center;
 }
 
 .empty-state-title {
@@ -345,14 +504,18 @@ a {
 
 .empty-state-description {
     color: var(--text-muted);
-    max-width: 60ch;
+    max-width: 52ch;
 }
 
 .empty-state-actions {
     display: flex;
-    gap: 12px;
+    gap: 10px;
     flex-wrap: wrap;
+    justify-content: center;
+    margin-top: 4px;
 }
+
+/* ─── Entity Row ─────────────────────────────────────────────────── */
 
 .entity-row-title,
 .grid-row-title {
@@ -368,17 +531,23 @@ a {
     text-decoration: none;
 }
 
+.entity-row-title a:hover,
+.grid-row-title a:hover {
+    color: var(--brand-accent);
+}
+
 .entity-row-subtitle,
 .grid-row-subtitle,
 .entity-row-hint,
 .grid-row-description {
     color: var(--text-muted);
+    font-size: 0.88rem;
 }
 
 .entity-row-stack {
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 4px;
 }
 
 .entity-row-metric {
@@ -386,33 +555,47 @@ a {
     color: var(--brand-strong);
 }
 
+/* ─── Pill Cluster ───────────────────────────────────────────────── */
+
 .pill-cluster {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: 6px;
 }
 
 .pill-chip {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
-    padding: 6px 10px;
+    gap: 5px;
+    padding: 4px 9px;
     border-radius: 999px;
     background: var(--neutral-bg);
     color: var(--neutral-text);
-    font-size: 0.86rem;
+    font-size: 0.82rem;
     font-weight: 600;
 }
+
+/* ─── Status Pills ───────────────────────────────────────────────── */
 
 .status-pill {
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    min-height: 30px;
-    padding: 4px 10px;
+    gap: 5px;
+    min-height: 24px;
+    padding: 3px 9px;
     border-radius: 999px;
-    font-size: 0.82rem;
+    font-size: 0.78rem;
     font-weight: 700;
+    letter-spacing: 0.01em;
+}
+
+.status-pill::before {
+    content: '';
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
 }
 
 .status-pill-success {
@@ -420,9 +603,17 @@ a {
     color: var(--success-text);
 }
 
+.status-pill-success::before {
+    background: var(--success-text);
+}
+
 .status-pill-warning {
     background: var(--warning-bg);
     color: var(--warning-text);
+}
+
+.status-pill-warning::before {
+    background: var(--warning-text);
 }
 
 .status-pill-danger {
@@ -430,21 +621,36 @@ a {
     color: var(--danger-text);
 }
 
+.status-pill-danger::before {
+    background: var(--danger-text);
+}
+
 .status-pill-neutral {
     background: var(--neutral-bg);
     color: var(--neutral-text);
 }
 
+.status-pill-neutral::before {
+    background: var(--neutral-text);
+    opacity: 0.5;
+}
+
+/* ─── Sidebar Panel ──────────────────────────────────────────────── */
+
 .sidebar-hint-title {
-    font-size: 0.95rem;
+    font-size: 0.88rem;
     font-weight: 700;
     color: var(--brand-strong);
-    margin-bottom: 8px;
+    margin-bottom: 6px;
 }
 
 .sidebar-hint-copy {
     color: var(--text-muted);
+    font-size: 0.88rem;
+    line-height: 1.5;
 }
+
+/* ─── Entity / Detail Header ─────────────────────────────────────── */
 
 .detail-header-main,
 .entity-header,
@@ -456,7 +662,7 @@ a {
 
 .entity-header {
     flex-direction: column;
-    gap: 6px;
+    gap: 5px;
 }
 
 .entity-title-row {
@@ -467,7 +673,8 @@ a {
 .entity-meta-row {
     flex-wrap: wrap;
     color: var(--text-muted);
-    font-size: 0.92rem;
+    font-size: 0.88rem;
+    gap: 10px;
 }
 
 .surface-panel .fa-solid,
@@ -476,6 +683,8 @@ a {
 .sidebar-panel .fa-regular {
     color: var(--brand-accent);
 }
+
+/* ─── Flat Button ────────────────────────────────────────────────── */
 
 .button-flat {
     border: none;
@@ -491,6 +700,17 @@ a {
     border: 1px solid lightgray;
 }
 
+/* ─── Diagram inline actions ─────────────────────────────────────── */
+
+.diagram-inline-actions {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin-top: 12px;
+}
+
+/* ─── Validation ─────────────────────────────────────────────────── */
+
 .valid.modified:not([type=checkbox]) {
     outline: 1px solid #26b050;
 }
@@ -502,6 +722,8 @@ a {
 .validation-message {
     color: red;
 }
+
+/* ─── Blazor Error UI ────────────────────────────────────────────── */
 
 #blazor-error-ui {
     background: lightyellow;
@@ -531,6 +753,8 @@ a {
 .blazor-error-boundary::after {
     content: 'An error has occurred.'
 }
+
+/* ─── Loading Progress ───────────────────────────────────────────── */
 
 .loading-progress {
     position: relative;
@@ -569,15 +793,115 @@ code {
     color: #c02d76;
 }
 
+/* ─── Fluent Dialog Overrides ────────────────────────────────────── */
+
+fluent-dialog::part(dialog) {
+    border-radius: 18px;
+    box-shadow: 0 24px 64px rgba(15, 23, 42, 0.22);
+    border: 1px solid var(--surface-border);
+}
+
+fluent-dialog .fluent-dialog-header,
+fluent-dialog [slot="header"] {
+    padding: 20px 24px 16px;
+    border-bottom: 1px solid var(--surface-border);
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--brand-strong);
+}
+
+fluent-dialog .fluent-dialog-body,
+fluent-dialog [slot="body"] {
+    padding: 20px 24px;
+}
+
+fluent-dialog .fluent-dialog-footer,
+fluent-dialog [slot="footer"] {
+    padding: 16px 24px;
+    border-top: 1px solid var(--surface-border);
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+}
+
+/* ─── Fluent DataGrid Overrides ──────────────────────────────────── */
+
+.fluent-data-grid {
+    --fluent-data-grid-header-opacity: 1;
+}
+
+.fluent-data-grid thead tr th {
+    font-size: 0.78rem !important;
+    font-weight: 700 !important;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted) !important;
+    background: #f8fafc !important;
+    border-bottom: 2px solid var(--surface-border) !important;
+    padding: 10px 12px !important;
+}
+
+.fluent-data-grid tbody tr td {
+    padding: 12px !important;
+    vertical-align: top !important;
+    border-bottom: 1px solid var(--surface-border) !important;
+}
+
+.fluent-data-grid tbody tr:last-child td {
+    border-bottom: none !important;
+}
+
+.fluent-data-grid tbody tr:hover td {
+    background: #f5f8fd !important;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────── */
+
 @media (max-width: 960px) {
-    .app-topbar {
-        flex-direction: column;
-        align-items: flex-start;
-        padding: 16px 20px;
+    .app-shell {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto 1fr;
+    }
+
+    .app-sidenav {
+        position: static;
+        height: auto;
+        flex-direction: row;
+        align-items: center;
+        padding: 0;
+        border-right: none;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        box-shadow: 0 4px 16px rgba(15, 23, 42, 0.2);
+    }
+
+    .app-brand-link {
+        padding: 12px 16px;
+        border-bottom: none;
+        border-right: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .app-brand-subtitle {
+        display: none;
+    }
+
+    .app-sidenav-items {
+        flex-direction: row;
+        flex: 1;
+        padding: 6px 8px;
+        gap: 2px;
+        overflow-x: auto;
+    }
+
+    .app-sidenav-footer {
+        display: none;
+    }
+
+    .app-main {
+        min-height: calc(100vh - 56px);
     }
 
     .app-page {
-        padding: 18px;
+        padding: 16px;
     }
 
     .page-intro,

--- a/tests/ui-smoke/package.json
+++ b/tests/ui-smoke/package.json
@@ -5,7 +5,7 @@
     "install:browsers": "playwright install --with-deps chromium",
     "test": "node ./scripts/run-playwright.js",
     "test:headed": "node ./scripts/run-playwright.js --headed",
-    "preview:screenshots": "FLOWZER_CAPTURE_DESIGN_PREVIEW=1 node ./scripts/run-playwright.js tests/design-preview.spec.js"
+    "preview:screenshots": "node ./scripts/run-playwright.js --capture-design-preview tests/design-preview.spec.js"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.1"

--- a/tests/ui-smoke/package.json
+++ b/tests/ui-smoke/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "install:browsers": "playwright install --with-deps chromium",
     "test": "node ./scripts/run-playwright.js",
-    "test:headed": "node ./scripts/run-playwright.js --headed"
+    "test:headed": "node ./scripts/run-playwright.js --headed",
+    "preview:screenshots": "FLOWZER_CAPTURE_DESIGN_PREVIEW=1 node ./scripts/run-playwright.js tests/design-preview.spec.js"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.1"

--- a/tests/ui-smoke/scripts/run-playwright.js
+++ b/tests/ui-smoke/scripts/run-playwright.js
@@ -3,7 +3,9 @@
 const { spawn } = require('child_process');
 const { cleanupProcesses, listCandidateProcesses, DEFAULT_STALE_THRESHOLD_SECONDS } = require('./playwright-process-guard');
 
-const args = process.argv.slice(2);
+const rawArgs = process.argv.slice(2);
+const shouldCaptureDesignPreview = rawArgs.includes('--capture-design-preview');
+const args = rawArgs.filter(arg => arg !== '--capture-design-preview');
 const knownPids = new Set(listCandidateProcesses().map(processInfo => processInfo.pid));
 const staleThresholdSeconds = Number.parseInt(
   process.env.PLAYWRIGHT_PROCESS_STALE_THRESHOLD_SECONDS || '',
@@ -50,7 +52,10 @@ async function main()
     {
       cwd: __dirname + '/..',
       stdio: 'inherit',
-      env: process.env
+      env: {
+        ...process.env,
+        ...(shouldCaptureDesignPreview ? { FLOWZER_CAPTURE_DESIGN_PREVIEW: '1' } : {})
+      }
     }
   );
 

--- a/tests/ui-smoke/tests/design-preview.spec.js
+++ b/tests/ui-smoke/tests/design-preview.spec.js
@@ -1,0 +1,77 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs/promises');
+const path = require('path');
+
+// Testzweck: Markiert die Design-Preview-Screenshots als bewusst separaten Opt-in-Lauf außerhalb des normalen UI-Smokes.
+test.skip(
+  process.env.FLOWZER_CAPTURE_DESIGN_PREVIEW !== '1',
+  'Design-Preview-Screenshots werden nur im expliziten Preview-Lauf erzeugt.'
+);
+
+const previewDirectory = path.resolve(__dirname, '..', 'design-preview');
+
+const previewPages = [
+  {
+    path: '/',
+    heading: 'Dashboard',
+    fileName: '01-dashboard-desktop.png',
+    viewport: { width: 1440, height: 1200 }
+  },
+  {
+    path: '/tasks',
+    heading: 'My tasks',
+    fileName: '02-task-inbox-desktop.png',
+    viewport: { width: 1440, height: 1200 }
+  },
+  {
+    path: '/models',
+    heading: 'Workflows',
+    fileName: '03-workflows-desktop.png',
+    viewport: { width: 1440, height: 1200 }
+  },
+  {
+    path: '/instances',
+    heading: 'Instances',
+    fileName: '04-instances-desktop.png',
+    viewport: { width: 1440, height: 1200 }
+  },
+  {
+    path: '/forms',
+    heading: 'Forms',
+    fileName: '05-forms-desktop.png',
+    viewport: { width: 1440, height: 1200 }
+  },
+  {
+    path: '/',
+    heading: 'Dashboard',
+    fileName: '06-dashboard-mobile.png',
+    viewport: { width: 390, height: 900 }
+  },
+  {
+    path: '/tasks',
+    heading: 'My tasks',
+    fileName: '07-task-inbox-mobile.png',
+    viewport: { width: 390, height: 900 }
+  }
+];
+
+test.beforeAll(async () => {
+  await fs.rm(previewDirectory, { recursive: true, force: true });
+  await fs.mkdir(previewDirectory, { recursive: true });
+});
+
+for (const previewPage of previewPages) {
+  // Testzweck: Erzeugt einen visuellen Review-Screenshot einer Kernseite als PR-/CI-Artefakt.
+  test(`Design-Preview-Screenshot für ${previewPage.fileName}`, async ({ page }) => {
+    await page.setViewportSize(previewPage.viewport);
+    await page.goto(previewPage.path, { waitUntil: 'networkidle' });
+
+    await expect(page.getByRole('heading', { level: 1, name: previewPage.heading })).toBeVisible();
+    await expect(page.locator('#blazor-error-ui')).toBeHidden();
+
+    await page.screenshot({
+      path: path.join(previewDirectory, previewPage.fileName),
+      fullPage: true
+    });
+  });
+}

--- a/tests/ui-smoke/tests/navigation.spec.js
+++ b/tests/ui-smoke/tests/navigation.spec.js
@@ -11,9 +11,17 @@ function isIgnoredFailedRequest(url) {
 const smokePages = [
   {
     path: '/',
-    heading: 'Welcome to Flowzer',
+    heading: 'Dashboard',
     ready: async page => {
-      await expect(page.getByText('Welcome to Flowzer', { exact: false })).toBeVisible();
+      await expect(page.getByText('All open tasks, workflow status and runtime health at a glance.')).toBeVisible();
+    }
+  },
+  {
+    path: '/tasks',
+    heading: 'My tasks',
+    ready: async page => {
+      await expect(page.getByRole('heading', { level: 2, name: 'Open tasks' })).toBeVisible();
+      await expect(page.getByRole('heading', { level: 2, name: 'Start a workflow' })).toBeVisible();
     }
   },
   {
@@ -94,19 +102,40 @@ for (const smokePage of smokePages) {
 test('Hauptnavigation springt zwischen den Kernseiten', async ({ page }) => {
   await page.goto('/', { waitUntil: 'networkidle' });
 
-  const topNav = page.locator('.app-topnav');
+  const primaryNav = page.locator('.app-sidenav');
 
-  await topNav.getByRole('link', { name: 'Workflows', exact: true }).click();
+  await primaryNav.getByRole('link', { name: 'Tasks', exact: true }).click();
+  await expect(page).toHaveURL(/\/tasks$/);
+  await expect(page.getByRole('heading', { level: 1, name: 'My tasks' })).toBeVisible();
+
+  await primaryNav.getByRole('link', { name: 'Dashboard', exact: true }).click();
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByRole('heading', { level: 1, name: 'Dashboard' })).toBeVisible();
+
+  await primaryNav.getByRole('link', { name: 'Workflows', exact: true }).click();
   await expect(page).toHaveURL(/\/models$/);
   await expect(page.getByRole('heading', { level: 1, name: 'Workflows' })).toBeVisible();
 
-  await topNav.getByRole('link', { name: 'Forms', exact: true }).click();
+  await primaryNav.getByRole('link', { name: 'Forms', exact: true }).click();
   await expect(page).toHaveURL(/\/forms$/);
   await expect(page.getByRole('heading', { level: 1, name: 'Forms' })).toBeVisible();
 
-  await topNav.getByRole('link', { name: 'Instances', exact: true }).click();
+  await primaryNav.getByRole('link', { name: 'Instances', exact: true }).click();
   await expect(page).toHaveURL(/\/instances$/);
   await expect(page.getByRole('heading', { level: 1, name: 'Instances' })).toBeVisible();
+});
+
+// Testzweck: Prüft, dass die mobile Hauptnavigation ohne störendes Abschnittslabel nutzbar bleibt.
+test('Mobile Hauptnavigation bleibt kompakt und nutzbar', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 900 });
+  await page.goto('/tasks', { waitUntil: 'networkidle' });
+
+  const primaryNav = page.locator('.app-sidenav');
+  await expect(primaryNav.locator('.app-sidenav-section-label')).toBeHidden();
+
+  await primaryNav.getByRole('link', { name: 'Dashboard', exact: true }).click();
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByRole('heading', { level: 1, name: 'Dashboard' })).toBeVisible();
 });
 
 // Testzweck: Prüft, dass die Instanzfilter-Navigation ausschließlich auf gültige Frontend-Routen verzweigt.
@@ -134,6 +163,10 @@ test('Instanzfilter-Navigation bleibt innerhalb gültiger Frontend-Routen', asyn
 test('Dashboard-Zusammenfassung verlinkt die wichtigsten Kernbereiche direkt', async ({ page }) => {
   await page.goto('/', { waitUntil: 'networkidle' });
 
+  await page.locator('#home-summary-open-tasks').click();
+  await expect(page).toHaveURL(/\/tasks$/);
+
+  await page.goto('/', { waitUntil: 'networkidle' });
   await page.locator('#home-summary-workflows').click();
   await expect(page).toHaveURL(/\/models$/);
 


### PR DESCRIPTION
## Zusammenfassung

Dieser PR bündelt den aktuellen UI-Rundumschlag als Review-Stand gegen `next` und ergänzt eine pragmatische Design-Preview für künftige PRs.

Wesentliche Punkte:

- Sidebar-/Dashboard-/Task-Inbox-UX wird konsistenter verzahnt.
- Das Dashboard führt offene Aufgaben jetzt direkt in die dedizierte Task-Inbox.
- Die UI-Smoke-Tests sind auf die neue Sidebar-Navigation und `/tasks` aktualisiert.
- Mobile Navigation wird zusätzlich abgesichert.
- Die CI erzeugt ein neues Artefakt `ui-design-preview` mit Desktop- und Mobile-Screenshots wichtiger Kernseiten.
- Lokale `.claude`-Einstellungen werden aus dem Branch entfernt und künftig ignoriert.

## Preview-CI/CD

Eine echte gehostete Preview-Umgebung gibt es aktuell noch nicht. Dieser PR ergänzt als Zwischenschritt ein visuelles Review-Artefakt:

- Workflow: `UI-Smoke-Tests`
- Artefakt: `ui-design-preview`
- Inhalt: Screenshots von Dashboard, Task-Inbox, Workflows, Instanzen, Formularen sowie mobilen Einstiegen.

Damit können wir Design-Änderungen im PR ansehen, ohne schon Hosting, Secrets und Persistenz für echte Deploy-Previews klären zu müssen.

## Lokale Validierung

- [x] `python3 scripts/ci/check_test_purpose_comments.py`
- [x] `dotnet build core-engine.sln --configuration Release --no-restore`
- [x] `dotnet test src/FlowzerFrontend.Tests/FlowzerFrontend.Tests.csproj --configuration Release --no-build`
- [x] `dotnet test src/WebApiEngine.Tests/WebApiEngine.Tests.csproj --configuration Release --no-build`
- [x] `npm --prefix tests/ui-smoke run test`
- [x] `npm --prefix tests/ui-smoke run preview:screenshots`

## Design-Hinweise

Mir sind beim erneuten Blick noch zwei Punkte aufgefallen und direkt eingeflossen:

1. Der programmatische `FocusOnNavigate`-Fokus auf der Seitenüberschrift erzeugte in Screenshots einen irreführenden sichtbaren Fokusrahmen. Da die Überschrift selbst kein interaktives Element ist, wird dieser visuell unterdrückt.
2. Auf mobilen Viewports nahm das Sidebar-Abschnittslabel `Admin` unnötig Platz in der horizontalen Navigation ein. Es wird mobil ausgeblendet und per Smoke-Test abgesichert.
